### PR TITLE
feat: load config from file

### DIFF
--- a/.game-ci.yml
+++ b/.game-ci.yml
@@ -1,0 +1,3 @@
+---
+cliOptions:
+  unityLicense: 'some license'

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,9 @@ class GameCI {
   public static async run() {
     try {
       // Configure
-      const cli = await new Cli(Deno.args);
-      await cli.configureGlobalSettings();
+      const cli = await new Cli(Deno.args, Deno.cwd());
       await cli.configureLogger();
+      await cli.configureGlobalSettings();
       await cli.configureGlobalOptions();
 
       // Command


### PR DESCRIPTION
#### Changes

Loads config from `.game-ci.yml` or `.game-ci.json` from current working directory.

hardcoded for now, as the override functionality seems broken in Yargs.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
