### PR TITLE
feat: support multi-engine

### DIFF
--- a/src/cli-commands.ts
+++ b/src/cli-commands.ts
@@ -1,0 +1,64 @@
+import { YargsInstance } from './dependencies.ts';
+import { ProjectOptions } from './command-options/project-options.ts';
+
+/**
+ * Register commands
+ *
+ * Bare minimum needed to register the commands. Any specific configuration (e.g. middleware) should be done from within
+ * the command itself through `CommandInterface.configureOptions`.
+ *
+ * @param yargs the global yargs instance
+ * @param register a function that registers the command. must be called from within the builder of each command.
+ */
+export class CliCommands {
+  private readonly yargs: YargsInstance;
+  private readonly register: (yargs: YargsInstance) => void;
+
+  constructor(yargs: YargsInstance, register: (yargs: YargsInstance) => void) {
+    this.yargs = yargs;
+    this.register = register;
+  }
+
+  public async registerAll() {
+    await this.configCommand();
+    await this.testCommand();
+    await this.buildCommand();
+    await this.remoteCommands();
+  }
+
+  private async configCommand() {
+    await this.yargs.command('config', 'GameCI CLI configuration', async (yargs: YargsInstance) => {
+      yargs.command('open', 'Opens the CLI configuration folder', async (yargs: YargsInstance) => {});
+      this.register(yargs);
+    });
+  }
+
+  private async testCommand() {
+    await this.yargs.command('test [projectPath]', 'Runs the tests of a given project', async (yargs) => {
+      ProjectOptions.preConfigure(yargs);
+      this.register(yargs);
+    });
+  }
+
+  private async buildCommand() {
+    await this.yargs.command('build [projectPath]', 'Builds a given project', async (yargs) => {
+      ProjectOptions.preConfigure(yargs);
+      this.register(yargs);
+    });
+  }
+
+  private async remoteCommands() {
+    await this.yargs.command('remote', 'Schedule jobs to be run remotely, in the cloud', async (yargs) => {
+      yargs
+        .command('build [projectPath]', 'Schedule a build to be run remotely', async (yargs) => {
+          ProjectOptions.preConfigure(yargs);
+          this.register(yargs);
+        })
+        .command('otherSubCommand', 'Other sub command', async (yargs) => {
+          // Todo - implement all subcommands
+          ProjectOptions.preConfigure(yargs);
+          this.register(yargs);
+        });
+    });
+  }
+}

--- a/src/command-options/android-options.ts
+++ b/src/command-options/android-options.ts
@@ -1,6 +1,7 @@
 import { YargsInstance, YargsArguments } from '../dependencies.ts';
+import { IOptions } from './options-interface.ts';
 
-export class AndroidOptions {
+export class AndroidOptions implements IOptions {
   public static configure(yargs: YargsInstance): void {
     yargs
       .option('androidAppBundle', {

--- a/src/command-options/build-options.ts
+++ b/src/command-options/build-options.ts
@@ -1,7 +1,8 @@
 import { YargsArguments, YargsInstance } from '../dependencies.ts';
 import UnityTargetPlatform from '../model/unity/target-platform/unity-target-platform.ts';
+import { IOptions } from './options-interface.ts';
 
-export class BuildOptions {
+export class BuildOptions implements IOptions {
   public static configure(yargs: YargsInstance): void {
     yargs
       .demandOption('targetPlatform', 'Target platform is mandatory for builds')

--- a/src/command-options/options-interface.ts
+++ b/src/command-options/options-interface.ts
@@ -1,0 +1,5 @@
+import { YargsInstance } from '../dependencies.ts';
+
+export class IOptions {
+  static configure: (yargs: YargsInstance) => Promise<void> | void;
+}

--- a/src/command-options/project-options.ts
+++ b/src/command-options/project-options.ts
@@ -1,9 +1,15 @@
 import { getHomeDir, YargsInstance } from '../dependencies.ts';
 import { engineDetection } from '../middleware/engine-detection/index.ts';
 import { vcsDetection } from '../middleware/vcs-detection/index.ts';
+import { IOptions } from './options-interface.ts';
 
-export class ProjectOptions {
-  public static configure(yargs: YargsInstance): void {
+export class ProjectOptions implements IOptions {
+  /**
+   * Configuration, used by middleware to detect the engine and VCS.
+   *
+   * Note: keep this method to a minimum, as it is processed before showing the help message.
+   */
+  public static preConfigure(yargs: YargsInstance): void {
     yargs
       .positional('projectPath', {
         describe: 'Path to the project',
@@ -11,8 +17,12 @@ export class ProjectOptions {
         demandOption: false,
         default: '.',
       })
-      .coerce('projectPath', async (arg) => {
-        return arg.replace(/^~/, getHomeDir()).replace(/\/$/, '');
+      .coerce('projectPath', async (arg: string) => {
+        const homeDir = getHomeDir();
+
+        if (homeDir === null) throw new Error('Could not determine home directory');
+
+        return arg.replace(/^~/, homeDir).replace(/\/$/, '');
       })
       .default('engine', '')
       .default('engineVersion', '')
@@ -20,4 +30,6 @@ export class ProjectOptions {
       .default('branch', '')
       .middleware([vcsDetection], true);
   }
+
+  public static async configure(yargs: YargsInstance): Promise<void> {}
 }

--- a/src/command-options/remote-options.ts
+++ b/src/command-options/remote-options.ts
@@ -4,9 +4,10 @@ import { GitRepoReader } from '../model/input-readers/git-repo.ts';
 import { GithubCliReader } from '../model/input-readers/github-cli.ts';
 import CloudRunnerConstants from '../model/cloud-runner/services/cloud-runner-constants.ts';
 import CloudRunnerBuildGuid from '../model/cloud-runner/services/cloud-runner-guid.ts';
+import { IOptions } from './options-interface.ts';
 
-export class RemoteOptions {
-  public static configure(yargs: YargsInstance): void {
+export class RemoteOptions implements IOptions {
+  public static async configure(yargs: YargsInstance): Promise<void> {
     // const cloudRunnerCluster = Cli.isCliMode
     //   ? this.input.getInput('cloudRunnerCluster') || 'aws'
     //   : this.input.getInput('cloudRunnerCluster') || 'local';

--- a/src/command-options/unity-options.ts
+++ b/src/command-options/unity-options.ts
@@ -1,9 +1,10 @@
 import type { YargsInstance } from '../dependencies.ts';
 import UnityTargetPlatform from '../model/unity/target-platform/unity-target-platform.ts';
 import { UnityTargetPlatforms } from '../model/unity/target-platform/unity-target-platforms.ts';
+import { IOptions } from './options-interface.ts';
 
-export class UnityOptions {
-  public static configure = async (yargs: YargsInstance) => {
+export class UnityOptions implements IOptions {
+  public static configure = async (yargs: YargsInstance): Promise<void> => {
     yargs
       .option('targetPlatform', {
         alias: 't',
@@ -42,7 +43,9 @@ export class UnityOptions {
           default: '',
         },
       })
-      .coerce('unityLicense', async (arg) => {
+      .coerce('unityLicense', async (arg: string) => {
+        if (arg.endsWith('.alf')) throw new Error('Unity License File (.ulf) expected, but got .alf');
+
         return arg.endsWith('.ulf') ? Deno.readTextFile(arg, { encoding: 'utf8' }) : arg;
       })
       .option('customImage', {

--- a/src/command-options/versioning-options.ts
+++ b/src/command-options/versioning-options.ts
@@ -2,9 +2,10 @@ import { YargsInstance } from '../dependencies.ts';
 import { VersioningStrategies } from '../model/versioning/versioning-strategies.ts';
 import { VersioningStrategy } from '../model/versioning/versioning-strategy.ts';
 import { buildVersioning } from '../middleware/build-versioning/index.ts';
+import { IOptions } from './options-interface.ts';
 
-export class VersioningOptions {
-  public static async configure(yargs: YargsInstance): void {
+export class VersioningOptions implements IOptions {
+  public static async configure(yargs: YargsInstance): Promise<void> {
     yargs
       .option('versioningStrategy', {
         description: 'Versioning strategy',

--- a/src/command/build/unity-build-command.ts
+++ b/src/command/build/unity-build-command.ts
@@ -9,6 +9,7 @@ import { VersioningOptions } from '../../command-options/versioning-options.ts';
 import { BuildOptions } from '../../command-options/build-options.ts';
 import { AndroidOptions } from '../../command-options/android-options.ts';
 import { PlatformValidation } from '../../logic/unity/platform-validation/platform-validation.ts';
+import { ProjectOptions } from '../../command-options/project-options.ts';
 
 export class UnityBuildCommand extends CommandBase implements CommandInterface {
   public async execute(options: YargsArguments): Promise<boolean> {
@@ -19,7 +20,7 @@ export class UnityBuildCommand extends CommandBase implements CommandInterface {
     CacheValidation.verify(options);
 
     const baseImage = new RunnerImageTag(options);
-    log.debug('Using image:', baseImage);
+    if (log.isVerbose) log.debug('Using image:', baseImage);
     //
     // await PlatformSetup.setup(parameters, actionFolder);
     // if (env.getOS() === 'darwin') {
@@ -35,6 +36,7 @@ export class UnityBuildCommand extends CommandBase implements CommandInterface {
   }
 
   public async configureOptions(yargs: YargsInstance): Promise<void> {
+    await ProjectOptions.configure(yargs);
     await UnityOptions.configure(yargs);
     await VersioningOptions.configure(yargs);
     await BuildOptions.configure(yargs);

--- a/src/command/remote/unity-remote-build-command.ts
+++ b/src/command/remote/unity-remote-build-command.ts
@@ -9,6 +9,7 @@ import CloudRunnerBuildGuid from '../../model/cloud-runner/services/cloud-runner
 import { GithubCliReader } from '../../model/input-readers/github-cli.ts';
 import { CommandBase } from '../command-base.ts';
 import { RemoteOptions } from '../../command-options/remote-options.ts';
+import { ProjectOptions } from '../../command-options/project-options.ts';
 
 // Todo - Verify this entire flow
 export class UnityRemoteBuildCommand extends CommandBase implements CommandInterface {
@@ -27,7 +28,8 @@ export class UnityRemoteBuildCommand extends CommandBase implements CommandInter
     return false;
   }
 
-  configureOptions(yargs: YargsInstance): Promise<void> {
-    RemoteOptions.configure(yargs);
+  public async configureOptions(yargs: YargsInstance): Promise<void> {
+    await ProjectOptions.configure(yargs);
+    await RemoteOptions.configure(yargs);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,9 @@ class GameCI {
     try {
       // Configure
       const cli = await new Cli(Deno.args, Deno.cwd());
-      await cli.configureLogger();
-      await cli.configureGlobalSettings();
-      await cli.configureGlobalOptions();
+      await cli.setup();
+      await cli.registerCommands();
+      await cli.registerSchemaForChosenCommand();
 
       // Command
       const { command, options } = await cli.validateAndParseArguments();

--- a/src/middleware/build-versioning/build-version-generator.ts
+++ b/src/middleware/build-versioning/build-version-generator.ts
@@ -75,7 +75,7 @@ export default class BuildVersionGenerator {
   /**
    * Log up to maxDiffLines of the git diff.
    */
-  static async logDiff() {
+  public async logDiff() {
     const diffCommand = `git --no-pager diff | head -n ${this.maxDiffLines.toString()}`;
     const result = await System.shellRun(diffCommand);
 
@@ -98,7 +98,7 @@ export default class BuildVersionGenerator {
     }
 
     if ((await this.isDirty()) && !allowDirtyBuild) {
-      await BuildVersionGenerator.logDiff();
+      await this.logDiff();
       throw new Error('Branch is dirty. Refusing to base semantic version on uncommitted changes');
     }
 

--- a/src/model/versioning/versioning-strategy.ts
+++ b/src/model/versioning/versioning-strategy.ts
@@ -1,6 +1,6 @@
 export class VersioningStrategy {
-  public static None: 'None';
-  public static Semantic: 'Semantic';
-  public static Tag: 'Tag';
-  public static Custom: 'Custom';
+  public static readonly None = 'None';
+  public static readonly Semantic = 'Semantic';
+  public static readonly Tag = 'Tag';
+  public static readonly Custom = 'Custom';
 }


### PR DESCRIPTION
#### Changes

- This allows the CLI to differentiate between running `game-ci build ~/myProject` where `myProject` is either a Unity project or using a different game engine.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
