### PR TITLE
feat: add non-strict operations

### DIFF
--- a/src/cli-commands.ts
+++ b/src/cli-commands.ts
@@ -24,6 +24,10 @@ export class CliCommands {
     await this.testCommand();
     await this.buildCommand();
     await this.remoteCommands();
+
+    // This is needed to run the engine and vcs detection middleware.
+    // Their output is used to register the correct commands based on the detected engine and vcs.
+    await this.yargs.parseAsync();
   }
 
   private async configCommand() {


### PR DESCRIPTION
#### Changes

- This allows some operations that need to use `yargs.parseAsync` to run under non-strict mode - so that the parsing action doesn't error out for "unknown flags" due to them being registered to the schema later.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
