### PR TITLE
fix: quickfix for the build-version-generator

### DIFF
--- a/src/middleware/build-versioning/build-version-generator.ts
+++ b/src/middleware/build-versioning/build-version-generator.ts
@@ -288,7 +288,7 @@ export default class BuildVersionGenerator {
     // We MUST specify the commitIsh that triggered the job.
     // Todo - make this compatible with more CI systems
     if (!Action.isRunningLocally) {
-      commitIsh = this.sha;
+      commitIsh = this.sha as string;
     }
 
     const numberOfCommitsAsString = await this.git(`rev-list --count ${commitIsh}`);

--- a/src/middleware/build-versioning/build-version-generator.ts
+++ b/src/middleware/build-versioning/build-version-generator.ts
@@ -219,13 +219,13 @@ export default class BuildVersionGenerator {
    * identifies the current commit.
    */
   private async getVersionDescription() {
-    let commitIsh = '';
+    let commitIsh = 'HEAD';
 
     // In CI the repo is checked out in detached head mode.
     // We MUST specify the commitIsh that triggered the job.
     // Todo - make this compatible with more CI systems
     if (!Action.isRunningLocally) {
-      commitIsh = this.sha;
+      commitIsh = this.sha as string;
     }
 
     return this.git(`describe --long --tags --always ${commitIsh}`);
@@ -282,7 +282,16 @@ export default class BuildVersionGenerator {
    * Note: HEAD should not be used, as it may be detached, resulting in an additional count.
    */
   private async getTotalNumberOfCommits() {
-    const numberOfCommitsAsString = await this.git(`rev-list --count ${this.sha}`);
+    let commitIsh = 'HEAD';
+
+    // In CI the repo is checked out in detached head mode.
+    // We MUST specify the commitIsh that triggered the job.
+    // Todo - make this compatible with more CI systems
+    if (!Action.isRunningLocally) {
+      commitIsh = this.sha;
+    }
+
+    const numberOfCommitsAsString = await this.git(`rev-list --count ${commitIsh}`);
 
     return Number.parseInt(numberOfCommitsAsString, 10);
   }


### PR DESCRIPTION
#### Changes

- This makes a few more things work locally, when `GITHUB_SHA` is not set.

A better refactor where we do some runner detection and determine if the cli is running "local", "ci" or "remote" and in case of "ci" which dialect, like `github`, `gitlab`, `circle-ci` etc.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
