### PR TITLE
fix: passing env variables into container

### DIFF
--- a/src/command/command-factory.ts
+++ b/src/command/command-factory.ts
@@ -24,6 +24,8 @@ export class CommandFactory {
     }
 
     switch (this.engine) {
+      case Engine.unknown:
+        throw new Error('Engine not detected from projectPath');
       case Engine.unity:
         return this.createUnityCommand(command, subCommands);
       default:

--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -23,6 +23,8 @@ class Docker {
     }
 
     try {
+      if (log.isVeryVerbose) log.debug(`docker command: ${command}`);
+
       const test = await System.run(command, { attach: true });
       log.warning('test', test);
     } catch (error) {
@@ -45,7 +47,7 @@ class Docker {
     }
   }
 
-  static async getLinuxCommand(image: string, options: Options): string {
+  private static async getLinuxCommand(image: string, options: Options): Promise<string> {
     const { currentWorkDir, homeDir, cliDistPath, runnerTempPath, sshAgent, gitPrivateToken } = options;
 
     const home = homeDir;
@@ -84,28 +86,28 @@ class Docker {
     );
   }
 
-  static async getWindowsCommand(image: string, options: Options): string {
+  private static async getWindowsCommand(image: string, options: Options): Promise<string> {
     const { currentWorkDir, homeDir, cliDistPath, unitySerial, gitPrivateToken, cliStoragePath } = options;
 
     // Note: the equals sign (=) is needed in Powershell.
     // Note: homedir is currently not configured for windows (yet).
     return String.dedent`
-      docker run \
-        --rm \
-        --workdir="c:/github/workspace" \
-        ${ImageEnvironmentFactory.getEnvVarString(options)} \
-        --env UNITY_SERIAL="${unitySerial}" \
-        --env GITHUB_WORKSPACE=c:/github/workspace \
-        --env GIT_PRIVATE_TOKEN="${gitPrivateToken}" \
-        --volume="${currentWorkDir}":"c:/github/workspace" \
-        --volume="${cliStoragePath}/registry-keys":"c:/registry-keys" \
-        --volume="C:/Program Files (x86)/Microsoft Visual Studio":"C:/Program Files (x86)/Microsoft Visual Studio" \
-        --volume="C:/Program Files (x86)/Windows Kits":"C:/Program Files (x86)/Windows Kits" \
-        --volume="C:/ProgramData/Microsoft/VisualStudio":"C:/ProgramData/Microsoft/VisualStudio" \
-        --volume="${cliDistPath}/default-build-script":"c:/UnityBuilderAction" \
-        --volume="${cliDistPath}/platforms/windows":"c:/steps" \
-        --volume="${cliDistPath}/BlankProject":"c:/BlankProject" \
-        ${image} \
+      docker run \`
+        --rm \`
+        --workdir="c:/github/workspace" \`
+        ${ImageEnvironmentFactory.getEnvVarString(options)} \`
+        --env UNITY_SERIAL="${unitySerial}" \`
+        --env GITHUB_WORKSPACE=c:/github/workspace \`
+        --env GIT_PRIVATE_TOKEN="${gitPrivateToken}" \`
+        --volume="${currentWorkDir}":"c:/github/workspace" \`
+        --volume="${cliStoragePath}/registry-keys":"c:/registry-keys" \`
+        --volume="C:/Program Files (x86)/Microsoft Visual Studio":"C:/Program Files (x86)/Microsoft Visual Studio" \`
+        --volume="C:/Program Files (x86)/Windows Kits":"C:/Program Files (x86)/Windows Kits" \`
+        --volume="C:/ProgramData/Microsoft/VisualStudio":"C:/ProgramData/Microsoft/VisualStudio" \`
+        --volume="${cliDistPath}/default-build-script":"c:/UnityBuilderAction" \`
+        --volume="${cliDistPath}/platforms/windows":"c:/steps" \`
+        --volume="${cliDistPath}/BlankProject":"c:/BlankProject" \`
+        ${image} \`
         powershell c:/steps/entrypoint.ps1
     `;
   }

--- a/src/model/image-environment-factory.ts
+++ b/src/model/image-environment-factory.ts
@@ -7,8 +7,9 @@ class Parameter {
 }
 
 class ImageEnvironmentFactory {
-  public static getEnvVarString(parameters) {
-    const environmentVariables = ImageEnvironmentFactory.getEnvironmentVariables(parameters);
+  public static getEnvVarString(options) {
+    const { hostOS } = options;
+    const environmentVariables = ImageEnvironmentFactory.getEnvironmentVariables(options);
     let string = '';
     for (const p of environmentVariables) {
       if (p.value === '' || p.value === undefined) {
@@ -19,14 +20,20 @@ class ImageEnvironmentFactory {
         continue;
       }
 
-      if (Deno.build.os === 'windows') {
+      if (hostOS === 'windows') {
         // The ampersand (&) character is not allowed. The & operator is reserved for future use; wrap an ampersand in
         // double quotation marks ("&") to pass it as part of a string.
         const escapedValue = typeof p.value !== 'string' ? p.value : p.value?.replace(/&/, '\\"&\\"');
-        string += `--env ${p.name}='${escapedValue}' `;
+        string += `--env ${p.name}='${escapedValue}' \`\n`;
       } else {
-        string += `--env ${p.name}="${p.value}" `;
+        string += `--env ${p.name}="${p.value}"\n`;
       }
+    }
+
+    if (hostOS === 'windows') {
+      string = string.replace(/`\n$/, '');
+    } else {
+      string = string.replace(/\n$/, '');
     }
 
     return string;
@@ -41,7 +48,7 @@ class ImageEnvironmentFactory {
       { name: 'UNITY_EMAIL', value: parameters.unityEmail },
       { name: 'UNITY_PASSWORD', value: parameters.unityPassword },
       { name: 'UNITY_SERIAL', value: parameters.unitySerial },
-      { name: 'UNITY_VERSION', value: parameters.editorVersion },
+      { name: 'UNITY_VERSION', value: parameters.engineVersion },
       { name: 'USYM_UPLOAD_AUTH_TOKEN', value: parameters.uploadAuthToken },
       { name: 'PROJECT_PATH', value: parameters.projectPath },
       { name: 'BUILD_TARGET', value: parameters.targetPlatform },


### PR DESCRIPTION
#### Changes

This fixes a few issues where
- The command that is run is never shown in veryVerbose mode.
- unityEngine was not defined (as it changed to engineVersion)
- reference to in-docker editor was no longer working
- windows string wasn't properly formatted

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
