### PR TITLE
Add .dir-locals.el

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,4 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((nil . ((lsp-enabled-clients . (deno-ls)))))


### PR DESCRIPTION
A little editor file so Emacs will use deno (lsp) by default.

#### Changes

- Add `.dir-locals.el` file for Emacs users

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
