### PR TITLE
chore: update way of passing token in codecov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,6 @@ on:
   push: { branches: [main] }
   pull_request: {}
 
-env:
-  CODECOV_TOKEN: '69cab0bb-8965-4f6e-8033-aa67540e6c28'
-
 jobs:
   tests:
     name: Tests


### PR DESCRIPTION
#### Changes

- CodeCov has a new "tokenless" way of uploading coverage information for public repositories, so we no longer need to pass it into the workflow.

![image](https://github.com/user-attachments/assets/6bf88e87-8be9-427e-bd3b-f668da8c0dc8)

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](https://github.com/game-ci/cli/blob/main/CONTRIBUTING.md) and accept the [code](https://github.com/game-ci/cli/blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the GitHub Actions workflow by removing the `CODECOV_TOKEN` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->