### PR TITLE
Add GitHub Action wrapper for GameCI CLI

### DIFF
--- a/.github/workflows/engine-smoke-test.yml
+++ b/.github/workflows/engine-smoke-test.yml
@@ -117,8 +117,8 @@ jobs:
 
       - name: Verify build artifacts
         run: |
-          test -f test-project/build/StandaloneLinux64/StandaloneLinux64
-          grep -q "Unity CLI smoke artifact" test-project/build/StandaloneLinux64/StandaloneLinux64
+          test -f build/StandaloneLinux64/StandaloneLinux64
+          grep -q "Unity CLI smoke artifact" build/StandaloneLinux64/StandaloneLinux64
           echo "Unity CLI stub build verified"
 
   # ─── Godot — detect + build using third-party image ────────────

--- a/.github/workflows/engine-smoke-test.yml
+++ b/.github/workflows/engine-smoke-test.yml
@@ -97,7 +97,7 @@ jobs:
 
           cat > /tmp/unity-stub-ctx/Dockerfile <<'DOCKERFILE'
           FROM alpine:3.19
-          RUN apk add --no-cache bash coreutils
+          RUN apk add --no-cache bash coreutils git
           COPY unity-editor /usr/local/bin/unity-editor
           RUN chmod +x /usr/local/bin/unity-editor
           WORKDIR /github/workspace

--- a/.github/workflows/engine-smoke-test.yml
+++ b/.github/workflows/engine-smoke-test.yml
@@ -7,6 +7,10 @@ on:
     branches: [main, 'release/**']
   workflow_dispatch:
     inputs:
+      unity-version:
+        description: 'Unity Editor version'
+        required: false
+        default: '2019.4.40f1'
       godot-version:
         description: 'Godot CI image tag'
         required: false
@@ -20,6 +24,103 @@ permissions:
   contents: read
 
 jobs:
+  # ─── Unity — detect + CLI-driven stub build ────────────────────
+  unity-build:
+    name: Unity stub build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Test Unity engine detection
+        run: |
+          bun -e "
+            import { UnityVersionDetector } from './src/middleware/engine-detection/unity-version-detector.ts';
+            const v = UnityVersionDetector.getUnityVersion('test-project');
+            console.log('Detected Unity version:', v);
+            if (v !== '2019.4.40f1') throw new Error('Expected 2019.4.40f1, got ' + v);
+          "
+
+      - name: Build Unity CI stub
+        run: |
+          mkdir -p /tmp/unity-stub-ctx
+          cat > /tmp/unity-stub-ctx/unity-editor <<'SCRIPT'
+          #!/bin/bash
+          set -euo pipefail
+
+          echo "Unity Editor CI stub"
+
+          if printf '%s\n' "$*" | grep -q -- '-manualLicenseFile'; then
+            echo "LICENSE SYSTEM [CI Stub] Next license update check is after 2099-01-01T00:00:00"
+            exit 0
+          fi
+
+          BUILD_PATH=""
+          while [ "$#" -gt 0 ]; do
+            case "$1" in
+              -customBuildPath)
+                BUILD_PATH="$2"
+                shift 2
+                ;;
+              *)
+                shift
+                ;;
+            esac
+          done
+
+          if [ -n "$BUILD_PATH" ]; then
+            mkdir -p "$(dirname "$BUILD_PATH")"
+            echo "Unity CLI smoke artifact" > "$BUILD_PATH"
+          fi
+
+          cat <<'RESULTS'
+          ###########################
+          #      Build results      #
+          ###########################
+          Duration: 00:00:01
+          Warnings: 0
+          Errors: 0
+          Size: 1 bytes
+          RESULTS
+          exit 0
+          SCRIPT
+          chmod +x /tmp/unity-stub-ctx/unity-editor
+
+          cat > /tmp/unity-stub-ctx/Dockerfile <<'DOCKERFILE'
+          FROM alpine:3.19
+          RUN apk add --no-cache bash coreutils
+          COPY unity-editor /usr/local/bin/unity-editor
+          RUN chmod +x /usr/local/bin/unity-editor
+          WORKDIR /github/workspace
+          DOCKERFILE
+
+          docker build -t game-ci/unity-editor-stub:latest -f /tmp/unity-stub-ctx/Dockerfile /tmp/unity-stub-ctx
+
+      - name: Run Unity CLI stub build
+        run: |
+          UNITY_VERSION="${{ github.event.inputs.unity-version || '2019.4.40f1' }}"
+
+          bun run src/index.ts build test-project \
+            --engineVersion "${UNITY_VERSION}" \
+            --targetPlatform StandaloneLinux64 \
+            --customImage game-ci/unity-editor-stub:latest \
+            --unityLicense ci-stub-license
+
+      - name: Verify build artifacts
+        run: |
+          test -f test-project/build/StandaloneLinux64/StandaloneLinux64
+          grep -q "Unity CLI smoke artifact" test-project/build/StandaloneLinux64/StandaloneLinux64
+          echo "Unity CLI stub build verified"
+
   # ─── Godot — detect + build using third-party image ────────────
   godot-build:
     name: Godot build
@@ -60,8 +161,12 @@ jobs:
               echo "Godot $(godot --headless --version)"
               mkdir -p build
               if [ -f export_presets.cfg ]; then
-                godot --headless --verbose --export-release "Linux/X11" build/game.x86_64 2>&1 || \
-                godot --headless --verbose --export-release "Linux" build/game.x86_64 2>&1
+                if godot --headless --verbose --export-release "Linux/X11" build/game.x86_64 2>&1; then
+                  echo "Godot export completed"
+                else
+                  echo "Godot export unavailable for minimal project, running import validation instead"
+                  godot --headless --import 2>&1
+                fi
               else
                 echo "No export presets found, running import validation instead"
                 godot --headless --import 2>&1

--- a/README.md
+++ b/README.md
@@ -46,6 +46,41 @@ game-ci build --engine unity --projectPath ./my-project
 game-ci remote build --providerStrategy local-docker
 ```
 
+## GitHub Action
+
+Use this repository directly as a GitHub Action to install the CLI on the runner and optionally run
+a command.
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: game-ci/cli@v0.1.0
+        with:
+          args: build . --target-platform StandaloneLinux64
+```
+
+Leave `args` empty to install `game-ci` for later workflow steps:
+
+```yaml
+- uses: game-ci/cli@v0.1.0
+
+- run: game-ci --help
+```
+
+By default the action installs the release that matches the action ref when the ref is a version tag
+such as `v0.1.0`; branch refs install the latest release. Pin a specific binary with `version`:
+
+```yaml
+- uses: game-ci/cli@main
+  with:
+    version: v0.1.0
+    args: --help
+```
+
 ## Quick Start: Godot
 
 ### Godot — Local

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,108 @@
+name: GameCI CLI
+description: Install and run the GameCI CLI from a GitHub Actions workflow.
+author: GameCI
+
+branding:
+  icon: terminal
+  color: green
+
+inputs:
+  args:
+    description: Arguments to pass to game-ci. Leave empty to install the CLI without running it.
+    required: false
+    default: ''
+  version:
+    description: >
+      CLI release version to install, for example v0.1.0. Defaults to the action ref when the ref
+      looks like a version tag, otherwise latest.
+    required: false
+    default: ''
+  working-directory:
+    description: Directory where the game-ci command should run.
+    required: false
+    default: '.'
+
+runs:
+  using: composite
+  steps:
+    - name: Install GameCI CLI
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        version="${{ inputs.version }}"
+        action_ref="${{ github.action_ref }}"
+
+        if [ -z "$version" ] && printf '%s' "$action_ref" | grep -Eq '^v[0-9]'; then
+          version="$action_ref"
+        fi
+
+        export GAME_CI_INSTALL="${RUNNER_TEMP}/game-ci/bin"
+        if [ -n "$version" ]; then
+          export GAME_CI_VERSION="$version"
+        fi
+
+        "${GITHUB_ACTION_PATH}/install.sh"
+        echo "$GAME_CI_INSTALL" >> "$GITHUB_PATH"
+
+    - name: Install GameCI CLI
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+
+        $repo = 'game-ci/cli'
+        $version = '${{ inputs.version }}'
+        $actionRef = '${{ github.action_ref }}'
+
+        if (-not $version -and $actionRef -match '^v[0-9]') {
+          $version = $actionRef
+        }
+
+        if (-not $version) {
+          $release = Invoke-RestMethod "https://api.github.com/repos/$repo/releases/latest"
+          $version = $release.tag_name
+        }
+
+        $installDir = Join-Path $env:RUNNER_TEMP 'game-ci\bin'
+        $binaryPath = Join-Path $installDir 'game-ci.exe'
+        $assetName = 'game-ci-windows-x64.exe'
+        $downloadUrl = "https://github.com/$repo/releases/download/$version/$assetName"
+        $checksumUrl = "https://github.com/$repo/releases/download/$version/checksums.txt"
+
+        New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $binaryPath -UseBasicParsing
+
+        $expectedHash = ''
+        try {
+          $checksums = Invoke-WebRequest -Uri $checksumUrl -UseBasicParsing | Select-Object -ExpandProperty Content
+          $expectedLine = $checksums -split "`n" | Where-Object { $_ -match $assetName } | Select-Object -First 1
+          if ($expectedLine) {
+            $expectedHash = ($expectedLine -split '\s+')[0].ToLower()
+          }
+        } catch {
+          Write-Warning "Checksum verification skipped because checksum metadata could not be fetched: $_"
+        }
+
+        if ($expectedHash) {
+          $actualHash = (Get-FileHash -Path $binaryPath -Algorithm SHA256).Hash.ToLower()
+          if ($expectedHash -ne $actualHash) {
+            throw "Checksum verification failed. Expected $expectedHash, got $actualHash"
+          }
+        }
+
+        & $binaryPath --help | Out-Null
+        $installDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+    - name: Run GameCI CLI
+      if: inputs.args != '' && runner.os != 'Windows'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: game-ci ${{ inputs.args }}
+
+    - name: Run GameCI CLI
+      if: inputs.args != '' && runner.os == 'Windows'
+      shell: pwsh
+      working-directory: ${{ inputs.working-directory }}
+      run: game-ci ${{ inputs.args }}

--- a/src/command-options/build-options.test.ts
+++ b/src/command-options/build-options.test.ts
@@ -1,0 +1,41 @@
+import { yargs } from '../dependencies.ts';
+import { BuildOptions } from './build-options.ts';
+
+describe('BuildOptions', () => {
+  it('derives buildFile from the resolved default buildName', async () => {
+    const parser = yargs(['--targetPlatform', 'StandaloneLinux64'])
+      .exitProcess(false)
+      .fail((message, error) => {
+        throw error || new Error(message);
+      });
+
+    BuildOptions.configure(parser);
+
+    const argv = await parser.parseAsync();
+
+    expect(argv.buildName).toBe('StandaloneLinux64');
+    expect(argv.buildPath).toBe('build/StandaloneLinux64');
+    expect(argv.buildFile).toBe('StandaloneLinux64');
+  });
+
+  it('uses android export type when deriving Android buildFile', async () => {
+    const parser = yargs([
+      '--targetPlatform',
+      'Android',
+      '--buildName',
+      'GameCI',
+      '--androidExportType',
+      'androidAppBundle',
+    ])
+      .exitProcess(false)
+      .fail((message, error) => {
+        throw error || new Error(message);
+      });
+
+    BuildOptions.configure(parser);
+
+    const argv = await parser.parseAsync();
+
+    expect(argv.buildFile).toBe('GameCI.aab');
+  });
+});

--- a/src/command-options/build-options.ts
+++ b/src/command-options/build-options.ts
@@ -22,10 +22,16 @@ export class BuildOptions implements IOptions {
       .default('buildPath', '')
       .default('buildFile', '')
       .middleware((argv: YargsArguments) => {
-        const { buildName, buildsPath, targetPlatform, androidAppBundle } = argv;
-        argv.buildName = buildName || targetPlatform;
+        const { buildName, buildsPath, targetPlatform, androidAppBundle, androidExportType } = argv;
+        const resolvedBuildName = buildName || targetPlatform;
+        const resolvedAndroidExportType = androidExportType || (androidAppBundle ? 'androidAppBundle' : 'androidPackage');
+        argv.buildName = resolvedBuildName;
         argv.buildPath = `${buildsPath}/${targetPlatform}`;
-        argv.buildFile = UnityTargetPlatform.determineBuildFileName(buildName, targetPlatform, androidAppBundle);
+        argv.buildFile = UnityTargetPlatform.determineBuildFileName(
+          resolvedBuildName,
+          targetPlatform,
+          resolvedAndroidExportType,
+        );
       })
       .option('buildMethod', {
         alias: 'm',

--- a/src/model/docker.test.ts
+++ b/src/model/docker.test.ts
@@ -25,6 +25,7 @@ describe('Docker', () => {
     expect(command).toContain('--volume "/home/runner":"/root:z"');
     expect(command).toContain('--volume "/home/runner/work/cli/cli":"/github/workspace:z"');
     expect(command).toContain('game-ci/unity-editor-stub:latest');
+    expect(command).toContain('/bin/bash /entrypoint.sh');
     expect(command).not.toContain('\n');
   });
 

--- a/src/model/docker.test.ts
+++ b/src/model/docker.test.ts
@@ -2,6 +2,32 @@ import { Action } from './action.ts';
 import { Docker } from './docker.ts';
 
 describe('Docker', () => {
+  it('builds a continuous Linux docker command', () => {
+    const command = (Docker as any).getLinuxCommand('game-ci/unity-editor-stub:latest', {
+      hostOS: 'linux',
+      currentWorkDir: '/home/runner/work/cli/cli',
+      homeDir: '/home/runner',
+      cliDistPath: '/home/runner/work/cli/cli/dist',
+      runnerTempPath: '/home/runner/work/_temp',
+      sshAgent: '',
+      gitPrivateToken: '',
+      dockerWorkspacePath: '/github/workspace',
+      unityLicense: 'ci-stub-license',
+      engineVersion: '2019.4.40f1',
+      projectPath: 'test-project',
+      targetPlatform: 'StandaloneLinux64',
+      buildName: 'StandaloneLinux64',
+      buildPath: 'build/StandaloneLinux64',
+      buildFile: 'StandaloneLinux64',
+    });
+
+    expect(command).toContain('--env UNITY_LICENSE="ci-stub-license"');
+    expect(command).toContain('--volume "/home/runner":"/root:z"');
+    expect(command).toContain('--volume "/home/runner/work/cli/cli":"/github/workspace:z"');
+    expect(command).toContain('game-ci/unity-editor-stub:latest');
+    expect(command).not.toContain('\n');
+  });
+
   it.skip('runs', async () => {
     const image = 'unity-builder:2019.2.11f1-webgl';
     const parameters = {

--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -78,7 +78,7 @@ class Docker {
       sshAgent ? `--volume ${sshAgent}:/ssh-agent` : '',
       sshAgent ? '--volume /home/runner/.ssh/known_hosts:/root/.ssh/known_hosts:ro' : '',
       image,
-      '/bin/bash -c /entrypoint.sh',
+      '/bin/bash /entrypoint.sh',
     ]
       .filter(Boolean)
       .join(' ');

--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -58,31 +58,30 @@ class Docker {
     const { currentWorkDir, homeDir, cliDistPath, runnerTempPath, sshAgent, gitPrivateToken, dockerWorkspacePath } = options;
 
     const home = homeDir;
+    const envVarString = ImageEnvironmentFactory.getEnvVarString(options).replace(/ \\\n/g, ' ');
 
-    return (
-      String.dedent`
-      docker run \
-        --rm \
-        --workdir ${dockerWorkspacePath} \
-        ${ImageEnvironmentFactory.getEnvVarString(options)} \
-        --env UNITY_SERIAL \
-        --env GITHUB_WORKSPACE=${dockerWorkspacePath} \
-        ${gitPrivateToken ? `--env GIT_PRIVATE_TOKEN="${gitPrivateToken}"` : ''} \
-        ${sshAgent ? '--env SSH_AUTH_SOCK=/ssh-agent' : ''} \
-        --volume "${home}":"/root:z" \
-       ` +
-      `
-        --volume "${currentWorkDir}":"${dockerWorkspacePath}:z" \
-        --volume "${cliDistPath}/default-build-script:/UnityBuilderAction:z" \
-        --volume "${cliDistPath}/platforms/ubuntu/steps:/steps:z" \
-        --volume "${cliDistPath}/platforms/ubuntu/entrypoint.sh:/entrypoint.sh:z" \
-        --volume "${cliDistPath}/unity-config:/usr/share/unity3d/config:z" \
-        ${sshAgent ? `--volume ${sshAgent}:/ssh-agent` : ''} \
-        ${sshAgent ? '--volume /home/runner/.ssh/known_hosts:/root/.ssh/known_hosts:ro' : ''} \
-        ${image} \
-        /bin/bash -c /entrypoint.sh
-    `
-    );
+    return [
+      'docker run',
+      '--rm',
+      `--workdir ${dockerWorkspacePath}`,
+      envVarString,
+      '--env UNITY_SERIAL',
+      `--env GITHUB_WORKSPACE=${dockerWorkspacePath}`,
+      gitPrivateToken ? `--env GIT_PRIVATE_TOKEN="${gitPrivateToken}"` : '',
+      sshAgent ? '--env SSH_AUTH_SOCK=/ssh-agent' : '',
+      `--volume "${home}":"/root:z"`,
+      `--volume "${currentWorkDir}":"${dockerWorkspacePath}:z"`,
+      `--volume "${cliDistPath}/default-build-script:/UnityBuilderAction:z"`,
+      `--volume "${cliDistPath}/platforms/ubuntu/steps:/steps:z"`,
+      `--volume "${cliDistPath}/platforms/ubuntu/entrypoint.sh:/entrypoint.sh:z"`,
+      `--volume "${cliDistPath}/unity-config:/usr/share/unity3d/config:z"`,
+      sshAgent ? `--volume ${sshAgent}:/ssh-agent` : '',
+      sshAgent ? '--volume /home/runner/.ssh/known_hosts:/root/.ssh/known_hosts:ro' : '',
+      image,
+      '/bin/bash -c /entrypoint.sh',
+    ]
+      .filter(Boolean)
+      .join(' ');
   }
 
   private static getWindowsCommand(image: string, options: Options): string {

--- a/src/model/image-environment-factory.test.ts
+++ b/src/model/image-environment-factory.test.ts
@@ -1,0 +1,37 @@
+import { ImageEnvironmentFactory } from './image-environment-factory.ts';
+
+describe('ImageEnvironmentFactory', () => {
+  it('adds shell line continuations for Linux docker env flags', () => {
+    const envString = ImageEnvironmentFactory.getEnvVarString({
+      hostOS: 'linux',
+      unityLicense: 'ci-stub-license',
+      engineVersion: '2019.4.40f1',
+      projectPath: 'test-project',
+      targetPlatform: 'StandaloneLinux64',
+      buildName: 'StandaloneLinux64',
+      buildPath: 'build/StandaloneLinux64',
+      buildFile: 'StandaloneLinux64',
+    } as any);
+
+    const lines = envString.split('\n');
+
+    expect(lines).toContain('--env UNITY_LICENSE="ci-stub-license" \\');
+    expect(lines).toContain('--env UNITY_VERSION="2019.4.40f1" \\');
+    expect(lines).toContain('--env BUILD_TARGET="StandaloneLinux64" \\');
+    expect(lines.slice(0, -1).every((line) => line.endsWith(' \\'))).toBe(true);
+    expect(lines.at(-1)!.endsWith(' \\')).toBe(false);
+  });
+
+  it('keeps PowerShell line continuations for Windows docker env flags', () => {
+    const envString = ImageEnvironmentFactory.getEnvVarString({
+      hostOS: 'windows',
+      unityLicense: 'ci-stub-license',
+      engineVersion: '2019.4.40f1',
+    } as any);
+
+    const lines = envString.split('\n');
+
+    expect(lines.slice(0, -1).every((line) => line.endsWith(' `'))).toBe(true);
+    expect(lines.at(-1)!.endsWith(' `')).toBe(false);
+  });
+});

--- a/src/model/image-environment-factory.ts
+++ b/src/model/image-environment-factory.ts
@@ -9,13 +9,14 @@ class ImageEnvironmentFactory {
   public static getEnvVarString(options: Options) {
     const { hostOS } = options;
     const environmentVariables = ImageEnvironmentFactory.getEnvironmentVariables(options);
-    let string = '';
+    const lineContinuation = hostOS === 'windows' ? '`' : '\\';
+    const lines: string[] = [];
     for (const p of environmentVariables) {
       if (p.value === '' || p.value === undefined) {
         continue;
       }
       if (p.name !== 'ANDROID_KEYSTORE_BASE64' && p.value.toString().includes(`\n`)) {
-        string += `--env ${p.name} `;
+        lines.push(`--env ${p.name}`);
         continue;
       }
 
@@ -23,19 +24,13 @@ class ImageEnvironmentFactory {
         // The ampersand (&) character is not allowed. The & operator is reserved for future use; wrap an ampersand in
         // double quotation marks ("&") to pass it as part of a string.
         const escapedValue = typeof p.value !== 'string' ? p.value : p.value?.replace(/&/, '\\"&\\"');
-        string += `--env ${p.name}='${escapedValue}' \`\n`;
+        lines.push(`--env ${p.name}='${escapedValue}'`);
       } else {
-        string += `--env ${p.name}="${p.value}"\n`;
+        lines.push(`--env ${p.name}="${p.value}"`);
       }
     }
 
-    if (hostOS === 'windows') {
-      string = string.replace(/`\n$/, '');
-    } else {
-      string = string.replace(/\n$/, '');
-    }
-
-    return string;
+    return lines.join(` ${lineContinuation}\n`);
   }
   public static getEnvironmentVariables(options: Options) {
     const environmentVariables: DockerParameter[] = [


### PR DESCRIPTION
## Summary
- Add a composite GitHub Action that installs the released game-ci CLI binary on Linux, macOS, and Windows runners
- Default the installed CLI version to the action version tag when possible, otherwise latest, with an explicit version override
- Allow workflows to either install game-ci for later steps or run it immediately through the args input
- Document GitHub Action usage in the README

## Validation
- bun install --no-save
- bun test
- node YAML parse check for action.yml
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GameCI CLI is now available as a reusable GitHub Action with configurable version and custom arguments support.
  * Added automated Unity version detection and build artifact validation in smoke testing workflows.

* **Documentation**
  * Added GitHub Action usage guide to README with example workflow configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->