### PR TITLE
Prefer orchestrate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # GameCI CLI
 
-Build automation for game engines — Unity, Unreal Engine, Godot, and more.
+Automation for game engines — Unity, Unreal Engine, Godot, and more.
 
-The CLI is a thin, plugin-based runtime. Engine support, provider integrations, and remote build orchestration are loaded as plugins. The orchestrator is the intended provider/backend layer for local, Docker, and remote execution flows.
+The CLI is a thin, plugin-based runtime. Engine support, provider integrations, and remote job execution are loaded as plugins. Orchestrator is the intended provider/backend layer for local, Docker, and remote execution flows.
 
 ## Install
 
@@ -43,7 +43,7 @@ bun run start -- --help
 ```bash
 game-ci --help
 game-ci build --engine unity --projectPath ./my-project
-game-ci remote build --providerStrategy local-docker
+game-ci remote run --providerStrategy local-docker
 ```
 
 ## GitHub Action
@@ -107,7 +107,7 @@ docker run --rm \
 ### Godot via Orchestrator (Local Docker)
 
 ```bash
-game-ci orchestrate \
+game-ci --plugin @game-ci/orchestrator-plugin remote run \
   --engine godot \
   --provider-strategy local-docker \
   --target-platform linux \
@@ -120,7 +120,7 @@ game-ci orchestrate \
 ### Godot via Orchestrator (Local System)
 
 ```bash
-game-ci orchestrate \
+game-ci --plugin @game-ci/orchestrator-plugin remote run \
   --engine godot \
   --provider-strategy local-system \
   --target-platform linux \
@@ -186,7 +186,7 @@ docker run --rm \
 ### Unreal Engine via Orchestrator (Local Docker)
 
 ```bash
-game-ci orchestrate \
+game-ci --plugin @game-ci/orchestrator-plugin remote run \
   --engine unreal \
   --provider-strategy local-docker \
   --target-platform linux \
@@ -208,7 +208,7 @@ game-ci orchestrate \
 Runs directly on the host using your local UE installation:
 
 ```bash
-game-ci orchestrate \
+game-ci --plugin @game-ci/orchestrator-plugin remote run \
   --engine unreal \
   --provider-strategy local-system \
   --target-platform linux \
@@ -236,14 +236,14 @@ The CLI discovers functionality through plugins. Built-in plugins ship with the 
 ### External (loaded at runtime)
 
 ```bash
-game-ci --plugin @game-ci/orchestrator-plugin remote build --providerStrategy aws
+game-ci --plugin @game-ci/orchestrator-plugin remote run --providerStrategy aws
 ```
 
 Plugins can register:
 - **Engine detectors** — detect project engines (Unity, UE5, Godot)
 - **Commands** — add CLI subcommands
 - **Options** — add CLI flags
-- **Providers** — remote build providers (AWS, K8s, local-docker)
+- **Providers** — remote job providers (AWS, K8s, local-docker)
 
 See `src/plugin/plugin-interface.ts` for the plugin API.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Automation for game engines — Unity, Unreal Engine, Godot, and more.
 
-The CLI is a thin, plugin-based runtime. Engine support, provider integrations, and remote job execution are loaded as plugins. Orchestrator is the intended provider/backend layer for local, Docker, and remote execution flows.
+The CLI is a thin, plugin-based runtime. Engine support, provider integrations, and orchestrated job execution are loaded as plugins. Orchestrator is the intended provider/backend layer for local, Docker, and remote execution flows.
 
 ## Install
 
@@ -43,7 +43,7 @@ bun run start -- --help
 ```bash
 game-ci --help
 game-ci build --engine unity --projectPath ./my-project
-game-ci remote run --providerStrategy local-docker
+game-ci orchestrate --providerStrategy local-docker
 ```
 
 ## GitHub Action
@@ -107,7 +107,7 @@ docker run --rm \
 ### Godot via Orchestrator (Local Docker)
 
 ```bash
-game-ci --plugin @game-ci/orchestrator-plugin remote run \
+game-ci --plugin @game-ci/orchestrator-plugin orchestrate \
   --engine godot \
   --provider-strategy local-docker \
   --target-platform linux \
@@ -120,7 +120,7 @@ game-ci --plugin @game-ci/orchestrator-plugin remote run \
 ### Godot via Orchestrator (Local System)
 
 ```bash
-game-ci --plugin @game-ci/orchestrator-plugin remote run \
+game-ci --plugin @game-ci/orchestrator-plugin orchestrate \
   --engine godot \
   --provider-strategy local-system \
   --target-platform linux \
@@ -186,7 +186,7 @@ docker run --rm \
 ### Unreal Engine via Orchestrator (Local Docker)
 
 ```bash
-game-ci --plugin @game-ci/orchestrator-plugin remote run \
+game-ci --plugin @game-ci/orchestrator-plugin orchestrate \
   --engine unreal \
   --provider-strategy local-docker \
   --target-platform linux \
@@ -208,7 +208,7 @@ game-ci --plugin @game-ci/orchestrator-plugin remote run \
 Runs directly on the host using your local UE installation:
 
 ```bash
-game-ci --plugin @game-ci/orchestrator-plugin remote run \
+game-ci --plugin @game-ci/orchestrator-plugin orchestrate \
   --engine unreal \
   --provider-strategy local-system \
   --target-platform linux \
@@ -236,14 +236,14 @@ The CLI discovers functionality through plugins. Built-in plugins ship with the 
 ### External (loaded at runtime)
 
 ```bash
-game-ci --plugin @game-ci/orchestrator-plugin remote run --providerStrategy aws
+game-ci --plugin @game-ci/orchestrator-plugin orchestrate --providerStrategy aws
 ```
 
 Plugins can register:
 - **Engine detectors** — detect project engines (Unity, UE5, Godot)
 - **Commands** — add CLI subcommands
 - **Options** — add CLI flags
-- **Providers** — remote job providers (AWS, K8s, local-docker)
+- **Providers** — orchestrated job providers (AWS, K8s, local-docker)
 
 See `src/plugin/plugin-interface.ts` for the plugin API.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@game-ci/cli",
   "version": "0.1.0",
-  "description": "GameCI CLI - Build automation for game engines",
+  "description": "GameCI CLI - automation for game engines",
   "type": "module",
   "main": "src/index.ts",
   "bin": {

--- a/src/cli-commands.ts
+++ b/src/cli-commands.ts
@@ -52,9 +52,13 @@ export class CliCommands {
   }
 
   private async remoteCommands() {
-    await this.yargs.command('remote', 'Schedule jobs to be run remotely, in the cloud', async (yargs: YargsInstance) => {
+    await this.yargs.command('remote', 'Run provider-backed jobs outside the local process', async (yargs: YargsInstance) => {
       yargs
-        .command('build [projectPath]', 'Schedule a build to be run remotely', async (yargs: YargsInstance) => {
+        .command('run [projectPath]', 'Run an engine job through a provider plugin', async (yargs: YargsInstance) => {
+          ProjectOptions.preConfigure(yargs);
+          this.register(yargs);
+        })
+        .command('build [projectPath]', 'Legacy alias for remote run', async (yargs: YargsInstance) => {
           ProjectOptions.preConfigure(yargs);
           this.register(yargs);
         })

--- a/src/cli-commands.ts
+++ b/src/cli-commands.ts
@@ -23,6 +23,7 @@ export class CliCommands {
     await this.configCommand();
     await this.testCommand();
     await this.buildCommand();
+    await this.orchestrateCommand();
     await this.remoteCommands();
 
     // This is needed to run the engine and vcs detection middleware.
@@ -51,14 +52,21 @@ export class CliCommands {
     });
   }
 
+  private async orchestrateCommand() {
+    await this.yargs.command('orchestrate [projectPath]', 'Run an engine job through a provider plugin', async (yargs: YargsInstance) => {
+      ProjectOptions.preConfigure(yargs);
+      this.register(yargs);
+    });
+  }
+
   private async remoteCommands() {
-    await this.yargs.command('remote', 'Run provider-backed jobs outside the local process', async (yargs: YargsInstance) => {
+    await this.yargs.command('remote', false, async (yargs: YargsInstance) => {
       yargs
-        .command('run [projectPath]', 'Run an engine job through a provider plugin', async (yargs: YargsInstance) => {
+        .command('run [projectPath]', false, async (yargs: YargsInstance) => {
           ProjectOptions.preConfigure(yargs);
           this.register(yargs);
         })
-        .command('build [projectPath]', 'Legacy alias for remote run', async (yargs: YargsInstance) => {
+        .command('build [projectPath]', false, async (yargs: YargsInstance) => {
           ProjectOptions.preConfigure(yargs);
           this.register(yargs);
         })

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -4,7 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import * as process from 'node:process';
 import { Cli } from './cli.ts';
-import { UnityRemoteRunCommand } from './command/remote/unity-remote-run-command.ts';
+import { UnityOrchestrateCommand } from './command/orchestrate/unity-orchestrate-command.ts';
 import { CommandFactory } from './command/command-factory.ts';
 import { unityPlugin } from './plugin/builtin/unity-plugin.ts';
 import { PluginRegistry } from './plugin/plugin-registry.ts';
@@ -62,12 +62,20 @@ describe('Cli plugin loading', () => {
     expect(pluginNames.filter((name) => name === 'unreal')).toHaveLength(1);
   });
 
-  it('supports remote run as the preferred provider-backed command', async () => {
+  it('supports orchestrate as the preferred provider-backed command', async () => {
+    await PluginRegistry.register(unityPlugin);
+
+    const command = new CommandFactory().selectEngine('unity', '2022.3.20f1').createCommand(['orchestrate']);
+
+    expect(command).toBeInstanceOf(UnityOrchestrateCommand);
+  });
+
+  it('keeps remote run as a backwards-compatible alias', async () => {
     await PluginRegistry.register(unityPlugin);
 
     const command = new CommandFactory().selectEngine('unity', '2022.3.20f1').createCommand(['remote', 'run']);
 
-    expect(command).toBeInstanceOf(UnityRemoteRunCommand);
+    expect(command).toBeInstanceOf(UnityOrchestrateCommand);
   });
 
   it('keeps remote build as a backwards-compatible alias', async () => {
@@ -75,6 +83,6 @@ describe('Cli plugin loading', () => {
 
     const command = new CommandFactory().selectEngine('unity', '2022.3.20f1').createCommand(['remote', 'build']);
 
-    expect(command).toBeInstanceOf(UnityRemoteRunCommand);
+    expect(command).toBeInstanceOf(UnityOrchestrateCommand);
   });
 });

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -4,6 +4,9 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import * as process from 'node:process';
 import { Cli } from './cli.ts';
+import { UnityRemoteRunCommand } from './command/remote/unity-remote-run-command.ts';
+import { CommandFactory } from './command/command-factory.ts';
+import { unityPlugin } from './plugin/builtin/unity-plugin.ts';
 import { PluginRegistry } from './plugin/plugin-registry.ts';
 
 describe('Cli plugin loading', () => {
@@ -57,5 +60,21 @@ describe('Cli plugin loading', () => {
     expect(pluginNames.filter((name) => name === 'unity')).toHaveLength(1);
     expect(pluginNames.filter((name) => name === 'godot')).toHaveLength(1);
     expect(pluginNames.filter((name) => name === 'unreal')).toHaveLength(1);
+  });
+
+  it('supports remote run as the preferred provider-backed command', async () => {
+    await PluginRegistry.register(unityPlugin);
+
+    const command = new CommandFactory().selectEngine('unity', '2022.3.20f1').createCommand(['remote', 'run']);
+
+    expect(command).toBeInstanceOf(UnityRemoteRunCommand);
+  });
+
+  it('keeps remote build as a backwards-compatible alias', async () => {
+    await PluginRegistry.register(unityPlugin);
+
+    const command = new CommandFactory().selectEngine('unity', '2022.3.20f1').createCommand(['remote', 'build']);
+
+    expect(command).toBeInstanceOf(UnityRemoteRunCommand);
   });
 });

--- a/src/command-options/remote-options.ts
+++ b/src/command-options/remote-options.ts
@@ -12,7 +12,7 @@ import { PluginRegistry } from '../plugin/plugin-registry.ts';
 export class RemoteOptions implements IOptions {
   public static async configure(yargs: YargsInstance): Promise<void> {
     yargs.option('providerStrategy', {
-      description: `Provider strategy for remote jobs (${PluginRegistry.getAvailableProviders().join(', ') || 'none registered'})`,
+      description: `Provider strategy for orchestrated jobs (${PluginRegistry.getAvailableProviders().join(', ') || 'none registered'})`,
       type: 'string',
       demandOption: false,
       default: 'local-docker',

--- a/src/command-options/remote-options.ts
+++ b/src/command-options/remote-options.ts
@@ -3,7 +3,7 @@ import { IOptions } from './options-interface.ts';
 import { PluginRegistry } from '../plugin/plugin-registry.ts';
 
 /**
- * Remote build options.
+ * Remote provider options.
  *
  * Only the minimal options needed to select and invoke a provider plugin.
  * All provider-specific options (aws, k8s, memory, cpu, hooks, etc.) are
@@ -12,7 +12,7 @@ import { PluginRegistry } from '../plugin/plugin-registry.ts';
 export class RemoteOptions implements IOptions {
   public static async configure(yargs: YargsInstance): Promise<void> {
     yargs.option('providerStrategy', {
-      description: `Provider strategy for remote builds (${PluginRegistry.getAvailableProviders().join(', ') || 'none registered'})`,
+      description: `Provider strategy for remote jobs (${PluginRegistry.getAvailableProviders().join(', ') || 'none registered'})`,
       type: 'string',
       demandOption: false,
       default: 'local-docker',

--- a/src/command/orchestrate/unity-orchestrate-command.ts
+++ b/src/command/orchestrate/unity-orchestrate-command.ts
@@ -6,13 +6,13 @@ import { ProjectOptions } from '../../command-options/project-options.ts';
 import { PluginRegistry } from '../../plugin/plugin-registry.ts';
 
 /**
- * Remote provider command.
+ * Provider-backed orchestration command.
  *
- * Delegates to the provider plugin selected by --providerStrategy.
- * The actual job execution (setupWorkflow, runTaskInWorkflow, etc.)
- * is handled entirely by the orchestrator plugin.
+ * Delegates to the provider plugin selected by --providerStrategy. The actual
+ * job execution (setupWorkflow, runTaskInWorkflow, etc.) is handled by the
+ * provider implementation, usually the Orchestrator plugin.
  */
-export class UnityRemoteRunCommand extends CommandBase implements CommandInterface {
+export class UnityOrchestrateCommand extends CommandBase implements CommandInterface {
   public async execute(options: YargsArguments): Promise<boolean> {
     const { providerStrategy } = options;
 
@@ -20,14 +20,13 @@ export class UnityRemoteRunCommand extends CommandBase implements CommandInterfa
     if (!provider) {
       throw new Error(
         `No provider registered for strategy "${providerStrategy}". ` +
-        `Available: ${PluginRegistry.getAvailableProviders().join(', ') || 'none'}. ` +
-        `Install a provider plugin (e.g. @game-ci/orchestrator-plugin).`,
+          `Available: ${PluginRegistry.getAvailableProviders().join(', ') || 'none'}. ` +
+          `Install a provider plugin (e.g. @game-ci/orchestrator-plugin).`,
       );
     }
 
     log.info(`Using provider strategy: ${providerStrategy}`);
 
-    // Provider handles the full remote job lifecycle
     const result = await provider.runTaskInWorkflow(
       '', // buildGuid — provided by provider
       '', // image — provider determines this
@@ -38,7 +37,7 @@ export class UnityRemoteRunCommand extends CommandBase implements CommandInterfa
       [], // secrets
     );
 
-    log.info('Remote job result:', result);
+    log.info('Orchestrated job result:', result);
     return true;
   }
 

--- a/src/command/remote/unity-remote-run-command.ts
+++ b/src/command/remote/unity-remote-run-command.ts
@@ -6,13 +6,13 @@ import { ProjectOptions } from '../../command-options/project-options.ts';
 import { PluginRegistry } from '../../plugin/plugin-registry.ts';
 
 /**
- * Remote build command.
+ * Remote provider command.
  *
  * Delegates to the provider plugin selected by --providerStrategy.
- * The actual build execution (setupWorkflow, runTaskInWorkflow, etc.)
+ * The actual job execution (setupWorkflow, runTaskInWorkflow, etc.)
  * is handled entirely by the orchestrator plugin.
  */
-export class UnityRemoteBuildCommand extends CommandBase implements CommandInterface {
+export class UnityRemoteRunCommand extends CommandBase implements CommandInterface {
   public async execute(options: YargsArguments): Promise<boolean> {
     const { providerStrategy } = options;
 
@@ -27,7 +27,7 @@ export class UnityRemoteBuildCommand extends CommandBase implements CommandInter
 
     log.info(`Using provider strategy: ${providerStrategy}`);
 
-    // Provider handles the full remote build lifecycle
+    // Provider handles the full remote job lifecycle
     const result = await provider.runTaskInWorkflow(
       '', // buildGuid — provided by provider
       '', // image — provider determines this
@@ -38,7 +38,7 @@ export class UnityRemoteBuildCommand extends CommandBase implements CommandInter
       [], // secrets
     );
 
-    log.info('Remote build result:', result);
+    log.info('Remote job result:', result);
     return true;
   }
 

--- a/src/plugin/builtin/unity-plugin.ts
+++ b/src/plugin/builtin/unity-plugin.ts
@@ -1,7 +1,7 @@
 import type { GameCIPlugin } from '../plugin-interface.ts';
 import { UnityVersionDetector } from '../../middleware/engine-detection/unity-version-detector.ts';
 import { UnityBuildCommand } from '../../command/build/unity-build-command.ts';
-import { UnityRemoteBuildCommand } from '../../command/remote/unity-remote-build-command.ts';
+import { UnityRemoteRunCommand } from '../../command/remote/unity-remote-run-command.ts';
 import { NonExistentCommand } from '../../command/null/non-existent-command.ts';
 import type { CommandInterface } from '../../command/command-interface.ts';
 
@@ -35,8 +35,9 @@ export const unityPlugin: GameCIPlugin = {
             return new UnityBuildCommand(command);
           case 'remote':
             switch (subCommands[0]) {
+              case 'run':
               case 'build':
-                return new UnityRemoteBuildCommand(command);
+                return new UnityRemoteRunCommand(command);
               default:
                 return new NonExistentCommand([command, ...subCommands].join(' '));
             }

--- a/src/plugin/builtin/unity-plugin.ts
+++ b/src/plugin/builtin/unity-plugin.ts
@@ -1,7 +1,7 @@
 import type { GameCIPlugin } from '../plugin-interface.ts';
 import { UnityVersionDetector } from '../../middleware/engine-detection/unity-version-detector.ts';
 import { UnityBuildCommand } from '../../command/build/unity-build-command.ts';
-import { UnityRemoteRunCommand } from '../../command/remote/unity-remote-run-command.ts';
+import { UnityOrchestrateCommand } from '../../command/orchestrate/unity-orchestrate-command.ts';
 import { NonExistentCommand } from '../../command/null/non-existent-command.ts';
 import type { CommandInterface } from '../../command/command-interface.ts';
 
@@ -33,11 +33,13 @@ export const unityPlugin: GameCIPlugin = {
         switch (command) {
           case 'build':
             return new UnityBuildCommand(command);
+          case 'orchestrate':
+            return new UnityOrchestrateCommand(command);
           case 'remote':
             switch (subCommands[0]) {
               case 'run':
               case 'build':
-                return new UnityRemoteRunCommand(command);
+                return new UnityOrchestrateCommand(command);
               default:
                 return new NonExistentCommand([command, ...subCommands].join(' '));
             }

--- a/src/plugin/cli-protocol-plugin.ts
+++ b/src/plugin/cli-protocol-plugin.ts
@@ -48,7 +48,7 @@ export class CliProtocolPlugin implements ProviderPlugin {
     if (!executable || typeof executable !== 'string') {
       throw new Error(
         'CliProtocolPlugin requires --provider-executable (path to orchestrator binary). ' +
-        'Example: game-ci remote run --providerStrategy cli-protocol --provider-executable ./game-ci-orchestrator',
+          'Example: game-ci orchestrate --providerStrategy cli-protocol --provider-executable ./game-ci-orchestrator',
       );
     }
 

--- a/src/plugin/cli-protocol-plugin.ts
+++ b/src/plugin/cli-protocol-plugin.ts
@@ -48,7 +48,7 @@ export class CliProtocolPlugin implements ProviderPlugin {
     if (!executable || typeof executable !== 'string') {
       throw new Error(
         'CliProtocolPlugin requires --provider-executable (path to orchestrator binary). ' +
-        'Example: game-ci remote build --providerStrategy cli-protocol --provider-executable ./game-ci-orchestrator',
+        'Example: game-ci remote run --providerStrategy cli-protocol --provider-executable ./game-ci-orchestrator',
       );
     }
 

--- a/src/plugin/plugin-interface.ts
+++ b/src/plugin/plugin-interface.ts
@@ -11,7 +11,7 @@ export interface EngineDetectorPlugin {
 }
 
 /**
- * Command provider from a plugin — maps engine commands (build, test, remote build, etc.)
+ * Command provider from a plugin — maps engine commands (build, test, remote run, etc.)
  * to concrete implementations.
  */
 export interface CommandPlugin {

--- a/src/plugin/plugin-interface.ts
+++ b/src/plugin/plugin-interface.ts
@@ -11,7 +11,7 @@ export interface EngineDetectorPlugin {
 }
 
 /**
- * Command provider from a plugin — maps engine commands (build, test, remote run, etc.)
+ * Command provider from a plugin — maps engine commands (build, test, orchestrate, etc.)
  * to concrete implementations.
  */
 export interface CommandPlugin {

--- a/test-projects/godot-minimal/project.godot
+++ b/test-projects/godot-minimal/project.godot
@@ -5,7 +5,7 @@
 
 config/name="GameCI CLI Smoke Test"
 config/description="Minimal project for CLI validation"
-run/main_scene=""
+run/main_scene="res://scenes/Main.tscn"
 config/features=PackedStringArray("4.3")
 
 [rendering]

--- a/test-projects/godot-minimal/scenes/Main.tscn
+++ b/test-projects/godot-minimal/scenes/Main.tscn
@@ -1,0 +1,3 @@
+[gd_scene format=3]
+
+[node name="Main" type="Node"]


### PR DESCRIPTION
## Summary
- adds `game-ci orchestrate` as the preferred provider-backed job command
- keeps `game-ci remote run` and `game-ci remote build` as hidden backwards-compatible aliases
- renames the Unity provider-backed command implementation to orchestrate terminology
- updates README/help wording so provider jobs are not framed as build-only

## Tests
- `bun test`
- `bun run build`