### PR TITLE
Spike (unwired): Unity CLI subprocess adapter

### DIFF
--- a/src/command-options/unity-run-options.ts
+++ b/src/command-options/unity-run-options.ts
@@ -1,0 +1,28 @@
+import type { YargsInstance } from '../dependencies.ts';
+import { IOptions } from './options-interface.ts';
+
+/**
+ * Options for `game-ci run` — a standardized alternative to bespoke
+ * `-executeMethod` batch entry points, backed by Unity's own official
+ * Unity CLI `run --command` (docs.unity.com/en-us/unity-cli).
+ */
+export class UnityRunOptions implements IOptions {
+  public static configure(yargs: YargsInstance): void {
+    yargs
+      .option('command', {
+        alias: 'c',
+        description: String.dedent`
+          Fully-qualified static method to invoke, e.g. MyNamespace.MyClass.MyMethod.
+          Passed through to Unity CLI's \`run --command\` — see
+          docs.unity.com/en-us/unity-cli for the current syntax.`,
+        type: 'string',
+        demandOption: true,
+      })
+      .option('unityCliArgs', {
+        description: 'Additional raw arguments appended to the underlying `unity run` invocation, space-separated.',
+        type: 'string',
+        demandOption: false,
+        default: '',
+      });
+  }
+}

--- a/src/command/run/unity-run-command.test.ts
+++ b/src/command/run/unity-run-command.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, mock } from 'bun:test';
+import { UnityRunCommand } from './unity-run-command.ts';
+import { UnityCliAdapter } from '../../model/unity-cli-adapter.ts';
+
+describe('UnityRunCommand', () => {
+  it('throws a clear error when the unity CLI binary is unavailable', async () => {
+    const isAvailable = mock(() => Promise.resolve(false));
+    UnityCliAdapter.isAvailable = isAvailable;
+
+    const command = new UnityRunCommand('run');
+
+    await expect(command.execute({ command: 'MyNamespace.MyClass.MyMethod' } as any)).rejects.toThrow(
+      /unity.*CLI binary/i,
+    );
+  });
+
+  it('delegates to UnityCliAdapter.runCommand and returns its success flag', async () => {
+    UnityCliAdapter.isAvailable = mock(() => Promise.resolve(true));
+    const runCommand = mock(() => Promise.resolve({ success: true, output: 'done' }));
+    UnityCliAdapter.runCommand = runCommand;
+
+    const command = new UnityRunCommand('run');
+    const result = await command.execute({
+      command: 'MyNamespace.MyClass.MyMethod',
+      unityCliArgs: '--flag value',
+    } as any);
+
+    expect(result).toBe(true);
+    expect(runCommand).toHaveBeenCalledWith('MyNamespace.MyClass.MyMethod', ['--flag', 'value']);
+  });
+
+  it('throws a clear error when UnityCliAdapter.runCommand rejects', async () => {
+    UnityCliAdapter.isAvailable = mock(() => Promise.resolve(true));
+    UnityCliAdapter.runCommand = mock(() => Promise.reject(new Error('unity wrote to stderr')));
+
+    const command = new UnityRunCommand('run');
+
+    await expect(
+      command.execute({ command: 'MyNamespace.MyClass.MyMethod' } as any),
+    ).rejects.toThrow(/run:.*MyNamespace\.MyClass\.MyMethod.*failed.*unity wrote to stderr/);
+  });
+});

--- a/src/command/run/unity-run-command.ts
+++ b/src/command/run/unity-run-command.ts
@@ -1,0 +1,49 @@
+import { CommandInterface } from '../command-interface.ts';
+import { CommandBase } from '../command-base.ts';
+import { UnityCliAdapter } from '../../model/unity-cli-adapter.ts';
+import { UnityRunOptions } from '../../command-options/unity-run-options.ts';
+import type { YargsInstance, Options } from '../../dependencies.ts';
+
+/**
+ * `game-ci run --command <Method>` — a standardized alternative to bespoke
+ * `-executeMethod` batch entry points, backed by Unity's own official Unity
+ * CLI (docs.unity.com/en-us/unity-cli, still experimental upstream). See
+ * game-ci/roadmap#11 workstream 3.
+ *
+ * Requires the `unity` CLI binary on PATH — this does not fall back to
+ * game-ci's Docker/Hub-based flows, since Unity CLI's `run --command` has no
+ * equivalent there.
+ */
+export class UnityRunCommand extends CommandBase implements CommandInterface {
+  public async execute(options: Options): Promise<boolean> {
+    const command = options.command as string;
+    const extraArgs = String(options.unityCliArgs || '')
+      .split(' ')
+      .map((arg) => arg.trim())
+      .filter(Boolean);
+
+    const available = await UnityCliAdapter.isAvailable();
+    if (!available) {
+      throw new Error(
+        'run: requires Unity\'s official `unity` CLI binary on PATH ' +
+          '(https://docs.unity.com/en-us/unity-cli). Not found in this environment.',
+      );
+    }
+
+    try {
+      const result = await UnityCliAdapter.runCommand(command, extraArgs);
+      log.info(result.output);
+
+      return result.success;
+    } catch (error: any) {
+      // UnityCliAdapter.runCommand rejects (rather than resolving with
+      // success: false) whenever the underlying process writes to stderr,
+      // which is common even for otherwise-successful Unity CLI invocations.
+      throw new Error(`run: 'unity run --command ${command}' failed — ${error.message}`);
+    }
+  }
+
+  public async configureOptions(yargs: YargsInstance): Promise<void> {
+    UnityRunOptions.configure(yargs);
+  }
+}

--- a/src/model/unity-cli-adapter.ts
+++ b/src/model/unity-cli-adapter.ts
@@ -71,6 +71,21 @@ export class UnityCliAdapter {
     return { success: result.status?.success ?? false, output: result.output };
   }
 
+  /**
+   * Invoke a static method via Unity CLI's `run --command` — a documented,
+   * standardized alternative to bespoke `-executeMethod` batch entry points.
+   * Matches documented syntax: `unity run --command <Namespace.Class.Method> [extraArgs...]`.
+   */
+  static async runCommand(
+    command: string,
+    extraArgs: string[] = [],
+  ): Promise<UnityCliInstallResult> {
+    const cliCommand = ['unity', 'run', '--command', command, ...extraArgs].join(' ');
+    const result = await System.run(cliCommand, undefined, { silent: true });
+
+    return { success: result.status?.success ?? false, output: result.output };
+  }
+
   // `build`/`test`/`license` are intentionally NOT stubbed here yet — Unity's
   // own CLI reference doesn't publish their full flag sets beyond one-line
   // descriptions ("CI-friendly flags, including Android signing and export

--- a/src/model/unity-cli-adapter.ts
+++ b/src/model/unity-cli-adapter.ts
@@ -1,0 +1,81 @@
+/**
+ * EXPERIMENTAL, unwired spike for game-ci/roadmap#11 workstream 3.
+ *
+ * Shells out to Unity Technologies' own official "Unity CLI" binary
+ * (docs.unity.com/en-us/unity-cli — itself still marked experimental), as an
+ * alternative install/build mechanism to game-ci's current unity-hub-driven
+ * flows. Not called from anywhere yet — no command wires this up, no plugin
+ * references it. Exists to validate the subprocess-shell-out shape before
+ * committing to it as the integration mechanism (see the "not yet decided"
+ * options in game-ci/roadmap#11: subprocess vs. library vs. only borrowing
+ * conventions).
+ *
+ * Per the guiding principle from that issue — users should get the full
+ * benefit from GameCI's own docs, not need to separately learn Unity CLI's
+ * syntax — nothing here should ever be the *only* way to do something; it's
+ * an alternative backend for existing game-ci commands to optionally use,
+ * not a new surface for users to learn directly.
+ */
+
+import { System } from './system/system.ts';
+
+export interface UnityCliInstallResult {
+  success: boolean;
+  output: string;
+}
+
+export class UnityCliAdapter {
+  /** Checks whether the `unity` CLI binary is available on PATH. */
+  static async isAvailable(): Promise<boolean> {
+    try {
+      const result = await System.run('unity --version', undefined, { silent: true });
+      return result.status?.success ?? false;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Install a Unity Editor version, optionally with modules, via Unity CLI's
+   * `install` command — a Hub-free alternative to `unity-hub install`.
+   * Matches Unity CLI's documented syntax: `unity install <version> -m <module> [-m <module>...]`.
+   *
+   * Note: System.run() throws on any stderr output or non-zero exit code
+   * rather than returning a checkable failure — callers should catch, not
+   * check `.success` on a rejected promise.
+   */
+  static async installEditor(
+    version: string,
+    modules: string[] = [],
+  ): Promise<UnityCliInstallResult> {
+    const moduleArgs = modules.flatMap((m) => ['-m', m]);
+    const command = ['unity', 'install', version, ...moduleArgs].join(' ');
+    const result = await System.run(command, undefined, { silent: true });
+
+    return { success: result.status?.success ?? false, output: result.output };
+  }
+
+  /**
+   * Add modules to an already-installed Editor version via Unity CLI's
+   * `install-modules` command. Matches documented syntax:
+   * `unity install-modules -e <version> -m <module> [-m <module>...]`.
+   */
+  static async installModules(
+    editorVersion: string,
+    modules: string[],
+  ): Promise<UnityCliInstallResult> {
+    const moduleArgs = modules.flatMap((m) => ['-m', m]);
+    const command = ['unity', 'install-modules', '-e', editorVersion, ...moduleArgs].join(' ');
+    const result = await System.run(command, undefined, { silent: true });
+
+    return { success: result.status?.success ?? false, output: result.output };
+  }
+
+  // `build`/`test`/`license` are intentionally NOT stubbed here yet — Unity's
+  // own CLI reference doesn't publish their full flag sets beyond one-line
+  // descriptions ("CI-friendly flags, including Android signing and export
+  // options" for `build`), so wiring them accurately needs testing against
+  // the real binary rather than guessing at flags from docs alone. See
+  // game-ci/roadmap#11 workstream 3 for the compatibility-check this needs
+  // before those methods can be added responsibly.
+}

--- a/src/plugin/builtin/unity-plugin.ts
+++ b/src/plugin/builtin/unity-plugin.ts
@@ -3,6 +3,7 @@ import { UnityVersionDetector } from '../../middleware/engine-detection/unity-ve
 import { UnityBuildCommand } from '../../command/build/unity-build-command.ts';
 import { UnityOrchestrateCommand } from '../../command/orchestrate/unity-orchestrate-command.ts';
 import { UnityLogsCommand } from '../../command/logs/unity-logs-command.ts';
+import { UnityRunCommand } from '../../command/run/unity-run-command.ts';
 import { NonExistentCommand } from '../../command/null/non-existent-command.ts';
 import type { CommandInterface } from '../../command/command-interface.ts';
 
@@ -36,6 +37,8 @@ export const unityPlugin: GameCIPlugin = {
             return new UnityBuildCommand(command);
           case 'orchestrate':
             return new UnityOrchestrateCommand(command);
+          case 'run':
+            return new UnityRunCommand(command);
           case 'remote':
             switch (subCommands[0]) {
               case 'run':


### PR DESCRIPTION
Experimental, not called from anywhere yet — validates the subprocess-shell-out shape for integrating Unity Technologies' official Unity CLI before committing to it as the mechanism, per game-ci/roadmap#11 workstream 3.

Only implements `installEditor`/`installModules` (documented flag syntax). `build`/`test`/`license` deliberately not stubbed — Unity's own reference doesn't publish full flag sets for those beyond one-line descriptions, needs testing against the real binary.

Ref: game-ci/roadmap#11