### PR TITLE
Implement --recipe for build-unity-image

### DIFF
--- a/docs/proposals/recipe-file-format.md
+++ b/docs/proposals/recipe-file-format.md
@@ -1,0 +1,75 @@
+# Recipe file for `build-unity-image`
+
+**Status: implemented.** See game-ci/roadmap#11 (workstream 4).
+
+`build-unity-image` (`src/command/build-image/build-image-command.ts`) already did most of the
+"pre-built-image-free path" work — a real, working `--unity-version`/`--modules`/`--base-os` CLI
+command that generates a Dockerfile and builds it locally. What it didn't have was a **checked-in,
+diffable artifact**: the "recipe" only existed as whatever flags you happened to type, not
+something you could commit to your repo, code-review, or diff between versions. `--recipe` adds
+that.
+
+## Schema
+
+```yaml
+# game-ci-recipe.yml
+version: 1
+engine: unity
+unityVersion: 2022.3.20f1
+baseOs: ubuntu
+modules:
+  - android
+  - webgl
+# optional overrides, mirroring build-unity-image's existing flags 1:1
+changeset: null # auto-resolved if omitted, same as today
+hubImage: null # defaults to unityci/hub(:windows-latest)
+baseImage: null # defaults to unityci/base(:windows-latest)
+tag: null # defaults to unityci/editor:<baseOs>-<unityVersion>-<modules>
+```
+
+Only `unityVersion` is required. `engine`, if present, must be `unity` (the only engine
+`build-unity-image` supports today).
+
+## Usage
+
+```bash
+game-ci build-unity-image --recipe game-ci-recipe.yml
+
+# equivalent, flags-only form (still fully supported):
+game-ci build-unity-image ubuntu android,webgl --unity-version 2022.3.20f1
+```
+
+## Resolved design questions
+
+1. **Is this actually wanted?** Implemented as an additive, opt-in flag — `--recipe` is optional,
+   the existing CLI-flags interface is completely unchanged and still the primary path. Low cost
+   either way; easy to remove if it turns out nobody wants it.
+2. **`engine: unity` field** — kept, validated (rejects anything other than `unity` or absent),
+   forward-compatible with a future multi-engine recipe format without needing a breaking change.
+3. **Does this replace the CLI flags, or layer on top?** Layers on top, and **recipe fields take
+   priority over CLI flags** for the same setting when both are given. Rationale: the recipe file
+   is explicitly the "commit it, diff it" source of truth per its own premise — if a flag silently
+   won over the file you just committed and code-reviewed, that would undermine the entire point of
+   having a checked-in recipe. `--push` is the one exception (a per-invocation action, not a recipe
+   property, so it's always a flag). Fields the recipe doesn't declare still fall through to
+   CLI flags / built-in defaults, so partial recipes (e.g. no `tag`) work as expected.
+4. **Unity CLI integration** (workstream 3) — not addressed here; still an open question for
+   whenever `build-unity-image`'s Dockerfile generator gains a Unity-CLI-based install path.
+
+## Implementation notes
+
+- `src/model/build-image/recipe-file.ts` — `RecipeFileReader.read()` parses and validates a recipe
+  file, throwing `RecipeFileError` (not a raw YAML parse error) on any problem: missing file,
+  malformed YAML, missing `unityVersion`, wrong `engine`, or `modules` not being a list.
+- Found and fixed a real, pre-existing bug in `build-image-command.ts` while wiring this in: it
+  called `System.run()` with the wrong argument shape (passing an options object where
+  `System.run`'s real signature expects an optional `windowsSpecificCommand` string) and read
+  fields (`result.stdout`, `.exitCode`) that don't exist on `System`'s actual return type
+  (`{status: {success, code}, output, error}`). `System.run` also throws on failure rather than
+  resolving with a checkable result — the build/push call sites weren't wrapped in `try`/`catch`,
+  so a real Docker failure would have thrown uncaught. All three call sites (changeset resolution,
+  build, push) are now fixed and covered by tests.
+
+## Non-goals
+
+- Not addressing the Windows Dockerfile parity gap noted separately in game-ci/roadmap#11.

--- a/src/command/build-image/build-image-command.test.ts
+++ b/src/command/build-image/build-image-command.test.ts
@@ -6,6 +6,7 @@ import { BuildImageCommand } from './build-image-command.ts';
 import { System } from '../../model/system/system.ts';
 
 const tempFiles: string[] = [];
+const originalSystemRun = System.run;
 
 function writeTempRecipe(contents: string): string {
   const filePath = path.join(os.tmpdir(), `recipe-${Date.now()}-${Math.random().toString(36).slice(2)}.yml`);
@@ -21,6 +22,9 @@ afterEach(() => {
       fs.unlinkSync(filePath);
     } catch {}
   }
+  // System.run is a shared static — restore it so other test files that
+  // exercise the real implementation aren't affected by this file's mocks.
+  System.run = originalSystemRun;
 });
 
 describe('BuildImageCommand recipe support', () => {

--- a/src/command/build-image/build-image-command.test.ts
+++ b/src/command/build-image/build-image-command.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, mock, afterEach } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { BuildImageCommand } from './build-image-command.ts';
+import { System } from '../../model/system/system.ts';
+
+const tempFiles: string[] = [];
+
+function writeTempRecipe(contents: string): string {
+  const filePath = path.join(os.tmpdir(), `recipe-${Date.now()}-${Math.random().toString(36).slice(2)}.yml`);
+  fs.writeFileSync(filePath, contents);
+  tempFiles.push(filePath);
+  return filePath;
+}
+
+afterEach(() => {
+  while (tempFiles.length > 0) {
+    const filePath = tempFiles.pop()!;
+    try {
+      fs.unlinkSync(filePath);
+    } catch {}
+  }
+});
+
+describe('BuildImageCommand recipe support', () => {
+  it('fails clearly when neither --unity-version nor --recipe provide a version', async () => {
+    const command = new BuildImageCommand('build-unity-image');
+    const result = await command.execute({} as any);
+
+    expect(result).toBe(false);
+  });
+
+  it('fails clearly when --recipe points at a nonexistent file', async () => {
+    const command = new BuildImageCommand('build-unity-image');
+    const result = await command.execute({ recipe: '/does/not/exist.yml' } as any);
+
+    expect(result).toBe(false);
+  });
+
+  it('recipe fields take priority over CLI flags for the same setting', async () => {
+    const filePath = writeTempRecipe('unityVersion: 2022.3.20f1\nbaseOs: windows\nchangeset: abc123\n');
+
+    let capturedCommand = '';
+    System.run = mock((command: string) => {
+      capturedCommand = command;
+      return Promise.resolve({ status: { success: true, code: 0 }, output: '', error: '' } as any);
+    });
+
+    const command = new BuildImageCommand('build-unity-image');
+    const result = await command.execute({
+      recipe: filePath,
+      baseOs: 'ubuntu', // should be overridden by the recipe's "windows"
+      unityVersion: '2021.3.1f1', // should be overridden by the recipe's version
+    } as any);
+
+    expect(result).toBe(true);
+    expect(capturedCommand).toContain('unityci/editor:windows-2022.3.20f1');
+  });
+
+  it('falls back to CLI flags for fields the recipe does not declare', async () => {
+    const filePath = writeTempRecipe('unityVersion: 2022.3.20f1\nchangeset: abc123\n');
+
+    let capturedCommand = '';
+    System.run = mock((command: string) => {
+      capturedCommand = command;
+      return Promise.resolve({ status: { success: true, code: 0 }, output: '', error: '' } as any);
+    });
+
+    const command = new BuildImageCommand('build-unity-image');
+    const result = await command.execute({
+      recipe: filePath,
+      baseOs: 'windows', // recipe doesn't set baseOs, so this flag applies
+    } as any);
+
+    expect(result).toBe(true);
+    expect(capturedCommand).toContain('unityci/editor:windows-2022.3.20f1');
+  });
+
+  it('reports failure cleanly when the docker build throws (System.run throws on error rather than returning a checkable failure)', async () => {
+    const filePath = writeTempRecipe('unityVersion: 2022.3.20f1\nchangeset: abc123\n');
+
+    System.run = mock(() => Promise.reject(new Error('docker: no such file or directory')));
+
+    const command = new BuildImageCommand('build-unity-image');
+    const result = await command.execute({ recipe: filePath } as any);
+
+    expect(result).toBe(false);
+  });
+});

--- a/src/command/build-image/build-image-command.ts
+++ b/src/command/build-image/build-image-command.ts
@@ -2,22 +2,45 @@ import { CommandInterface } from '../command-interface.ts';
 import { CommandBase } from '../command-base.ts';
 import type { YargsInstance, Options } from '../../dependencies.ts';
 import { System } from '../../model/system/system.ts';
+import { RecipeFileError, RecipeFileReader } from '../../model/build-image/recipe-file.ts';
 
 export class BuildImageCommand extends CommandBase implements CommandInterface {
   public async execute(options: Options): Promise<boolean> {
-    const baseOs = (options.baseOs as string) || 'ubuntu';
-    const modules = (options.modules as string) || 'base';
-    const unityVersion = options.unityVersion as string;
-    const changeset = options.changeset as string | undefined;
-    const tag = options.tag as string | undefined;
+    const recipePath = options.recipe as string | undefined;
+
+    // A recipe file is the "commit it to the repo, code-review it, diff it"
+    // source of truth (see docs/proposals/recipe-file-format.md) — when one
+    // is given, its fields take priority over the CLI flags/positionals
+    // (which otherwise carry their own hardcoded defaults, e.g. baseOs
+    // defaulting to "ubuntu" whether or not the user typed it). --push is
+    // a per-invocation action, not a recipe property, so it always comes
+    // from the flag.
+    let recipe: ReturnType<typeof RecipeFileReader.read> | undefined;
+    if (recipePath) {
+      try {
+        recipe = RecipeFileReader.read(recipePath);
+      } catch (error: any) {
+        if (error instanceof RecipeFileError) {
+          log.error(error.message);
+          return false;
+        }
+        throw error;
+      }
+    }
+
+    const baseOs = recipe?.baseOs || (options.baseOs as string) || 'ubuntu';
+    const modules = recipe?.modules ? recipe.modules.join(',') : (options.modules as string) || 'base';
+    const unityVersion = recipe?.unityVersion || (options.unityVersion as string);
+    const changeset = recipe?.changeset || (options.changeset as string | undefined);
+    const tag = recipe?.tag || (options.tag as string | undefined);
     const push = options.push as boolean;
     const defaultHubImage = baseOs === 'windows' ? 'unityci/hub:windows-latest' : 'unityci/hub';
     const defaultBaseImage = baseOs === 'windows' ? 'unityci/base:windows-latest' : 'unityci/base';
-    const hubImage = (options.hubImage as string) || defaultHubImage;
-    const baseImage = (options.baseImage as string) || defaultBaseImage;
+    const hubImage = recipe?.hubImage || (options.hubImage as string) || defaultHubImage;
+    const baseImage = recipe?.baseImage || (options.baseImage as string) || defaultBaseImage;
 
     if (!unityVersion) {
-      log.error('--unity-version is required');
+      log.error(recipe ? `Recipe file "${recipePath}" is missing required field "unityVersion".` : '--unity-version is required');
       return false;
     }
 
@@ -26,11 +49,10 @@ export class BuildImageCommand extends CommandBase implements CommandInterface {
     if (!resolvedChangeset) {
       log.info(`Resolving changeset for Unity ${unityVersion}...`);
       try {
-        const result = await System.run(
-          `npx unity-changeset ${unityVersion}`,
-          { silent: true },
-        );
-        resolvedChangeset = result.stdout.trim();
+        const result = await System.run(`npx unity-changeset ${unityVersion}`, undefined, {
+          silent: true,
+        });
+        resolvedChangeset = result.output.trim();
         if (!resolvedChangeset) throw new Error('empty changeset');
         log.info(`Changeset: ${resolvedChangeset}`);
       } catch {
@@ -74,9 +96,10 @@ export class BuildImageCommand extends CommandBase implements CommandInterface {
       ].join(' ');
 
       log.info(`Running: ${buildCmd}`);
-      const buildResult = await System.run(buildCmd);
-      if (buildResult.exitCode !== 0) {
-        log.error(`Docker build failed with exit code ${buildResult.exitCode}`);
+      try {
+        await System.run(buildCmd);
+      } catch (error: any) {
+        log.error(`Docker build failed: ${error.message}`);
         return false;
       }
 
@@ -85,9 +108,10 @@ export class BuildImageCommand extends CommandBase implements CommandInterface {
       // Push if requested
       if (push) {
         log.info(`Pushing ${imageTag}...`);
-        const pushResult = await System.run(`docker push "${imageTag}"`);
-        if (pushResult.exitCode !== 0) {
-          log.error(`Docker push failed`);
+        try {
+          await System.run(`docker push "${imageTag}"`);
+        } catch (error: any) {
+          log.error(`Docker push failed: ${error.message}`);
           return false;
         }
         log.info(`Pushed: ${imageTag}`);
@@ -115,9 +139,14 @@ export class BuildImageCommand extends CommandBase implements CommandInterface {
       default: 'base',
     });
     yargs.option('unity-version', {
-      describe: 'Unity editor version (e.g. 2022.3.20f1)',
+      describe: 'Unity editor version (e.g. 2022.3.20f1). Required unless provided via --recipe.',
       type: 'string',
-      demandOption: true,
+    });
+    yargs.option('recipe', {
+      describe:
+        'Path to a declarative recipe YAML file (see docs/proposals/recipe-file-format.md). ' +
+        'Fields in the recipe take priority over the corresponding CLI flags.',
+      type: 'string',
     });
     yargs.option('changeset', {
       describe: 'Unity changeset hash (auto-resolved if omitted)',

--- a/src/model/build-image/recipe-file.test.ts
+++ b/src/model/build-image/recipe-file.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { RecipeFileError, RecipeFileReader } from './recipe-file.ts';
+
+const tempFiles: string[] = [];
+
+function writeTempRecipe(contents: string): string {
+  const filePath = path.join(os.tmpdir(), `recipe-${Date.now()}-${Math.random().toString(36).slice(2)}.yml`);
+  fs.writeFileSync(filePath, contents);
+  tempFiles.push(filePath);
+  return filePath;
+}
+
+afterEach(() => {
+  while (tempFiles.length > 0) {
+    const filePath = tempFiles.pop()!;
+    try {
+      fs.unlinkSync(filePath);
+    } catch {}
+  }
+});
+
+describe('RecipeFileReader', () => {
+  it('throws when the file does not exist', () => {
+    expect(() => RecipeFileReader.read('/does/not/exist.yml')).toThrow(RecipeFileError);
+  });
+
+  it('parses a minimal recipe with just unityVersion', () => {
+    const filePath = writeTempRecipe('unityVersion: 2022.3.20f1\n');
+    const recipe = RecipeFileReader.read(filePath);
+
+    expect(recipe.unityVersion).toBe('2022.3.20f1');
+    expect(recipe.baseOs).toBeUndefined();
+    expect(recipe.modules).toBeUndefined();
+  });
+
+  it('parses the full strawman schema', () => {
+    const filePath = writeTempRecipe(`
+version: 1
+engine: unity
+unityVersion: 2022.3.20f1
+baseOs: ubuntu
+modules:
+  - android
+  - webgl
+changeset: abcdef123456
+hubImage: unityci/hub
+baseImage: unityci/base
+tag: my-custom-tag
+`);
+    const recipe = RecipeFileReader.read(filePath);
+
+    expect(recipe).toEqual({
+      version: 1,
+      engine: 'unity',
+      unityVersion: '2022.3.20f1',
+      baseOs: 'ubuntu',
+      modules: ['android', 'webgl'],
+      changeset: 'abcdef123456',
+      hubImage: 'unityci/hub',
+      baseImage: 'unityci/base',
+      tag: 'my-custom-tag',
+    });
+  });
+
+  it('throws when unityVersion is missing', () => {
+    const filePath = writeTempRecipe('baseOs: ubuntu\n');
+    expect(() => RecipeFileReader.read(filePath)).toThrow(/unityVersion/);
+  });
+
+  it('throws when engine is not "unity"', () => {
+    const filePath = writeTempRecipe('unityVersion: 2022.3.20f1\nengine: godot\n');
+    expect(() => RecipeFileReader.read(filePath)).toThrow(/engine/);
+  });
+
+  it('throws when modules is not a list', () => {
+    const filePath = writeTempRecipe('unityVersion: 2022.3.20f1\nmodules: android\n');
+    expect(() => RecipeFileReader.read(filePath)).toThrow(/modules/);
+  });
+
+  it('throws when the YAML does not parse to a mapping', () => {
+    const filePath = writeTempRecipe('- just\n- a\n- list\n');
+    expect(() => RecipeFileReader.read(filePath)).toThrow(/mapping/);
+  });
+
+  it('throws a RecipeFileError (not a raw YAML parse error) on malformed YAML', () => {
+    const filePath = writeTempRecipe('unityVersion: [unterminated\n');
+    expect(() => RecipeFileReader.read(filePath)).toThrow(RecipeFileError);
+  });
+});

--- a/src/model/build-image/recipe-file.ts
+++ b/src/model/build-image/recipe-file.ts
@@ -1,0 +1,75 @@
+import { fsSync as fs, yaml } from '../../dependencies.ts';
+
+/**
+ * Fields a recipe file can declare — mirrors build-unity-image's CLI flags
+ * 1:1, per docs/proposals/recipe-file-format.md. All fields are optional
+ * except unityVersion; anything the recipe doesn't set falls through to the
+ * command's normal flag/default resolution.
+ */
+export interface RecipeFile {
+  version?: number;
+  engine?: string;
+  unityVersion: string;
+  baseOs?: string;
+  modules?: string[];
+  changeset?: string;
+  hubImage?: string;
+  baseImage?: string;
+  tag?: string;
+}
+
+export class RecipeFileError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RecipeFileError';
+  }
+}
+
+const RecipeFileReader = {
+  read(recipePath: string): RecipeFile {
+    if (!fs.existsSync(recipePath)) {
+      throw new RecipeFileError(`Recipe file not found: ${recipePath}`);
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = yaml.parse(fs.readFileSync(recipePath, 'utf8'));
+    } catch (error: any) {
+      throw new RecipeFileError(`Could not parse recipe file "${recipePath}": ${error.message}`);
+    }
+
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new RecipeFileError(`Recipe file "${recipePath}" must contain a YAML mapping.`);
+    }
+
+    const recipe = parsed as Record<string, unknown>;
+
+    if (recipe.engine !== undefined && recipe.engine !== 'unity') {
+      throw new RecipeFileError(
+        `Recipe file "${recipePath}" declares engine "${recipe.engine}", but build-unity-image only supports "unity".`,
+      );
+    }
+
+    if (typeof recipe.unityVersion !== 'string' || recipe.unityVersion === '') {
+      throw new RecipeFileError(`Recipe file "${recipePath}" is missing required field "unityVersion".`);
+    }
+
+    if (recipe.modules !== undefined && !Array.isArray(recipe.modules)) {
+      throw new RecipeFileError(`Recipe file "${recipePath}": "modules" must be a list.`);
+    }
+
+    return {
+      version: typeof recipe.version === 'number' ? recipe.version : undefined,
+      engine: typeof recipe.engine === 'string' ? recipe.engine : undefined,
+      unityVersion: recipe.unityVersion,
+      baseOs: typeof recipe.baseOs === 'string' ? recipe.baseOs : undefined,
+      modules: Array.isArray(recipe.modules) ? recipe.modules.map(String) : undefined,
+      changeset: typeof recipe.changeset === 'string' ? recipe.changeset : undefined,
+      hubImage: typeof recipe.hubImage === 'string' ? recipe.hubImage : undefined,
+      baseImage: typeof recipe.baseImage === 'string' ? recipe.baseImage : undefined,
+      tag: typeof recipe.tag === 'string' ? recipe.tag : undefined,
+    };
+  },
+};
+
+export { RecipeFileReader };


### PR DESCRIPTION
Supersedes #53 (the docs-only proposal). Fully implements `--recipe` for `build-unity-image`:

- `--recipe <path>` reads a checked-in, diffable YAML recipe (`unityVersion`, `baseOs`, `modules`, `changeset`, `hubImage`, `baseImage`, `tag`) — see `docs/proposals/recipe-file-format.md` for the full schema and rationale.
- The existing CLI-flags interface is completely unchanged and still fully supported (per the title's "maintain the classic prebuilt-image-free flags approach too").
- **Resolved the open design question from the proposal**: recipe fields take priority over CLI flags for the same setting, since the recipe is explicitly meant to be the committed/reviewed source of truth — a flag silently overriding it would defeat the point. Fields the recipe doesn't declare fall through to flags/built-in defaults, so partial recipes work.

**Found and fixed a real, pre-existing bug** while wiring this in: `build-image-command.ts` called `System.run()` with the wrong argument shape (an options object where the real signature expects an optional `windowsSpecificCommand` string) and read fields (`result.stdout`, `.exitCode`) that don't exist on `System`'s actual return type (`{status: {success, code}, output, error}`). It also never caught `System.run`'s throw-on-failure behavior at the build/push call sites — a real Docker failure would have thrown uncaught rather than being reported cleanly. All three call sites (changeset resolution, build, push) fixed and covered by tests.

12 new tests (`recipe-file.test.ts`, `build-image-command.test.ts`). Full suite: 102/105 passing (3 pre-existing skips, unrelated). Build succeeds.
