### PR TITLE
Fix mock leak in unity-run-command tests

### DIFF
--- a/src/command/run/unity-run-command.test.ts
+++ b/src/command/run/unity-run-command.test.ts
@@ -1,6 +1,16 @@
-import { describe, it, expect, mock } from 'bun:test';
+import { describe, it, expect, mock, afterEach } from 'bun:test';
 import { UnityRunCommand } from './unity-run-command.ts';
 import { UnityCliAdapter } from '../../model/unity-cli-adapter.ts';
+
+const originalIsAvailable = UnityCliAdapter.isAvailable;
+const originalRunCommand = UnityCliAdapter.runCommand;
+
+afterEach(() => {
+  // Both are shared statics — restore them so other test files that exercise
+  // the real UnityCliAdapter aren't affected by this file's mocks.
+  UnityCliAdapter.isAvailable = originalIsAvailable;
+  UnityCliAdapter.runCommand = originalRunCommand;
+});
 
 describe('UnityRunCommand', () => {
   it('throws a clear error when the unity CLI binary is unavailable', async () => {


### PR DESCRIPTION
Same class of bug found while implementing #56: `UnityCliAdapter.isAvailable`/`.runCommand` are shared statics, mocked in this test file without being restored afterward — leaks into any other test file that runs after it and expects the real implementation. Not currently observed failing (no other test exercises `UnityCliAdapter` directly yet), but it's the same latent issue. Fixed with an `afterEach` restore, same pattern as the fix in #56.