### PR TITLE
Add log line grouping, closing #12

### DIFF
--- a/src/command/build-image/build-image-command.ts
+++ b/src/command/build-image/build-image-command.ts
@@ -96,24 +96,32 @@ export class BuildImageCommand extends CommandBase implements CommandInterface {
       ].join(' ');
 
       log.info(`Running: ${buildCmd}`);
-      try {
-        await System.run(buildCmd);
-      } catch (error: any) {
-        log.error(`Docker build failed: ${error.message}`);
-        return false;
-      }
+      let buildFailed = false;
+      await log.group(`docker build (${imageTag})`, async () => {
+        try {
+          await System.run(buildCmd);
+        } catch (error: any) {
+          log.error(`Docker build failed: ${error.message}`);
+          buildFailed = true;
+        }
+      });
+      if (buildFailed) return false;
 
       log.info(`Successfully built: ${imageTag}`);
 
       // Push if requested
       if (push) {
         log.info(`Pushing ${imageTag}...`);
-        try {
-          await System.run(`docker push "${imageTag}"`);
-        } catch (error: any) {
-          log.error(`Docker push failed: ${error.message}`);
-          return false;
-        }
+        let pushFailed = false;
+        await log.group(`docker push (${imageTag})`, async () => {
+          try {
+            await System.run(`docker push "${imageTag}"`);
+          } catch (error: any) {
+            log.error(`Docker push failed: ${error.message}`);
+            pushFailed = true;
+          }
+        });
+        if (pushFailed) return false;
         log.info(`Pushed: ${imageTag}`);
       }
     } finally {

--- a/src/command/build/godot-build-command.ts
+++ b/src/command/build/godot-build-command.ts
@@ -15,9 +15,11 @@ export class GodotBuildCommand extends CommandBase implements CommandInterface {
     log.info(`Export preset: ${exportPreset}`);
 
     const { Docker } = await import('../../model/index.ts');
-    await Docker.run(godotImage, {
-      ...options,
-      commands: `godot --headless --verbose --export-release "${exportPreset}" ${outputPath}`,
+    await log.group('Godot export', async () => {
+      await Docker.run(godotImage, {
+        ...options,
+        commands: `godot --headless --verbose --export-release "${exportPreset}" ${outputPath}`,
+      });
     });
 
     return true;

--- a/src/command/build/unity-build-command.ts
+++ b/src/command/build/unity-build-command.ts
@@ -42,11 +42,13 @@ export class UnityBuildCommand extends CommandBase implements CommandInterface {
     let buildError: unknown;
     let buildSucceeded = true;
     try {
-      if (hostPlatform === 'darwin') {
-        await MacBuilder.run(options);
-      } else {
-        await Docker.run(image.toString(), options);
-      }
+      await log.group('Unity build', async () => {
+        if (hostPlatform === 'darwin') {
+          await MacBuilder.run(options);
+        } else {
+          await Docker.run(image.toString(), options);
+        }
+      });
     } catch (error) {
       buildError = error;
       buildSucceeded = false;

--- a/src/command/build/unreal-build-command.ts
+++ b/src/command/build/unreal-build-command.ts
@@ -22,7 +22,7 @@ export class UnrealBuildCommand extends CommandBase implements CommandInterface 
     log.info(`Target platform: ${targetPlatform}, Config: ${buildConfig}`);
 
     const { Docker } = await import('../../model/index.ts');
-    await Docker.run(customImage, {
+    await log.group('Unreal build', () => Docker.run(customImage, {
       ...options,
       commands: [
         // RunUAT.sh is the standard Unreal Automation Tool entry point
@@ -40,7 +40,7 @@ export class UnrealBuildCommand extends CommandBase implements CommandInterface 
         '-noP4',
         '-unattended',
       ].join(' '),
-    });
+    }));
 
     return true;
   }

--- a/src/core/logger/index.test.ts
+++ b/src/core/logger/index.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { configureLogger, Verbosity } from './index.ts';
+
+describe('logger groups', () => {
+  const originalGithubActions = process.env.GITHUB_ACTIONS;
+  const originalConsoleLog = console.log;
+  let logLines: string[] = [];
+
+  beforeEach(async () => {
+    logLines = [];
+    console.log = mock((...args: any[]) => {
+      logLines.push(args.join(' '));
+    });
+    await configureLogger(Verbosity.normal);
+  });
+
+  afterEach(() => {
+    // console.log is a shared global — restore it so other test files that
+    // exercise real console output aren't affected by this file's mock.
+    console.log = originalConsoleLog;
+    if (originalGithubActions === undefined) {
+      delete process.env.GITHUB_ACTIONS;
+    } else {
+      process.env.GITHUB_ACTIONS = originalGithubActions;
+    }
+  });
+
+  it('emits ::group::/::endgroup:: markers when running in GitHub Actions', () => {
+    process.env.GITHUB_ACTIONS = 'true';
+
+    (globalThis as any).log.startGroup('My Group');
+    (globalThis as any).log.endGroup();
+
+    expect(logLines).toContain('::group::My Group');
+    expect(logLines).toContain('::endgroup::');
+  });
+
+  it('falls back to a plain separator outside GitHub Actions', () => {
+    delete process.env.GITHUB_ACTIONS;
+
+    (globalThis as any).log.startGroup('My Group');
+
+    expect(logLines.some((line) => line.includes('My Group'))).toBe(true);
+    expect(logLines.some((line) => line.includes('::group::'))).toBe(false);
+  });
+
+  it('group() closes the group even when the callback throws', async () => {
+    process.env.GITHUB_ACTIONS = 'true';
+
+    await expect(
+      (globalThis as any).log.group('Failing group', () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(logLines).toContain('::endgroup::');
+  });
+
+  it('group() returns the callback result', async () => {
+    const result = await (globalThis as any).log.group('Group', () => 42);
+    expect(result).toBe(42);
+  });
+});

--- a/src/core/logger/index.ts
+++ b/src/core/logger/index.ts
@@ -92,6 +92,37 @@ export const configureLogger = async (verbosity: Verbosity) => {
       writeToFile('ERROR', formatted);
       console.error(`[ERROR] ${formatted}`);
     },
+
+    // GitHub Actions log line grouping (::group::/::endgroup::) — collapses
+    // a section of output into a foldable block in the Actions UI instead of
+    // one long unbroken stream. No-op outside GitHub Actions (GITHUB_ACTIONS
+    // unset), since ::group:: markers would just show up as literal text in
+    // a plain terminal or local log file.
+    startGroup: (name: string) => {
+      writeToFile('GROUP', name);
+      if (process.env.GITHUB_ACTIONS === 'true' && !isQuiet) {
+        console.log(`::group::${name}`);
+      } else if (!isQuiet) {
+        console.log(`--- ${name} ---`);
+      }
+    },
+
+    endGroup: () => {
+      if (process.env.GITHUB_ACTIONS === 'true' && !isQuiet) {
+        console.log('::endgroup::');
+      }
+    },
+
+    // Convenience wrapper: runs fn() inside a named group, closing the group
+    // even if fn() throws.
+    group: async <T>(name: string, fn: () => Promise<T> | T): Promise<T> => {
+      logger.startGroup(name);
+      try {
+        return await fn();
+      } finally {
+        logger.endGroup();
+      }
+    },
   };
 
   (globalThis as any).log = logger;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -19,6 +19,9 @@ declare global {
     info: (msg: any, ...args: any[]) => void;
     warning: (msg: any, ...args: any[]) => void;
     error: (msg: any, ...args: any[]) => void;
+    startGroup: (name: string) => void;
+    endGroup: () => void;
+    group: <T>(name: string, fn: () => Promise<T> | T) => Promise<T>;
   };
 
   var process: typeof import('node:process');

--- a/src/test-preload.ts
+++ b/src/test-preload.ts
@@ -16,4 +16,7 @@ const noop = () => {};
   info: noop,
   warning: noop,
   error: noop,
+  startGroup: noop,
+  endGroup: noop,
+  group: async (_name: string, fn: () => any) => fn(),
 };


### PR DESCRIPTION
Closes #12.

Adds \`log.startGroup()\`/\`endGroup()\`/\`group()\` — emits GitHub Actions' \`::group::\`/\`::endgroup::\` markers (falls back to a plain \`--- name ---\` separator outside GitHub Actions, detected via \`GITHUB_ACTIONS\`) so build output collapses into a foldable section instead of one long unbroken stream.

Wired into all three engines' build commands (Unity, Godot, Unreal) and \`build-unity-image\`'s docker build/push steps — exactly the "7000 unseparated lines" case #12 described.

4 new tests for the logger. Full suite: 106/109 passing (3 pre-existing skips), build succeeds.
