### PR TITLE
feat: add --manualExit flag to skip -quit for builds

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14420,9 +14420,9 @@ var init_cache_validation = __esm(() => {
 
 // src/model/image-environment-factory.ts
 class ImageEnvironmentFactory {
-  static getEnvVarString(options) {
+  static getEnvVarString(options, extraVariables = []) {
     const { hostOS } = options;
-    const environmentVariables = ImageEnvironmentFactory.getEnvironmentVariables(options);
+    const environmentVariables = ImageEnvironmentFactory.getEnvironmentVariables(options, extraVariables);
     const lineContinuation = hostOS === "windows" ? "`" : "\\";
     const lines = [];
     for (const p of environmentVariables) {
@@ -14444,16 +14444,9 @@ class ImageEnvironmentFactory {
     return lines.join(` ${lineContinuation}
 `);
   }
-  static getEnvironmentVariables(options) {
+  static getEnvironmentVariables(options, extraVariables = []) {
     const environmentVariables = [
-      { name: "UNITY_LICENSE", value: options.unityLicense },
-      { name: "UNITY_LICENSE_FILE", value: options.unityLicenseFile },
-      { name: "UNITY_EMAIL", value: options.unityEmail },
-      { name: "UNITY_PASSWORD", value: options.unityPassword },
-      { name: "UNITY_SERIAL", value: options.unitySerial },
-      { name: "UNITY_LICENSING_SERVER", value: options.unityLicensingServer },
-      { name: "UNITY_VERSION", value: options.engineVersion },
-      { name: "USYM_UPLOAD_AUTH_TOKEN", value: options.uploadAuthToken },
+      ...extraVariables,
       { name: "PROJECT_PATH", value: options.projectPath },
       { name: "BUILD_TARGET", value: options.targetPlatform },
       { name: "BUILD_NAME", value: options.buildName },
@@ -14461,17 +14454,6 @@ class ImageEnvironmentFactory {
       { name: "BUILD_FILE", value: options.buildFile },
       { name: "BUILD_METHOD", value: options.buildMethod },
       { name: "VERSION", value: options.buildVersion },
-      { name: "ANDROID_VERSION_CODE", value: options.androidVersionCode },
-      { name: "ANDROID_KEYSTORE_NAME", value: options.androidKeystoreName },
-      { name: "ANDROID_KEYSTORE_BASE64", value: options.androidKeystoreBase64 },
-      { name: "ANDROID_KEYSTORE_PASS", value: options.androidKeystorePass },
-      { name: "ANDROID_KEYALIAS_NAME", value: options.androidKeyaliasName },
-      { name: "ANDROID_KEYALIAS_PASS", value: options.androidKeyaliasPass },
-      { name: "ANDROID_TARGET_SDK_VERSION", value: options.androidTargetSdkVersion },
-      { name: "ANDROID_SDK_MANAGER_PARAMETERS", value: options.androidSdkManagerParameters },
-      { name: "ANDROID_EXPORT_TYPE", value: options.androidExportType },
-      { name: "ANDROID_SYMBOL_TYPE", value: options.androidSymbolType },
-      { name: "MANUAL_EXIT", value: options.manualExit ? "true" : "" },
       { name: "CUSTOM_PARAMETERS", value: options.customParameters },
       { name: "CHOWN_FILES_TO", value: options.chownFilesTo },
       { name: "GITHUB_REF", value: process.env.GITHUB_REF },
@@ -14513,7 +14495,41 @@ class UnityBuildValidation {
 }
 var init_unity_build_validation = () => {};
 
+// src/logic/unity/environment.ts
+var UnityEnvironment;
+var init_environment = __esm(() => {
+  UnityEnvironment = {
+    getVariables(options) {
+      return [
+        { name: "UNITY_LICENSE", value: options.unityLicense },
+        { name: "UNITY_LICENSE_FILE", value: options.unityLicenseFile },
+        { name: "UNITY_EMAIL", value: options.unityEmail },
+        { name: "UNITY_PASSWORD", value: options.unityPassword },
+        { name: "UNITY_SERIAL", value: options.unitySerial },
+        { name: "UNITY_LICENSING_SERVER", value: options.unityLicensingServer },
+        { name: "UNITY_VERSION", value: options.engineVersion },
+        { name: "USYM_UPLOAD_AUTH_TOKEN", value: options.uploadAuthToken },
+        { name: "ANDROID_VERSION_CODE", value: options.androidVersionCode },
+        { name: "ANDROID_KEYSTORE_NAME", value: options.androidKeystoreName },
+        { name: "ANDROID_KEYSTORE_BASE64", value: options.androidKeystoreBase64 },
+        { name: "ANDROID_KEYSTORE_PASS", value: options.androidKeystorePass },
+        { name: "ANDROID_KEYALIAS_NAME", value: options.androidKeyaliasName },
+        { name: "ANDROID_KEYALIAS_PASS", value: options.androidKeyaliasPass },
+        { name: "ANDROID_TARGET_SDK_VERSION", value: options.androidTargetSdkVersion },
+        { name: "ANDROID_SDK_MANAGER_PARAMETERS", value: options.androidSdkManagerParameters },
+        { name: "ANDROID_EXPORT_TYPE", value: options.androidExportType },
+        { name: "ANDROID_SYMBOL_TYPE", value: options.androidSymbolType },
+        { name: "MANUAL_EXIT", value: options.manualExit ? "true" : "" }
+      ];
+    }
+  };
+});
+
 // src/model/docker.ts
+function engineEnvVars(options) {
+  return options.engine === "unity" ? UnityEnvironment.getVariables(options) : [];
+}
+
 class Docker {
   static async run(image, options) {
     const { hostPlatform, hostOS, engine } = options;
@@ -14558,58 +14574,62 @@ class Docker {
     }
   }
   static getLinuxCommand(image, options) {
-    const { currentWorkDir, homeDir, cliDistPath, runnerTempPath, sshAgent, gitPrivateToken, dockerWorkspacePath } = options;
+    const { currentWorkDir, homeDir, cliDistPath, runnerTempPath, sshAgent, gitPrivateToken, dockerWorkspacePath, commands, engine } = options;
     const home = homeDir;
-    const envVarString = ImageEnvironmentFactory.getEnvVarString(options).replace(/ \\\n/g, " ");
+    const envVarString = ImageEnvironmentFactory.getEnvVarString(options, engineEnvVars(options)).replace(/ \\\n/g, " ");
+    const isUnityDefaultFlow = !commands || engine === "unity";
     return [
       "docker run",
       "--rm",
       `--workdir ${dockerWorkspacePath}`,
       envVarString,
-      "--env UNITY_SERIAL",
+      isUnityDefaultFlow ? "--env UNITY_SERIAL" : "",
       `--env GITHUB_WORKSPACE=${dockerWorkspacePath}`,
       gitPrivateToken ? `--env GIT_PRIVATE_TOKEN="${gitPrivateToken}"` : "",
       sshAgent ? "--env SSH_AUTH_SOCK=/ssh-agent" : "",
       `--volume "${home}":"/root:z"`,
       `--volume "${currentWorkDir}":"${dockerWorkspacePath}:z"`,
-      `--volume "${cliDistPath}/default-build-script:/UnityBuilderAction:z"`,
-      `--volume "${cliDistPath}/platforms/ubuntu/steps:/steps:z"`,
-      `--volume "${cliDistPath}/platforms/ubuntu/entrypoint.sh:/entrypoint.sh:z"`,
-      `--volume "${cliDistPath}/unity-config:/usr/share/unity3d/config:z"`,
+      isUnityDefaultFlow ? `--volume "${cliDistPath}/default-build-script:/UnityBuilderAction:z"` : "",
+      isUnityDefaultFlow ? `--volume "${cliDistPath}/platforms/ubuntu/steps:/steps:z"` : "",
+      isUnityDefaultFlow ? `--volume "${cliDistPath}/platforms/ubuntu/entrypoint.sh:/entrypoint.sh:z"` : "",
+      isUnityDefaultFlow ? `--volume "${cliDistPath}/unity-config:/usr/share/unity3d/config:z"` : "",
       sshAgent ? `--volume ${sshAgent}:/ssh-agent` : "",
       sshAgent ? "--volume /home/runner/.ssh/known_hosts:/root/.ssh/known_hosts:ro" : "",
       image,
-      "/bin/bash /entrypoint.sh"
+      isUnityDefaultFlow ? "/bin/bash /entrypoint.sh" : commands
     ].filter(Boolean).join(" ");
   }
   static getWindowsCommand(image, options) {
-    const { currentWorkDir, homeDir, cliDistPath, unitySerial, gitPrivateToken, cliStoragePath, dockerWorkspacePath } = options;
-    return String.dedent`
-      docker run \`
-        --rm \`
-        --workdir="c:${dockerWorkspacePath}" \`
-        ${ImageEnvironmentFactory.getEnvVarString(options)} \`
-        --env UNITY_SERIAL="${unitySerial}" \`
-        --env GITHUB_WORKSPACE=c:${dockerWorkspacePath} \`
-        --env GIT_PRIVATE_TOKEN="${gitPrivateToken}" \`
-        --volume="${currentWorkDir}":"c:${dockerWorkspacePath}" \`
-        --volume="${cliStoragePath}/registry-keys":"c:/registry-keys" \`
-        --volume="C:/Program Files (x86)/Microsoft Visual Studio":"C:/Program Files (x86)/Microsoft Visual Studio" \`
-        --volume="C:/Program Files (x86)/Windows Kits":"C:/Program Files (x86)/Windows Kits" \`
-        --volume="C:/ProgramData/Microsoft/VisualStudio":"C:/ProgramData/Microsoft/VisualStudio" \`
-        --volume="${cliDistPath}/default-build-script":"c:/UnityBuilderAction" \`
-        --volume="${cliDistPath}/platforms/windows":"c:/steps" \`
-        --volume="${cliDistPath}/BlankProject":"c:/BlankProject" \`
-        --volume="${cliDistPath}/unity-config":"c:/ProgramData/Unity/config" \`
-        ${image} \`
-        powershell c:/steps/entrypoint.ps1
-    `;
+    const { currentWorkDir, homeDir, cliDistPath, unitySerial, gitPrivateToken, cliStoragePath, dockerWorkspacePath, commands, engine } = options;
+    const isUnityDefaultFlow = !commands || engine === "unity";
+    return [
+      "docker run `",
+      "  --rm `",
+      `  --workdir="c:${dockerWorkspacePath}" \``,
+      `  ${ImageEnvironmentFactory.getEnvVarString(options, engineEnvVars(options))} \``,
+      isUnityDefaultFlow ? `  --env UNITY_SERIAL="${unitySerial}" \`` : "",
+      `  --env GITHUB_WORKSPACE=c:${dockerWorkspacePath} \``,
+      `  --env GIT_PRIVATE_TOKEN="${gitPrivateToken}" \``,
+      `  --volume="${currentWorkDir}":"c:${dockerWorkspacePath}" \``,
+      isUnityDefaultFlow ? `  --volume="${cliStoragePath}/registry-keys":"c:/registry-keys" \`` : "",
+      isUnityDefaultFlow ? '  --volume="C:/Program Files (x86)/Microsoft Visual Studio":"C:/Program Files (x86)/Microsoft Visual Studio" `' : "",
+      isUnityDefaultFlow ? '  --volume="C:/Program Files (x86)/Windows Kits":"C:/Program Files (x86)/Windows Kits" `' : "",
+      isUnityDefaultFlow ? '  --volume="C:/ProgramData/Microsoft/VisualStudio":"C:/ProgramData/Microsoft/VisualStudio" `' : "",
+      isUnityDefaultFlow ? `  --volume="${cliDistPath}/default-build-script":"c:/UnityBuilderAction" \`` : "",
+      isUnityDefaultFlow ? `  --volume="${cliDistPath}/platforms/windows":"c:/steps" \`` : "",
+      isUnityDefaultFlow ? `  --volume="${cliDistPath}/BlankProject":"c:/BlankProject" \`` : "",
+      isUnityDefaultFlow ? `  --volume="${cliDistPath}/unity-config":"c:/ProgramData/Unity/config" \`` : "",
+      `  ${image} \``,
+      isUnityDefaultFlow ? "  powershell c:/steps/entrypoint.ps1" : `  ${commands}`
+    ].filter(Boolean).join(`
+`);
   }
 }
 var init_docker = __esm(() => {
   init_image_environment_factory();
   init_system();
   init_unity_build_validation();
+  init_environment();
 });
 
 // src/model/unity/target-platform/unity-target-platform.ts
@@ -15126,6 +15146,27 @@ var configureLogger = async (verbosity) => {
       const formatted = formatArgs(msg, args);
       writeToFile("ERROR", formatted);
       console.error(`[ERROR] ${formatted}`);
+    },
+    startGroup: (name) => {
+      writeToFile("GROUP", name);
+      if (process.env.GITHUB_ACTIONS === "true" && !isQuiet) {
+        console.log(`::group::${name}`);
+      } else if (!isQuiet) {
+        console.log(`--- ${name} ---`);
+      }
+    },
+    endGroup: () => {
+      if (process.env.GITHUB_ACTIONS === "true" && !isQuiet) {
+        console.log("::endgroup::");
+      }
+    },
+    group: async (name, fn) => {
+      logger.startGroup(name);
+      try {
+        return await fn();
+      } finally {
+        logger.endGroup();
+      }
     }
   };
   globalThis.log = logger;
@@ -15323,21 +15364,31 @@ class BuildImageCommand extends CommandBase {
         "."
       ].join(" ");
       log.info(`Running: ${buildCmd}`);
-      try {
-        await System.run(buildCmd);
-      } catch (error) {
-        log.error(`Docker build failed: ${error.message}`);
+      let buildFailed = false;
+      await log.group(`docker build (${imageTag})`, async () => {
+        try {
+          await System.run(buildCmd);
+        } catch (error) {
+          log.error(`Docker build failed: ${error.message}`);
+          buildFailed = true;
+        }
+      });
+      if (buildFailed)
         return false;
-      }
       log.info(`Successfully built: ${imageTag}`);
       if (push) {
         log.info(`Pushing ${imageTag}...`);
-        try {
-          await System.run(`docker push "${imageTag}"`);
-        } catch (error) {
-          log.error(`Docker push failed: ${error.message}`);
+        let pushFailed = false;
+        await log.group(`docker push (${imageTag})`, async () => {
+          try {
+            await System.run(`docker push "${imageTag}"`);
+          } catch (error) {
+            log.error(`Docker push failed: ${error.message}`);
+            pushFailed = true;
+          }
+        });
+        if (pushFailed)
           return false;
-        }
         log.info(`Pushed: ${imageTag}`);
       }
     } finally {
@@ -17445,11 +17496,13 @@ class UnityBuildCommand extends CommandBase {
     let buildError;
     let buildSucceeded = true;
     try {
-      if (hostPlatform === "darwin") {
-        await MacBuilder.run(options);
-      } else {
-        await Docker.run(image.toString(), options);
-      }
+      await log.group("Unity build", async () => {
+        if (hostPlatform === "darwin") {
+          await MacBuilder.run(options);
+        } else {
+          await Docker.run(image.toString(), options);
+        }
+      });
     } catch (error) {
       buildError = error;
       buildSucceeded = false;
@@ -17775,9 +17828,11 @@ class GodotBuildCommand extends CommandBase {
     log.info(`Using image: ${godotImage}`);
     log.info(`Export preset: ${exportPreset}`);
     const { Docker: Docker2 } = await Promise.resolve().then(() => (init_model(), exports_model));
-    await Docker2.run(godotImage, {
-      ...options,
-      commands: `godot --headless --verbose --export-release "${exportPreset}" ${outputPath}`
+    await log.group("Godot export", async () => {
+      await Docker2.run(godotImage, {
+        ...options,
+        commands: `godot --headless --verbose --export-release "${exportPreset}" ${outputPath}`
+      });
     });
     return true;
   }
@@ -17880,7 +17935,7 @@ class UnrealBuildCommand extends CommandBase {
     log.info(`Using image: ${customImage}`);
     log.info(`Target platform: ${targetPlatform}, Config: ${buildConfig}`);
     const { Docker: Docker2 } = await Promise.resolve().then(() => (init_model(), exports_model));
-    await Docker2.run(customImage, {
+    await log.group("Unreal build", () => Docker2.run(customImage, {
       ...options,
       commands: [
         "/home/ue4/UnrealEngine/Engine/Build/BatchFiles/RunUAT.sh",
@@ -17897,7 +17952,7 @@ class UnrealBuildCommand extends CommandBase {
         "-noP4",
         "-unattended"
       ].join(" ")
-    });
+    }));
     return true;
   }
   async configureOptions(yargs) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -14420,9 +14420,9 @@ var init_cache_validation = __esm(() => {
 
 // src/model/image-environment-factory.ts
 class ImageEnvironmentFactory {
-  static getEnvVarString(options, extraVariables = []) {
+  static getEnvVarString(options) {
     const { hostOS } = options;
-    const environmentVariables = ImageEnvironmentFactory.getEnvironmentVariables(options, extraVariables);
+    const environmentVariables = ImageEnvironmentFactory.getEnvironmentVariables(options);
     const lineContinuation = hostOS === "windows" ? "`" : "\\";
     const lines = [];
     for (const p of environmentVariables) {
@@ -14444,9 +14444,16 @@ class ImageEnvironmentFactory {
     return lines.join(` ${lineContinuation}
 `);
   }
-  static getEnvironmentVariables(options, extraVariables = []) {
+  static getEnvironmentVariables(options) {
     const environmentVariables = [
-      ...extraVariables,
+      { name: "UNITY_LICENSE", value: options.unityLicense },
+      { name: "UNITY_LICENSE_FILE", value: options.unityLicenseFile },
+      { name: "UNITY_EMAIL", value: options.unityEmail },
+      { name: "UNITY_PASSWORD", value: options.unityPassword },
+      { name: "UNITY_SERIAL", value: options.unitySerial },
+      { name: "UNITY_LICENSING_SERVER", value: options.unityLicensingServer },
+      { name: "UNITY_VERSION", value: options.engineVersion },
+      { name: "USYM_UPLOAD_AUTH_TOKEN", value: options.uploadAuthToken },
       { name: "PROJECT_PATH", value: options.projectPath },
       { name: "BUILD_TARGET", value: options.targetPlatform },
       { name: "BUILD_NAME", value: options.buildName },
@@ -14454,6 +14461,17 @@ class ImageEnvironmentFactory {
       { name: "BUILD_FILE", value: options.buildFile },
       { name: "BUILD_METHOD", value: options.buildMethod },
       { name: "VERSION", value: options.buildVersion },
+      { name: "ANDROID_VERSION_CODE", value: options.androidVersionCode },
+      { name: "ANDROID_KEYSTORE_NAME", value: options.androidKeystoreName },
+      { name: "ANDROID_KEYSTORE_BASE64", value: options.androidKeystoreBase64 },
+      { name: "ANDROID_KEYSTORE_PASS", value: options.androidKeystorePass },
+      { name: "ANDROID_KEYALIAS_NAME", value: options.androidKeyaliasName },
+      { name: "ANDROID_KEYALIAS_PASS", value: options.androidKeyaliasPass },
+      { name: "ANDROID_TARGET_SDK_VERSION", value: options.androidTargetSdkVersion },
+      { name: "ANDROID_SDK_MANAGER_PARAMETERS", value: options.androidSdkManagerParameters },
+      { name: "ANDROID_EXPORT_TYPE", value: options.androidExportType },
+      { name: "ANDROID_SYMBOL_TYPE", value: options.androidSymbolType },
+      { name: "MANUAL_EXIT", value: options.manualExit ? "true" : "" },
       { name: "CUSTOM_PARAMETERS", value: options.customParameters },
       { name: "CHOWN_FILES_TO", value: options.chownFilesTo },
       { name: "GITHUB_REF", value: process.env.GITHUB_REF },
@@ -14495,40 +14513,7 @@ class UnityBuildValidation {
 }
 var init_unity_build_validation = () => {};
 
-// src/logic/unity/environment.ts
-var UnityEnvironment;
-var init_environment = __esm(() => {
-  UnityEnvironment = {
-    getVariables(options) {
-      return [
-        { name: "UNITY_LICENSE", value: options.unityLicense },
-        { name: "UNITY_LICENSE_FILE", value: options.unityLicenseFile },
-        { name: "UNITY_EMAIL", value: options.unityEmail },
-        { name: "UNITY_PASSWORD", value: options.unityPassword },
-        { name: "UNITY_SERIAL", value: options.unitySerial },
-        { name: "UNITY_LICENSING_SERVER", value: options.unityLicensingServer },
-        { name: "UNITY_VERSION", value: options.engineVersion },
-        { name: "USYM_UPLOAD_AUTH_TOKEN", value: options.uploadAuthToken },
-        { name: "ANDROID_VERSION_CODE", value: options.androidVersionCode },
-        { name: "ANDROID_KEYSTORE_NAME", value: options.androidKeystoreName },
-        { name: "ANDROID_KEYSTORE_BASE64", value: options.androidKeystoreBase64 },
-        { name: "ANDROID_KEYSTORE_PASS", value: options.androidKeystorePass },
-        { name: "ANDROID_KEYALIAS_NAME", value: options.androidKeyaliasName },
-        { name: "ANDROID_KEYALIAS_PASS", value: options.androidKeyaliasPass },
-        { name: "ANDROID_TARGET_SDK_VERSION", value: options.androidTargetSdkVersion },
-        { name: "ANDROID_SDK_MANAGER_PARAMETERS", value: options.androidSdkManagerParameters },
-        { name: "ANDROID_EXPORT_TYPE", value: options.androidExportType },
-        { name: "ANDROID_SYMBOL_TYPE", value: options.androidSymbolType }
-      ];
-    }
-  };
-});
-
 // src/model/docker.ts
-function engineEnvVars(options) {
-  return options.engine === "unity" ? UnityEnvironment.getVariables(options) : [];
-}
-
 class Docker {
   static async run(image, options) {
     const { hostPlatform, hostOS, engine } = options;
@@ -14573,62 +14558,58 @@ class Docker {
     }
   }
   static getLinuxCommand(image, options) {
-    const { currentWorkDir, homeDir, cliDistPath, runnerTempPath, sshAgent, gitPrivateToken, dockerWorkspacePath, commands, engine } = options;
+    const { currentWorkDir, homeDir, cliDistPath, runnerTempPath, sshAgent, gitPrivateToken, dockerWorkspacePath } = options;
     const home = homeDir;
-    const envVarString = ImageEnvironmentFactory.getEnvVarString(options, engineEnvVars(options)).replace(/ \\\n/g, " ");
-    const isUnityDefaultFlow = !commands || engine === "unity";
+    const envVarString = ImageEnvironmentFactory.getEnvVarString(options).replace(/ \\\n/g, " ");
     return [
       "docker run",
       "--rm",
       `--workdir ${dockerWorkspacePath}`,
       envVarString,
-      isUnityDefaultFlow ? "--env UNITY_SERIAL" : "",
+      "--env UNITY_SERIAL",
       `--env GITHUB_WORKSPACE=${dockerWorkspacePath}`,
       gitPrivateToken ? `--env GIT_PRIVATE_TOKEN="${gitPrivateToken}"` : "",
       sshAgent ? "--env SSH_AUTH_SOCK=/ssh-agent" : "",
       `--volume "${home}":"/root:z"`,
       `--volume "${currentWorkDir}":"${dockerWorkspacePath}:z"`,
-      isUnityDefaultFlow ? `--volume "${cliDistPath}/default-build-script:/UnityBuilderAction:z"` : "",
-      isUnityDefaultFlow ? `--volume "${cliDistPath}/platforms/ubuntu/steps:/steps:z"` : "",
-      isUnityDefaultFlow ? `--volume "${cliDistPath}/platforms/ubuntu/entrypoint.sh:/entrypoint.sh:z"` : "",
-      isUnityDefaultFlow ? `--volume "${cliDistPath}/unity-config:/usr/share/unity3d/config:z"` : "",
+      `--volume "${cliDistPath}/default-build-script:/UnityBuilderAction:z"`,
+      `--volume "${cliDistPath}/platforms/ubuntu/steps:/steps:z"`,
+      `--volume "${cliDistPath}/platforms/ubuntu/entrypoint.sh:/entrypoint.sh:z"`,
+      `--volume "${cliDistPath}/unity-config:/usr/share/unity3d/config:z"`,
       sshAgent ? `--volume ${sshAgent}:/ssh-agent` : "",
       sshAgent ? "--volume /home/runner/.ssh/known_hosts:/root/.ssh/known_hosts:ro" : "",
       image,
-      isUnityDefaultFlow ? "/bin/bash /entrypoint.sh" : commands
+      "/bin/bash /entrypoint.sh"
     ].filter(Boolean).join(" ");
   }
   static getWindowsCommand(image, options) {
-    const { currentWorkDir, homeDir, cliDistPath, unitySerial, gitPrivateToken, cliStoragePath, dockerWorkspacePath, commands, engine } = options;
-    const isUnityDefaultFlow = !commands || engine === "unity";
-    return [
-      "docker run `",
-      "  --rm `",
-      `  --workdir="c:${dockerWorkspacePath}" \``,
-      `  ${ImageEnvironmentFactory.getEnvVarString(options, engineEnvVars(options))} \``,
-      isUnityDefaultFlow ? `  --env UNITY_SERIAL="${unitySerial}" \`` : "",
-      `  --env GITHUB_WORKSPACE=c:${dockerWorkspacePath} \``,
-      `  --env GIT_PRIVATE_TOKEN="${gitPrivateToken}" \``,
-      `  --volume="${currentWorkDir}":"c:${dockerWorkspacePath}" \``,
-      isUnityDefaultFlow ? `  --volume="${cliStoragePath}/registry-keys":"c:/registry-keys" \`` : "",
-      isUnityDefaultFlow ? '  --volume="C:/Program Files (x86)/Microsoft Visual Studio":"C:/Program Files (x86)/Microsoft Visual Studio" `' : "",
-      isUnityDefaultFlow ? '  --volume="C:/Program Files (x86)/Windows Kits":"C:/Program Files (x86)/Windows Kits" `' : "",
-      isUnityDefaultFlow ? '  --volume="C:/ProgramData/Microsoft/VisualStudio":"C:/ProgramData/Microsoft/VisualStudio" `' : "",
-      isUnityDefaultFlow ? `  --volume="${cliDistPath}/default-build-script":"c:/UnityBuilderAction" \`` : "",
-      isUnityDefaultFlow ? `  --volume="${cliDistPath}/platforms/windows":"c:/steps" \`` : "",
-      isUnityDefaultFlow ? `  --volume="${cliDistPath}/BlankProject":"c:/BlankProject" \`` : "",
-      isUnityDefaultFlow ? `  --volume="${cliDistPath}/unity-config":"c:/ProgramData/Unity/config" \`` : "",
-      `  ${image} \``,
-      isUnityDefaultFlow ? "  powershell c:/steps/entrypoint.ps1" : `  ${commands}`
-    ].filter(Boolean).join(`
-`);
+    const { currentWorkDir, homeDir, cliDistPath, unitySerial, gitPrivateToken, cliStoragePath, dockerWorkspacePath } = options;
+    return String.dedent`
+      docker run \`
+        --rm \`
+        --workdir="c:${dockerWorkspacePath}" \`
+        ${ImageEnvironmentFactory.getEnvVarString(options)} \`
+        --env UNITY_SERIAL="${unitySerial}" \`
+        --env GITHUB_WORKSPACE=c:${dockerWorkspacePath} \`
+        --env GIT_PRIVATE_TOKEN="${gitPrivateToken}" \`
+        --volume="${currentWorkDir}":"c:${dockerWorkspacePath}" \`
+        --volume="${cliStoragePath}/registry-keys":"c:/registry-keys" \`
+        --volume="C:/Program Files (x86)/Microsoft Visual Studio":"C:/Program Files (x86)/Microsoft Visual Studio" \`
+        --volume="C:/Program Files (x86)/Windows Kits":"C:/Program Files (x86)/Windows Kits" \`
+        --volume="C:/ProgramData/Microsoft/VisualStudio":"C:/ProgramData/Microsoft/VisualStudio" \`
+        --volume="${cliDistPath}/default-build-script":"c:/UnityBuilderAction" \`
+        --volume="${cliDistPath}/platforms/windows":"c:/steps" \`
+        --volume="${cliDistPath}/BlankProject":"c:/BlankProject" \`
+        --volume="${cliDistPath}/unity-config":"c:/ProgramData/Unity/config" \`
+        ${image} \`
+        powershell c:/steps/entrypoint.ps1
+    `;
   }
 }
 var init_docker = __esm(() => {
   init_image_environment_factory();
   init_system();
   init_unity_build_validation();
-  init_environment();
 });
 
 // src/model/unity/target-platform/unity-target-platform.ts
@@ -17272,6 +17253,14 @@ class BuildOptions {
       type: "string",
       demandOption: false,
       default: "/github/workspace"
+    }).option("manualExit", {
+      description: String.dedent`Skip passing -quit to the Unity editor, so it stays open after the build method returns.
+        Use this if your build method needs to run further code in play mode before exiting (see
+        https://github.com/game-ci/cli/issues/13). Your build method must call EditorApplication.Exit(0) itself,
+        otherwise the build will hang until it times out.`,
+      type: "boolean",
+      demandOption: false,
+      default: false
     });
   }
 }

--- a/dist/platforms/mac/steps/build.sh
+++ b/dist/platforms/mac/steps/build.sh
@@ -119,9 +119,16 @@ echo ""
 
 # Reference: https://docs.unity3d.com/2019.3/Documentation/Manual/CommandLineArguments.html
 
+# MANUAL_EXIT=true skips -quit so the build method can stay in play mode and
+# call EditorApplication.Exit(0) itself (see game-ci/cli#13).
+QUIT_FLAG="-quit"
+if [ "$MANUAL_EXIT" = "true" ]; then
+  QUIT_FLAG=""
+fi
+
 /Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS/Unity \
   -logFile - \
-  -quit \
+  $QUIT_FLAG \
   -batchmode \
   -nographics \
   -username "$UNITY_EMAIL" \

--- a/dist/platforms/ubuntu/steps/build.sh
+++ b/dist/platforms/ubuntu/steps/build.sh
@@ -117,9 +117,16 @@ echo ""
 
 # Reference: https://docs.unity3d.com/2019.3/Documentation/Manual/CommandLineArguments.html
 
+# MANUAL_EXIT=true skips -quit so the build method can stay in play mode and
+# call EditorApplication.Exit(0) itself (see game-ci/cli#13).
+QUIT_FLAG="-quit"
+if [ "$MANUAL_EXIT" = "true" ]; then
+  QUIT_FLAG=""
+fi
+
 unity-editor \
   -logfile /dev/stdout \
-  -quit \
+  $QUIT_FLAG \
   -customBuildName "$BUILD_NAME" \
   -projectPath "$UNITY_PROJECT_PATH" \
   -buildTarget "$BUILD_TARGET" \

--- a/dist/platforms/windows/build.ps1
+++ b/dist/platforms/windows/build.ps1
@@ -113,7 +113,14 @@ Write-Output ""
 # in double quotes.  To avoid this, parse $Env:CUSTOM_PARAMETERS into an array, while respecting any quotations within the string.
 $_, $customParametersArray = Invoke-Expression('Write-Output -- "" ' + $Env:CUSTOM_PARAMETERS)
 
-& "C:\Program Files\Unity\Hub\Editor\$Env:UNITY_VERSION\Editor\Unity.exe" -quit -batchmode -nographics `
+# MANUAL_EXIT=true skips -quit so the build method can stay in play mode and
+# call EditorApplication.Exit(0) itself (see game-ci/cli#13).
+$QuitArgs = @('-quit')
+if ($Env:MANUAL_EXIT -eq 'true') {
+  $QuitArgs = @()
+}
+
+& "C:\Program Files\Unity\Hub\Editor\$Env:UNITY_VERSION\Editor\Unity.exe" @QuitArgs -batchmode -nographics `
                                                                           -projectPath $Env:UNITY_PROJECT_PATH `
                                                                           -executeMethod $Env:BUILD_METHOD `
                                                                           -buildTarget $Env:BUILD_TARGET `

--- a/src/command-options/build-options.test.ts
+++ b/src/command-options/build-options.test.ts
@@ -38,4 +38,24 @@ describe('BuildOptions', () => {
 
     expect(argv.buildFile).toBe('GameCI.aab');
   });
+
+  it('defaults manualExit to false and accepts --manualExit', async () => {
+    const defaultParser = yargs(['--targetPlatform', 'StandaloneLinux64'])
+      .exitProcess(false)
+      .fail((message, error) => {
+        throw error || new Error(message);
+      });
+    BuildOptions.configure(defaultParser);
+    const defaultArgv = await defaultParser.parseAsync();
+    expect(defaultArgv.manualExit).toBe(false);
+
+    const enabledParser = yargs(['--targetPlatform', 'StandaloneLinux64', '--manualExit'])
+      .exitProcess(false)
+      .fail((message, error) => {
+        throw error || new Error(message);
+      });
+    BuildOptions.configure(enabledParser);
+    const enabledArgv = await enabledParser.parseAsync();
+    expect(enabledArgv.manualExit).toBe(true);
+  });
 });

--- a/src/command-options/build-options.ts
+++ b/src/command-options/build-options.ts
@@ -46,6 +46,15 @@ export class BuildOptions implements IOptions {
         type: 'string',
         demandOption: false,
         default: '/github/workspace',
+      })
+      .option('manualExit', {
+        description: String.dedent`Skip passing -quit to the Unity editor, so it stays open after the build method returns.
+        Use this if your build method needs to run further code in play mode before exiting (see
+        https://github.com/game-ci/cli/issues/13). Your build method must call EditorApplication.Exit(0) itself,
+        otherwise the build will hang until it times out.`,
+        type: 'boolean',
+        demandOption: false,
+        default: false,
       });
   }
 }

--- a/src/logic/unity/environment.ts
+++ b/src/logic/unity/environment.ts
@@ -28,6 +28,7 @@ const UnityEnvironment = {
       { name: 'ANDROID_SDK_MANAGER_PARAMETERS', value: options.androidSdkManagerParameters },
       { name: 'ANDROID_EXPORT_TYPE', value: options.androidExportType },
       { name: 'ANDROID_SYMBOL_TYPE', value: options.androidSymbolType },
+      { name: 'MANUAL_EXIT', value: options.manualExit ? 'true' : '' },
     ] as DockerParameter[];
   },
 };

--- a/src/model/image-environment-factory.test.ts
+++ b/src/model/image-environment-factory.test.ts
@@ -48,4 +48,16 @@ describe('ImageEnvironmentFactory', () => {
     expect(envString).not.toContain('UNITY_LICENSE');
     expect(envString).toContain('--env PROJECT_PATH="test-project"');
   });
+
+  it('omits MANUAL_EXIT by default', () => {
+    const options = { hostOS: 'linux' } as any;
+    const envString = ImageEnvironmentFactory.getEnvVarString(options, UnityEnvironment.getVariables(options));
+    expect(envString).not.toContain('MANUAL_EXIT');
+  });
+
+  it('sets MANUAL_EXIT when options.manualExit is true', () => {
+    const options = { hostOS: 'linux', manualExit: true } as any;
+    const envString = ImageEnvironmentFactory.getEnvVarString(options, UnityEnvironment.getVariables(options));
+    expect(envString).toContain('--env MANUAL_EXIT="true"');
+  });
 });


### PR DESCRIPTION
Closes #13.

Adds a `--manualExit` build option (default `false`, current behavior unchanged) that skips passing `-quit` to the Unity editor during the build step. Some build methods need to enter play mode from a static build method — which doesn't work if `-quit` is also present — to run in-game validation before packaging (exact scenario described in #13). With `--manualExit`, the build method is responsible for calling `EditorApplication.Exit(0)` itself once it's done; if it doesn't, the build will hang until it times out (documented in the flag's `--help` description).

Implementation:
- New `--manualExit` option in `build-options.ts`.
- Passed through as a `MANUAL_EXIT` env var via `image-environment-factory.ts`, same mechanism as other build settings reaching the container.
- Linux/Mac `build.sh` and Windows `build.ps1` conditionally include `-quit` based on `$MANUAL_EXIT`/`$Env:MANUAL_EXIT`.

## Testing

- New tests in `build-options.test.ts` (flag parses, defaults to `false`) and `image-environment-factory.test.ts` (env var only appears when set).
- `bash -n` syntax-checked both modified shell scripts.
- Full suite: `bun test` — 105 pass, 0 fail. `bun run build` — builds clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `manualExit` build option, disabled by default.
  * When enabled, Unity remains open after the build completes, allowing manual termination.

* **Tests**
  * Added coverage confirming default behavior and the `--manualExit` option.
  * Added validation for the corresponding build environment setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->