### PR TITLE
fix: return_license step reopens built project on Unity 2019, causing reimport

### DIFF
--- a/dist/platforms/ubuntu/steps/return_license.sh
+++ b/dist/platforms/ubuntu/steps/return_license.sh
@@ -16,10 +16,15 @@ elif [[ -n "$UNITY_SERIAL" ]]; then
   #
   # This will return the license that is currently in use.
   #
+  # -projectPath points at the scratch activation directory, not the built
+  # project, so Unity doesn't reopen the real project (and reimport its
+  # library against whatever the editor's default target is) just to
+  # return the license (game-ci/cli#33).
   unity-editor \
     -logFile /dev/stdout \
     -quit \
-    -returnlicense
+    -returnlicense \
+    -projectPath "$ACTIVATE_LICENSE_PATH"
 fi
 
 # Return to previous working directory

--- a/dist/platforms/windows/return_license.ps1
+++ b/dist/platforms/windows/return_license.ps1
@@ -10,10 +10,15 @@ if ($env:UNITY_LICENSING_SERVER) {
   & 'C:\Program Files\Unity\Hub\Editor\$Env:UNITY_VERSION\Editor\Data\Resources\Licensing\Client\Unity.Licensing.Client.exe' --return-floating $global:FLOATING_LICENSE
 }
 else {
+  # -projectPath points at the scratch activation directory, not the built
+  # project, so Unity doesn't reopen the real project (and reimport its
+  # library against whatever the editor's default target is) just to
+  # return the license (game-ci/cli#33).
   & "C:\Program Files\Unity\Hub\Editor\$Env:UNITY_VERSION\Editor\Unity.exe" -batchmode -quit -nographics `
                                                                             -username $Env:UNITY_EMAIL `
                                                                             -password $Env:UNITY_PASSWORD `
                                                                             -returnlicense `
+                                                                            -projectPath $ACTIVATE_LICENSE_PATH `
                                                                             -logfile | Out-Host
 }
 


### PR DESCRIPTION
Closes #33.

`return_license.sh`/`return_license.ps1` ran `unity-editor -returnlicense` with no `-projectPath`. On Unity 2019 this makes the editor fall back to reopening whatever project it last had open in that container — the project that was just built — with the editor's default target platform. If that default differs from the actual build target, Unity kicks off a full library reimport just to return a license, costing 10+ minutes per build (as reported in #33).

The Mac build script already sidesteps this by pointing `-projectPath` at the scratch license-activation directory instead of the real project, so Unity has nothing meaningful to reimport. This applies the same fix to the Linux and Windows scripts.

## Testing

- `bash -n` syntax-checked the modified shell script.
- Full suite: `bun test` — 102 pass, 0 fail (no TS source touched, this is dist-script-only). `bun run build` — builds clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>