### PR TITLE
fix: mac entrypoint crashes on reused self-hosted runners

### DIFF
--- a/dist/platforms/mac/entrypoint.sh
+++ b/dist/platforms/mac/entrypoint.sh
@@ -4,8 +4,11 @@
 # Create directories for license activation
 #
 
-sudo mkdir /Library/Application\ Support/Unity
-sudo chmod -R 777 /Library/Application\ Support/Unity
+UNITY_LICENSE_PATH="/Library/Application Support/Unity"
+if [ ! -d "$UNITY_LICENSE_PATH" ]; then
+  sudo mkdir -p "$UNITY_LICENSE_PATH"
+  sudo chmod -R 777 "$UNITY_LICENSE_PATH"
+fi
 
 ACTIVATE_LICENSE_PATH="$ACTION_FOLDER/BlankProject"
 mkdir -p "$ACTIVATE_LICENSE_PATH"
@@ -20,8 +23,10 @@ source $ACTION_FOLDER/platforms/mac/steps/return_license.sh
 #
 # Remove license activation directory
 #
+# Note: $UNITY_LICENSE_PATH is intentionally left in place - it may be a
+# shared system directory pre-existing across runs (e.g. on a reused
+# self-hosted runner), not something this script necessarily created.
 
-sudo rm -r /Library/Application\ Support/Unity
 rm -r "$ACTIVATE_LICENSE_PATH"
 
 #


### PR DESCRIPTION
Item 6 from #65's audit — smallest, safest fix, landing it separately since there's no reason to wait on the rest.

\`sudo mkdir /Library/Application\ Support/Unity\` (no \`-p\`) errors if the directory already exists — e.g. on a self-hosted macOS runner reused across jobs where a previous run's state persisted. Real \`unity-builder\` guards this with an existence check before creating it, and — found while matching that exactly — never deletes the directory at cleanup either, since it may be shared system state the script didn't necessarily create itself. Matched both behaviors.

## Testing

- \`bash -n\` syntax-checked the modified script.
- Full suite: \`bun test\` — 116 pass, 0 fail (script-only change, no TS source touched). \`bun run build\` — clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>