### PR TITLE
feat: add `activate` command as the real pilot for actions-invoke-cli

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -17137,35 +17137,35 @@ class UnityOptions {
         description: "Email address for your Unity account",
         type: "string",
         demandOption: false,
-        default: ""
+        default: process.env.UNITY_EMAIL || ""
       },
       unityPassword: {
         alias: "p",
         description: "Password for your Unity account",
         type: "string",
         demandOption: false,
-        default: ""
+        default: process.env.UNITY_PASSWORD || ""
       },
       unitySerial: {
         alias: "s",
         description: "Serial number identifying a pro-license seat",
         type: "string",
         demandOption: false,
-        default: ""
+        default: process.env.UNITY_SERIAL || ""
       },
       unityLicense: {
         alias: "l",
         description: "Contents of, or path to your Unity License File (.ulf)",
         type: "string",
         demandOption: false,
-        default: ""
+        default: process.env.UNITY_LICENSE || ""
       },
       unityLicensingServer: {
         alias: "ls",
         description: "Licensing server to use for Unity activation",
         type: "string",
         demandOption: false,
-        default: ""
+        default: process.env.UNITY_LICENSING_SERVER || ""
       },
       unityLicensingToolset: {
         alias: "lt",

--- a/dist/index.js
+++ b/dist/index.js
@@ -14523,6 +14523,7 @@ var init_environment = __esm(() => {
         { name: "MANUAL_EXIT", value: options.manualExit ? "true" : "" },
         { name: "BUILD_PROFILE", value: options.buildProfile },
         { name: "SKIP_ACTIVATION", value: options.skipActivation ? "true" : "" },
+        { name: "ACTIVATE_ONLY", value: options.activateOnly ? "true" : "" },
         { name: "RUN_AS_HOST_USER", value: options.runAsHostUser ? "true" : "" },
         { name: "ENABLE_GPU", value: options.enableGpu ? "true" : "" },
         { name: "GIT_CONFIG_EXTENSIONS", value: options.gitConfigExtensions }
@@ -16158,6 +16159,7 @@ class CliCommands {
     await this.configCommand();
     await this.testCommand();
     await this.buildCommand();
+    await this.activateCommand();
     await this.buildImageCommand();
     await this.orchestrateCommand();
     await this.remoteCommands();
@@ -16177,6 +16179,12 @@ class CliCommands {
   }
   async buildCommand() {
     await this.yargs.command("build [projectPath]", "Builds a given project", async (yargs) => {
+      ProjectOptions.preConfigure(yargs);
+      this.register(yargs);
+    });
+  }
+  async activateCommand() {
+    await this.yargs.command("activate [projectPath]", "Activates a license, leaving it active for a later step", async (yargs) => {
       ProjectOptions.preConfigure(yargs);
       this.register(yargs);
     });
@@ -17602,6 +17610,39 @@ class UnityBuildCommand extends CommandBase {
   }
 }
 
+// src/command/activate/activate-command.ts
+init_model();
+class ActivateCommand extends CommandBase {
+  async execute(options) {
+    const { hostPlatform } = options;
+    const activateOptions = { ...options, activateOnly: true };
+    PlatformValidation.checkCompatibility(activateOptions);
+    const image = new RunnerImageTag(activateOptions);
+    if (log.isVerbose)
+      log.debug("Using image:", image);
+    await PlatformSetup.setup(activateOptions);
+    await log.group("Unity activate", async () => {
+      if (hostPlatform === "darwin") {
+        await MacBuilder.run(activateOptions);
+      } else {
+        await Docker.run(image.toString(), activateOptions);
+      }
+    });
+    return true;
+  }
+  async configureOptions(yargs) {
+    await ProjectOptions.configure(yargs);
+    await UnityOptions.configure(yargs);
+    yargs.option("dockerWorkspacePath", {
+      description: String.dedent`The path to mount the workspace inside the docker container. For windows, leave out the drive letter. For example
+      c:/github/workspace should be defined as /github/workspace`,
+      type: "string",
+      demandOption: false,
+      default: "/github/workspace"
+    });
+  }
+}
+
 // src/command-options/remote-options.ts
 class RemoteOptions {
   static async configure(yargs) {
@@ -17850,6 +17891,8 @@ var unityPlugin = {
         switch (command2) {
           case "build":
             return new UnityBuildCommand(command2);
+          case "activate":
+            return new ActivateCommand(command2);
           case "orchestrate":
             return new UnityOrchestrateCommand(command2);
           case "run":

--- a/dist/platforms/mac/entrypoint.sh
+++ b/dist/platforms/mac/entrypoint.sh
@@ -19,6 +19,14 @@ else
   echo "Skipping activation"
 fi
 
+# ACTIVATE_ONLY=true (used by `game-ci activate`) activates and stops here -
+# no build, and the license is deliberately left active for a later step to
+# use, so no return_license.sh either.
+if [ "$ACTIVATE_ONLY" = "true" ]; then
+  rm -r "$ACTIVATE_LICENSE_PATH"
+  exit $UNITY_EXIT_CODE
+fi
+
 #
 # Run Build
 #

--- a/dist/platforms/ubuntu/steps/runsteps.sh
+++ b/dist/platforms/ubuntu/steps/runsteps.sh
@@ -17,6 +17,14 @@ else
   echo "Skipping activation"
 fi
 
+# ACTIVATE_ONLY=true (used by `game-ci activate`, see game-ci/cli's ActivateCommand)
+# activates and stops here - no build, and the license is deliberately left
+# active for a later step to use, so no return_license.sh either.
+if [ "$ACTIVATE_ONLY" = "true" ]; then
+  rm -r "$ACTIVATE_LICENSE_PATH"
+  exit $UNITY_EXIT_CODE
+fi
+
 source /steps/build.sh
 
 if [ "$SKIP_ACTIVATION" != "true" ]; then

--- a/dist/platforms/windows/entrypoint.ps1
+++ b/dist/platforms/windows/entrypoint.ps1
@@ -32,6 +32,13 @@ if ($Env:SKIP_ACTIVATION -ne "true") {
   Write-Host "Skipping activation"
 }
 
+# ACTIVATE_ONLY=true (used by `game-ci activate`) activates and stops here -
+# no build, and the license is deliberately left active for a later step to
+# use, so no return_license.ps1 either.
+if ($Env:ACTIVATE_ONLY -eq "true") {
+  exit $LASTEXITCODE
+}
+
 # Build the project
 & "c:\steps\build.ps1"
 

--- a/src/cli-commands.ts
+++ b/src/cli-commands.ts
@@ -23,6 +23,7 @@ export class CliCommands {
     await this.configCommand();
     await this.testCommand();
     await this.buildCommand();
+    await this.activateCommand();
     await this.buildImageCommand();
     await this.orchestrateCommand();
     await this.remoteCommands();
@@ -48,6 +49,13 @@ export class CliCommands {
 
   private async buildCommand() {
     await this.yargs.command('build [projectPath]', 'Builds a given project', async (yargs: YargsInstance) => {
+      ProjectOptions.preConfigure(yargs);
+      this.register(yargs);
+    });
+  }
+
+  private async activateCommand() {
+    await this.yargs.command('activate [projectPath]', 'Activates a license, leaving it active for a later step', async (yargs: YargsInstance) => {
       ProjectOptions.preConfigure(yargs);
       this.register(yargs);
     });

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import * as process from 'node:process';
+import { spawn } from 'node:child_process';
 import { Cli } from './cli.ts';
 import { UnityOrchestrateCommand } from './command/orchestrate/unity-orchestrate-command.ts';
 import { CommandFactory } from './command/command-factory.ts';
@@ -84,5 +85,45 @@ describe('Cli plugin loading', () => {
     const command = new CommandFactory().selectEngine('unity', '2022.3.20f1').createCommand(['remote', 'build']);
 
     expect(command).toBeInstanceOf(UnityOrchestrateCommand);
+  });
+});
+
+describe('Cli env var option mapping', () => {
+  // Secrets (Unity credentials, license contents) must reach the CLI via
+  // environment variables, not argv - argv can leak through process
+  // listings and gets echoed by exec loggers. UnityOptions defaults each
+  // credential option to its matching UNITY_* env var (see
+  // unity-options.ts) rather than using yargs' blanket .env(), which
+  // combined with strict(true) rejects every unrelated process env var as
+  // an unrecognized argument.
+  it('populates unityEmail from the UNITY_EMAIL env var', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'game-ci-cli-'));
+    try {
+      await fs.mkdir(path.join(tempDir, 'ProjectSettings'), { recursive: true });
+      await fs.writeFile(path.join(tempDir, 'ProjectSettings', 'ProjectVersion.txt'), 'm_EditorVersion: 2022.3.20f1\n', 'utf8');
+      // vcsDetection shells out to git and throws if the project path isn't a repo.
+      await new Promise((resolve, reject) => {
+        const child = spawn('git', ['init', tempDir]);
+        child.on('error', reject);
+        child.on('exit', (code) => (code === 0 ? resolve(undefined) : reject(new Error(`git init exited with ${code}`))));
+      });
+
+      const previousEmail = process.env.UNITY_EMAIL;
+      process.env.UNITY_EMAIL = 'bot@game.ci';
+      try {
+        const cli = new Cli(['activate', tempDir], process.cwd());
+        await cli.setup();
+        await cli.registerCommands();
+        await cli.registerSchemaForChosenCommand();
+        const { options } = await cli.validateAndParseArguments();
+
+        expect(options.unityEmail).toBe('bot@game.ci');
+      } finally {
+        if (previousEmail === undefined) delete process.env.UNITY_EMAIL;
+        else process.env.UNITY_EMAIL = previousEmail;
+      }
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -149,8 +149,11 @@ export class Cli {
       .exitProcess(true) // Fixes broken `_handle` in yargs 17.0.0
       .strict(true);
 
-      // Todo: Enable env as this is still throwing errors when added
-      // .env();
+      // Deliberately not using yargs' blanket .env(): combined with strict(true)
+      // it treats every process env var (not just game-ci-relevant ones) as an
+      // unrecognized argument and fails. Secret-bearing options set their own
+      // env fallback in their .option() default instead - see unityEmail etc.
+      // in unity-options.ts.
   }
 
   protected configureGlobalOptions() {

--- a/src/command-options/unity-options.ts
+++ b/src/command-options/unity-options.ts
@@ -16,40 +16,45 @@ export class UnityOptions implements IOptions {
         default: UnityTargetPlatform.default,
       })
       .options({
+        // Default to the matching UNITY_* env var, not just an empty string:
+        // these carry secrets (passwords, license contents), so callers like
+        // unity-activate's thin wrapper need to pass them via the child
+        // process's environment rather than argv, which can leak through
+        // process listings and exec-style command logging.
         unityEmail: {
           alias: 'u',
           description: 'Email address for your Unity account',
           type: 'string',
           demandOption: false,
-          default: '',
+          default: process.env.UNITY_EMAIL || '',
         },
         unityPassword: {
           alias: 'p',
           description: 'Password for your Unity account',
           type: 'string',
           demandOption: false,
-          default: '',
+          default: process.env.UNITY_PASSWORD || '',
         },
         unitySerial: {
           alias: 's',
           description: 'Serial number identifying a pro-license seat',
           type: 'string',
           demandOption: false,
-          default: '',
+          default: process.env.UNITY_SERIAL || '',
         },
         unityLicense: {
           alias: 'l',
           description: 'Contents of, or path to your Unity License File (.ulf)',
           type: 'string',
           demandOption: false,
-          default: '',
+          default: process.env.UNITY_LICENSE || '',
         },
         unityLicensingServer: {
           alias: 'ls',
           description: 'Licensing server to use for Unity activation',
           type: 'string',
           demandOption: false,
-          default: '',
+          default: process.env.UNITY_LICENSING_SERVER || '',
         },
         unityLicensingToolset: {
           alias: 'lt',

--- a/src/command/activate/activate-command.test.ts
+++ b/src/command/activate/activate-command.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, mock, afterEach } from 'bun:test';
+import { ActivateCommand } from './activate-command.ts';
+import { Docker } from '../../model/index.ts';
+import { MacBuilder } from '../../model/mac-builder.ts';
+import { PlatformSetup } from '../../logic/unity/platform-setup/index.ts';
+import { PlatformValidation } from '../../logic/unity/platform-validation/platform-validation.ts';
+
+const originalDockerRun = Docker.run;
+const originalMacBuilderRun = MacBuilder.run;
+const originalPlatformSetup = PlatformSetup.setup;
+const originalCheckCompatibility = PlatformValidation.checkCompatibility;
+
+afterEach(() => {
+  // All are shared statics — restore them so other test files exercising the
+  // real implementations aren't affected by this file's mocks.
+  Docker.run = originalDockerRun;
+  MacBuilder.run = originalMacBuilderRun;
+  PlatformSetup.setup = originalPlatformSetup;
+  PlatformValidation.checkCompatibility = originalCheckCompatibility;
+});
+
+const baseOptions = { hostPlatform: 'linux', engineVersion: '2019.2.11f1', targetPlatform: 'Test' } as any;
+
+describe('ActivateCommand', () => {
+  it('runs Docker with activateOnly set, and returns true, on non-mac hosts', async () => {
+    PlatformValidation.checkCompatibility = mock(() => {});
+    PlatformSetup.setup = mock(() => Promise.resolve());
+    const dockerRunMock = mock(() => Promise.resolve());
+    Docker.run = dockerRunMock;
+
+    const command = new ActivateCommand('activate');
+    const result = await command.execute(baseOptions);
+
+    expect(result).toBe(true);
+    expect(dockerRunMock).toHaveBeenCalled();
+    const [, optionsPassedToDocker] = dockerRunMock.mock.calls[0];
+    expect(optionsPassedToDocker.activateOnly).toBe(true);
+  });
+
+  it('runs MacBuilder instead of Docker on darwin hosts', async () => {
+    PlatformValidation.checkCompatibility = mock(() => {});
+    PlatformSetup.setup = mock(() => Promise.resolve());
+    const dockerRunMock = mock(() => Promise.resolve());
+    const macBuilderRunMock = mock(() => Promise.resolve());
+    Docker.run = dockerRunMock;
+    MacBuilder.run = macBuilderRunMock;
+
+    const command = new ActivateCommand('activate');
+    await command.execute({ ...baseOptions, hostPlatform: 'darwin' });
+
+    expect(macBuilderRunMock).toHaveBeenCalled();
+    expect(dockerRunMock).not.toHaveBeenCalled();
+  });
+
+  it('does not mutate the original options object', async () => {
+    PlatformValidation.checkCompatibility = mock(() => {});
+    PlatformSetup.setup = mock(() => Promise.resolve());
+    Docker.run = mock(() => Promise.resolve());
+
+    const command = new ActivateCommand('activate');
+    await command.execute(baseOptions);
+
+    expect(baseOptions.activateOnly).toBeUndefined();
+  });
+});

--- a/src/command/activate/activate-command.ts
+++ b/src/command/activate/activate-command.ts
@@ -1,0 +1,59 @@
+import { CommandInterface } from '../command-interface.ts';
+import { Docker, RunnerImageTag } from '../../model/index.ts';
+import { PlatformSetup } from '../../logic/unity/platform-setup/index.ts';
+import { MacBuilder } from '../../model/mac-builder.ts';
+import { CommandBase } from '../command-base.ts';
+import { UnityOptions } from '../../command-options/unity-options.ts';
+import type { YargsInstance, Options } from '../../dependencies.ts';
+import { PlatformValidation } from '../../logic/unity/platform-validation/platform-validation.ts';
+import { ProjectOptions } from '../../command-options/project-options.ts';
+
+/**
+ * Activates (and only activates) a Unity license, leaving it active for a
+ * later step to use - it does not build or return the license itself.
+ *
+ * This is the real, working pilot for the "actions invoke cli" architecture
+ * (see game-ci/roadmap#11 workstream 2): unlike `build`/`test`, which the
+ * popular action repos still call into as an in-process library today,
+ * `game-ci/unity-activate`'s thin wrapper shells out to this command
+ * directly, so the exact same code path runs locally and in CI.
+ */
+export class ActivateCommand extends CommandBase implements CommandInterface {
+  public async execute(options: Options): Promise<boolean> {
+    const { hostPlatform } = options;
+    const activateOptions: Options = { ...options, activateOnly: true };
+
+    PlatformValidation.checkCompatibility(activateOptions);
+
+    const image = new RunnerImageTag(activateOptions);
+    if (log.isVerbose) log.debug('Using image:', image);
+
+    await PlatformSetup.setup(activateOptions);
+
+    await log.group('Unity activate', async () => {
+      if (hostPlatform === 'darwin') {
+        await MacBuilder.run(activateOptions);
+      } else {
+        await Docker.run(image.toString(), activateOptions);
+      }
+    });
+
+    return true;
+  }
+
+  public async configureOptions(yargs: YargsInstance): Promise<void> {
+    await ProjectOptions.configure(yargs);
+    await UnityOptions.configure(yargs);
+    // Needed by Docker.run() for the container mount path - normally comes
+    // from BuildOptions, but `activate` intentionally doesn't pull in
+    // BuildOptions' build-specific flags (buildName, buildMethod, etc.),
+    // which don't apply to activation-only.
+    yargs.option('dockerWorkspacePath', {
+      description: String.dedent`The path to mount the workspace inside the docker container. For windows, leave out the drive letter. For example
+      c:/github/workspace should be defined as /github/workspace`,
+      type: 'string',
+      demandOption: false,
+      default: '/github/workspace',
+    });
+  }
+}

--- a/src/logic/unity/environment.ts
+++ b/src/logic/unity/environment.ts
@@ -31,6 +31,7 @@ const UnityEnvironment = {
       { name: 'MANUAL_EXIT', value: options.manualExit ? 'true' : '' },
       { name: 'BUILD_PROFILE', value: options.buildProfile },
       { name: 'SKIP_ACTIVATION', value: options.skipActivation ? 'true' : '' },
+      { name: 'ACTIVATE_ONLY', value: options.activateOnly ? 'true' : '' },
       { name: 'RUN_AS_HOST_USER', value: options.runAsHostUser ? 'true' : '' },
       { name: 'ENABLE_GPU', value: options.enableGpu ? 'true' : '' },
       { name: 'GIT_CONFIG_EXTENSIONS', value: options.gitConfigExtensions },

--- a/src/plugin/builtin/unity-plugin.ts
+++ b/src/plugin/builtin/unity-plugin.ts
@@ -1,6 +1,7 @@
 import type { GameCIPlugin } from '../plugin-interface.ts';
 import { UnityVersionDetector } from '../../middleware/engine-detection/unity-version-detector.ts';
 import { UnityBuildCommand } from '../../command/build/unity-build-command.ts';
+import { ActivateCommand } from '../../command/activate/activate-command.ts';
 import { UnityOrchestrateCommand } from '../../command/orchestrate/unity-orchestrate-command.ts';
 import { UnityLogsCommand } from '../../command/logs/unity-logs-command.ts';
 import { UnityRunCommand } from '../../command/run/unity-run-command.ts';
@@ -36,6 +37,8 @@ export const unityPlugin: GameCIPlugin = {
         switch (command) {
           case 'build':
             return new UnityBuildCommand(command);
+          case 'activate':
+            return new ActivateCommand(command);
           case 'orchestrate':
             return new UnityOrchestrateCommand(command);
           case 'run':


### PR DESCRIPTION
## What

Adds a `game-ci activate [projectPath]` command: activates a Unity license and stops immediately - no build, no license return - leaving the license active for a later step to use.

This is the working counterpart to `unity-activate`'s thin-wrapper rewrite (see companion PR on `game-ci/unity-activate`). Today the action repos import `@game-ci/unity-engine-core` as an in-process library, which means the code path exercised in CI is never actually the same code path a developer runs locally. `game-ci activate` gives `unity-activate` a real CLI command to shell out to instead, so the exact same path runs in both places - the core idea from the actions-invoke-cli discussion in game-ci/roadmap#11 (workstream 2).

## How

- `ActivateCommand` (`src/command/activate/activate-command.ts`) mirrors `UnityBuildCommand`'s platform dispatch (`Docker.run` / `MacBuilder.run`, branched on `hostPlatform === 'darwin'`), but only runs `PlatformValidation.checkCompatibility` + `PlatformSetup.setup` + the platform run - no build, no log collection, no version output.
- Adds `ACTIVATE_ONLY` env var to `UnityEnvironment.getVariables()`, mirroring the existing `SKIP_ACTIVATION` pattern. Consumed by all three platform entrypoints/runsteps (`ubuntu/steps/runsteps.sh`, `mac/entrypoint.sh`, `windows/entrypoint.ps1`) to activate and exit right after, before the build step and without returning the license.
- Registers `activate` in `cli-commands.ts` (new `activateCommand()` method, same pattern as `testCommand()`/`buildCommand()`) and in `unity-plugin.ts`'s `createCommand` switch.
- `configureOptions` reuses `ProjectOptions` + `UnityOptions`, plus a minimal inline `dockerWorkspacePath` option (normally only defined in `BuildOptions`, which also carries a lot of build-only flags like `buildName`/`buildMethod` that don't apply here).

## Scope note

This follows the existing pattern where Unity-specific implementation (`RunnerImageTag`, `PlatformSetup`, Docker orchestration) lives inline in `cli`'s built-in Unity plugin, same as `build`/`test`/`orchestrate` do today. There's a separate, bigger discussion about whether that implementation should instead live in `unity-engine-core` with `cli`'s built-in plugin as a thin adapter (to keep `cli`'s own release cadence free of Unity-specific churn) - intentionally out of scope here so this PR doesn't block on it. Opening a tracking issue for that separately.

## Testing

- `bun test` - all passing (128 pass, 3 skip), including new `activate-command.test.ts` covering the Docker/MacBuilder platform branch and confirming `activateOnly` is passed through without mutating the caller's options.
- `bun run build` - succeeds.
- Windows/macOS entrypoint changes syntax-checked (`bash -n`, PowerShell AST parser); not live-tested against a real runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `activate` command for activating Unity projects without performing a build or returning a license.
  * Supports activation through Docker on non-macOS systems and MacBuilder on macOS.
  * Added project path, Unity, and Docker workspace configuration options.
  * Activation-only mode is now passed to the Unity environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->