### PR TITLE
feat: close build-command feature gaps blocking unity-builder's migration

### DIFF
--- a/.github/workflows/engine-smoke-test.yml
+++ b/.github/workflows/engine-smoke-test.yml
@@ -117,8 +117,11 @@ jobs:
 
       - name: Verify build artifacts
         run: |
-          test -f build/StandaloneLinux64/StandaloneLinux64
-          grep -q "Unity CLI smoke artifact" build/StandaloneLinux64/StandaloneLinux64
+          # StandaloneLinux64 builds get a .x86_64 extension by default now
+          # (matching unity-builder - see game-ci/cli#70), unless
+          # --linux64RemoveExecutableExtension is passed.
+          test -f build/StandaloneLinux64/StandaloneLinux64.x86_64
+          grep -q "Unity CLI smoke artifact" build/StandaloneLinux64/StandaloneLinux64.x86_64
           echo "Unity CLI stub build verified"
 
   # ─── Godot — detect + build using third-party image ────────────

--- a/dist/index.js
+++ b/dist/index.js
@@ -14580,7 +14580,21 @@ class Docker {
     }
   }
   static getLinuxCommand(image, options) {
-    const { currentWorkDir, homeDir, cliDistPath, runnerTempPath, sshAgent, gitPrivateToken, dockerWorkspacePath, commands, engine } = options;
+    const {
+      currentWorkDir,
+      homeDir,
+      cliDistPath,
+      runnerTempPath,
+      sshAgent,
+      sshPublicKeysDirectoryPath,
+      gitPrivateToken,
+      dockerWorkspacePath,
+      commands,
+      engine,
+      useHostNetwork,
+      dockerCpuLimit,
+      dockerMemoryLimit
+    } = options;
     const home = homeDir;
     const envVarString = ImageEnvironmentFactory.getEnvVarString(options, engineEnvVars(options)).replace(/ \\\n/g, " ");
     const isUnityDefaultFlow = !commands || engine === "unity";
@@ -14593,6 +14607,9 @@ class Docker {
       `--env GITHUB_WORKSPACE=${dockerWorkspacePath}`,
       gitPrivateToken ? `--env GIT_PRIVATE_TOKEN="${gitPrivateToken}"` : "",
       sshAgent ? "--env SSH_AUTH_SOCK=/ssh-agent" : "",
+      dockerCpuLimit ? `--cpus=${dockerCpuLimit}` : "",
+      dockerMemoryLimit ? `--memory=${dockerMemoryLimit}` : "",
+      useHostNetwork ? "--net=host" : "",
       `--volume "${home}":"/root:z"`,
       `--volume "${currentWorkDir}":"${dockerWorkspacePath}:z"`,
       isUnityDefaultFlow ? `--volume "${cliDistPath}/default-build-script:/UnityBuilderAction:z"` : "",
@@ -14600,13 +14617,27 @@ class Docker {
       isUnityDefaultFlow ? `--volume "${cliDistPath}/platforms/ubuntu/entrypoint.sh:/entrypoint.sh:z"` : "",
       isUnityDefaultFlow ? `--volume "${cliDistPath}/unity-config:/usr/share/unity3d/config:z"` : "",
       sshAgent ? `--volume ${sshAgent}:/ssh-agent` : "",
-      sshAgent ? "--volume /home/runner/.ssh/known_hosts:/root/.ssh/known_hosts:ro" : "",
+      sshAgent && !sshPublicKeysDirectoryPath ? "--volume /home/runner/.ssh/known_hosts:/root/.ssh/known_hosts:ro" : "",
+      sshPublicKeysDirectoryPath ? `--volume ${sshPublicKeysDirectoryPath}:/root/.ssh:ro` : "",
       image,
       isUnityDefaultFlow ? "/bin/bash /entrypoint.sh" : commands
     ].filter(Boolean).join(" ");
   }
   static getWindowsCommand(image, options) {
-    const { currentWorkDir, homeDir, cliDistPath, unitySerial, gitPrivateToken, cliStoragePath, dockerWorkspacePath, commands, engine } = options;
+    const {
+      currentWorkDir,
+      homeDir,
+      cliDistPath,
+      unitySerial,
+      gitPrivateToken,
+      cliStoragePath,
+      dockerWorkspacePath,
+      commands,
+      engine,
+      dockerCpuLimit,
+      dockerMemoryLimit,
+      dockerIsolationMode
+    } = options;
     const isUnityDefaultFlow = !commands || engine === "unity";
     return [
       "docker run `",
@@ -14616,6 +14647,9 @@ class Docker {
       isUnityDefaultFlow ? `  --env UNITY_SERIAL="${unitySerial}" \`` : "",
       `  --env GITHUB_WORKSPACE=c:${dockerWorkspacePath} \``,
       `  --env GIT_PRIVATE_TOKEN="${gitPrivateToken}" \``,
+      dockerCpuLimit ? `  --cpus=${dockerCpuLimit} \`` : "",
+      dockerMemoryLimit ? `  --memory=${dockerMemoryLimit} \`` : "",
+      dockerIsolationMode ? `  --isolation=${dockerIsolationMode} \`` : "",
       `  --volume="${currentWorkDir}":"c:${dockerWorkspacePath}" \``,
       isUnityDefaultFlow ? `  --volume="${cliStoragePath}/registry-keys":"c:/registry-keys" \`` : "",
       isUnityDefaultFlow ? '  --volume="C:/Program Files (x86)/Microsoft Visual Studio":"C:/Program Files (x86)/Microsoft Visual Studio" `' : "",
@@ -14678,7 +14712,7 @@ class UnityTargetPlatform {
         return false;
     }
   }
-  static determineBuildFileName(buildName, platform2, androidExportType) {
+  static determineBuildFileName(buildName, platform2, androidExportType, linux64RemoveExecutableExtension = false) {
     if (UnityTargetPlatform.isWindows(platform2)) {
       return `${buildName}.exe`;
     }
@@ -14691,6 +14725,9 @@ class UnityTargetPlatform {
         case "androidStudioProject":
           return `${buildName}`;
       }
+    }
+    if (platform2 === UnityTargetPlatform.StandaloneLinux64 && !linux64RemoveExecutableExtension) {
+      return `${buildName}.x86_64`;
     }
     return buildName;
   }
@@ -14712,19 +14749,25 @@ class RunnerImageTag {
       engineVersion = "2019.2.11f1",
       hostPlatform,
       targetPlatform,
-      customImage
+      customImage,
+      containerRegistryRepository = "unityci/editor",
+      containerRegistryImageVersion = "3"
     } = options;
     if (!RunnerImageTag.versionPattern.test(engineVersion)) {
       throw new Error(`Invalid version "${engineVersion}".`);
     }
+    const registryString = String(containerRegistryRepository);
+    const lastSlashIndex = registryString.lastIndexOf("/");
+    const repository = lastSlashIndex === -1 ? "unityci" : registryString.slice(0, lastSlashIndex);
+    const name = lastSlashIndex === -1 ? registryString : registryString.slice(lastSlashIndex + 1);
     this.customImage = customImage;
-    this.repository = "unityci";
-    this.name = "editor";
+    this.repository = repository;
+    this.name = name;
     this.engineVersion = engineVersion;
     this.targetPlatform = targetPlatform;
     this.imagePlatformPrefix = RunnerImageTag.getImagePlatformPrefixes(hostPlatform);
     this.builderPlatform = RunnerImageTag.getTargetPlatformToTargetPlatformSuffixMap(hostPlatform, targetPlatform, engineVersion);
-    this.imageRollingVersion = 1;
+    this.imageRollingVersion = Number(containerRegistryImageVersion);
   }
   static get versionPattern() {
     return /^20\d{2}\.\d\.\w{3,4}|3$/;
@@ -17298,6 +17341,23 @@ class VersioningOptions {
 
 // src/command-options/build-options.ts
 init_unity_target_platform();
+import * as os2 from "node:os";
+function defaultDockerMemoryLimit() {
+  const bytesInMegabyte = 1024 * 1024;
+  let memoryMultiplier;
+  switch (os2.platform()) {
+    case "linux":
+      memoryMultiplier = 0.95;
+      break;
+    case "win32":
+      memoryMultiplier = 0.8;
+      break;
+    default:
+      memoryMultiplier = 0.75;
+      break;
+  }
+  return `${Math.floor(os2.totalmem() / bytesInMegabyte * memoryMultiplier)}m`;
+}
 
 class BuildOptions {
   static configure(yargs) {
@@ -17313,12 +17373,12 @@ class BuildOptions {
       demandOption: false,
       default: "build"
     }).default("buildPath", "").default("buildFile", "").middleware((argv) => {
-      const { buildName, buildsPath, targetPlatform, androidAppBundle, androidExportType } = argv;
+      const { buildName, buildsPath, targetPlatform, androidAppBundle, androidExportType, linux64RemoveExecutableExtension } = argv;
       const resolvedBuildName = buildName || targetPlatform;
       const resolvedAndroidExportType = androidExportType || (androidAppBundle ? "androidAppBundle" : "androidPackage");
       argv.buildName = resolvedBuildName;
       argv.buildPath = `${buildsPath}/${targetPlatform}`;
-      argv.buildFile = UnityTargetPlatform.determineBuildFileName(resolvedBuildName, targetPlatform, resolvedAndroidExportType);
+      argv.buildFile = UnityTargetPlatform.determineBuildFileName(resolvedBuildName, targetPlatform, resolvedAndroidExportType, Boolean(linux64RemoveExecutableExtension));
     }).option("buildMethod", {
       alias: "m",
       description: "Build method to use",
@@ -17367,6 +17427,52 @@ class BuildOptions {
     }).option("gitConfigExtensions", {
       description: String.dedent`Linux only. Newline-separated list of extra git config entries to set before the
         build, in "key=value" form (e.g. for LFS/submodule auth setups not covered by gitPrivateToken).`,
+      type: "string",
+      demandOption: false,
+      default: ""
+    }).option("linux64RemoveExecutableExtension", {
+      description: String.dedent`When building for StandaloneLinux64, remove the default .x86_64 file extension
+        Unity appends to the build's executable.`,
+      type: "boolean",
+      demandOption: false,
+      default: false
+    }).option("useHostNetwork", {
+      description: "Linux only. Initialises Docker using the host network.",
+      type: "boolean",
+      demandOption: false,
+      default: false
+    }).option("dockerCpuLimit", {
+      description: "Number of CPU cores to assign the docker container. Defaults to all available cores.",
+      type: "string",
+      demandOption: false,
+      default: os2.cpus().length.toString()
+    }).option("dockerMemoryLimit", {
+      description: String.dedent`Amount of memory to assign the docker container. Defaults to 95% of total system
+        memory rounded down to the nearest megabyte on Linux and 80% on Windows. On unrecognized platforms, defaults
+        to 75% of total system memory. To manually specify a value, use the format <number><unit>, where unit is
+        either m or g. ie: 512m = 512 megabytes`,
+      type: "string",
+      demandOption: false,
+      default: defaultDockerMemoryLimit()
+    }).option("dockerIsolationMode", {
+      description: String.dedent`Windows only. Isolation mode to use for the docker container. Can be one of
+        process, hyperv, or default. Default will pick the default mode as described by Microsoft where server
+        versions use process and desktop versions use hyperv.`,
+      type: "string",
+      demandOption: false,
+      default: "default"
+    }).option("containerRegistryRepository", {
+      description: "Container registry and repository to pull the Unity editor image from. Only applies if customImage is not set.",
+      type: "string",
+      demandOption: false,
+      default: "unityci/editor"
+    }).option("containerRegistryImageVersion", {
+      description: "Container registry image rolling version. Only applies if customImage is not set.",
+      type: "string",
+      demandOption: false,
+      default: "3"
+    }).option("sshPublicKeysDirectoryPath", {
+      description: "Path to a directory containing SSH public keys to forward to the container.",
       type: "string",
       demandOption: false,
       default: ""

--- a/src/command-options/build-options.test.ts
+++ b/src/command-options/build-options.test.ts
@@ -15,6 +15,22 @@ describe('BuildOptions', () => {
 
     expect(argv.buildName).toBe('StandaloneLinux64');
     expect(argv.buildPath).toBe('build/StandaloneLinux64');
+    // Unity appends .x86_64 by default for StandaloneLinux64 - matches
+    // unity-builder's default (linux64RemoveExecutableExtension: false).
+    expect(argv.buildFile).toBe('StandaloneLinux64.x86_64');
+  });
+
+  it('omits the .x86_64 extension when linux64RemoveExecutableExtension is set', async () => {
+    const parser = yargs(['--targetPlatform', 'StandaloneLinux64', '--linux64RemoveExecutableExtension'])
+      .exitProcess(false)
+      .fail((message, error) => {
+        throw error || new Error(message);
+      });
+
+    BuildOptions.configure(parser);
+
+    const argv = await parser.parseAsync();
+
     expect(argv.buildFile).toBe('StandaloneLinux64');
   });
 
@@ -95,5 +111,53 @@ describe('BuildOptions', () => {
     expect(setArgv.runAsHostUser).toBe(true);
     expect(setArgv.enableGpu).toBe(true);
     expect(setArgv.gitConfigExtensions).toBe('http.sslVerify=false');
+  });
+
+  it('defaults the container registry, docker resource, and ssh options and accepts them when set', async () => {
+    const defaultParser = yargs(['--targetPlatform', 'StandaloneLinux64'])
+      .exitProcess(false)
+      .fail((message, error) => {
+        throw error || new Error(message);
+      });
+    BuildOptions.configure(defaultParser);
+    const defaultArgv = await defaultParser.parseAsync();
+    expect(defaultArgv.containerRegistryRepository).toBe('unityci/editor');
+    expect(defaultArgv.containerRegistryImageVersion).toBe('3');
+    expect(defaultArgv.dockerIsolationMode).toBe('default');
+    expect(defaultArgv.useHostNetwork).toBe(false);
+    expect(defaultArgv.sshPublicKeysDirectoryPath).toBe('');
+    expect(typeof defaultArgv.dockerCpuLimit).toBe('string');
+    expect(typeof defaultArgv.dockerMemoryLimit).toBe('string');
+
+    const setParser = yargs([
+      '--targetPlatform',
+      'StandaloneLinux64',
+      '--containerRegistryRepository',
+      'ghcr.io/example/editor',
+      '--containerRegistryImageVersion',
+      '5',
+      '--dockerIsolationMode',
+      'process',
+      '--useHostNetwork',
+      '--sshPublicKeysDirectoryPath',
+      '/home/runner/.ssh/keys',
+      '--dockerCpuLimit',
+      '2',
+      '--dockerMemoryLimit',
+      '4096m',
+    ])
+      .exitProcess(false)
+      .fail((message, error) => {
+        throw error || new Error(message);
+      });
+    BuildOptions.configure(setParser);
+    const setArgv = await setParser.parseAsync();
+    expect(setArgv.containerRegistryRepository).toBe('ghcr.io/example/editor');
+    expect(setArgv.containerRegistryImageVersion).toBe('5');
+    expect(setArgv.dockerIsolationMode).toBe('process');
+    expect(setArgv.useHostNetwork).toBe(true);
+    expect(setArgv.sshPublicKeysDirectoryPath).toBe('/home/runner/.ssh/keys');
+    expect(setArgv.dockerCpuLimit).toBe('2');
+    expect(setArgv.dockerMemoryLimit).toBe('4096m');
   });
 });

--- a/src/command-options/build-options.ts
+++ b/src/command-options/build-options.ts
@@ -1,6 +1,26 @@
 import type { YargsArguments, YargsInstance } from '../dependencies.ts';
 import { UnityTargetPlatform } from '../model/unity/target-platform/unity-target-platform.ts';
 import { IOptions } from './options-interface.ts';
+import * as os from 'node:os';
+
+function defaultDockerMemoryLimit(): string {
+  const bytesInMegabyte = 1024 * 1024;
+
+  let memoryMultiplier: number;
+  switch (os.platform()) {
+    case 'linux':
+      memoryMultiplier = 0.95;
+      break;
+    case 'win32':
+      memoryMultiplier = 0.8;
+      break;
+    default:
+      memoryMultiplier = 0.75;
+      break;
+  }
+
+  return `${Math.floor((os.totalmem() / bytesInMegabyte) * memoryMultiplier)}m`;
+}
 
 export class BuildOptions implements IOptions {
   public static configure(yargs: YargsInstance): void {
@@ -22,7 +42,7 @@ export class BuildOptions implements IOptions {
       .default('buildPath', '')
       .default('buildFile', '')
       .middleware((argv: YargsArguments) => {
-        const { buildName, buildsPath, targetPlatform, androidAppBundle, androidExportType } = argv;
+        const { buildName, buildsPath, targetPlatform, androidAppBundle, androidExportType, linux64RemoveExecutableExtension } = argv;
         const resolvedBuildName = buildName || targetPlatform;
         const resolvedAndroidExportType = androidExportType || (androidAppBundle ? 'androidAppBundle' : 'androidPackage');
         argv.buildName = resolvedBuildName;
@@ -31,6 +51,7 @@ export class BuildOptions implements IOptions {
           resolvedBuildName,
           targetPlatform,
           resolvedAndroidExportType,
+          Boolean(linux64RemoveExecutableExtension),
         );
       })
       .option('buildMethod', {
@@ -88,6 +109,60 @@ export class BuildOptions implements IOptions {
       .option('gitConfigExtensions', {
         description: String.dedent`Linux only. Newline-separated list of extra git config entries to set before the
         build, in "key=value" form (e.g. for LFS/submodule auth setups not covered by gitPrivateToken).`,
+        type: 'string',
+        demandOption: false,
+        default: '',
+      })
+      .option('linux64RemoveExecutableExtension', {
+        description: String.dedent`When building for StandaloneLinux64, remove the default .x86_64 file extension
+        Unity appends to the build's executable.`,
+        type: 'boolean',
+        demandOption: false,
+        default: false,
+      })
+      .option('useHostNetwork', {
+        description: 'Linux only. Initialises Docker using the host network.',
+        type: 'boolean',
+        demandOption: false,
+        default: false,
+      })
+      .option('dockerCpuLimit', {
+        description: 'Number of CPU cores to assign the docker container. Defaults to all available cores.',
+        type: 'string',
+        demandOption: false,
+        default: os.cpus().length.toString(),
+      })
+      .option('dockerMemoryLimit', {
+        description: String.dedent`Amount of memory to assign the docker container. Defaults to 95% of total system
+        memory rounded down to the nearest megabyte on Linux and 80% on Windows. On unrecognized platforms, defaults
+        to 75% of total system memory. To manually specify a value, use the format <number><unit>, where unit is
+        either m or g. ie: 512m = 512 megabytes`,
+        type: 'string',
+        demandOption: false,
+        default: defaultDockerMemoryLimit(),
+      })
+      .option('dockerIsolationMode', {
+        description: String.dedent`Windows only. Isolation mode to use for the docker container. Can be one of
+        process, hyperv, or default. Default will pick the default mode as described by Microsoft where server
+        versions use process and desktop versions use hyperv.`,
+        type: 'string',
+        demandOption: false,
+        default: 'default',
+      })
+      .option('containerRegistryRepository', {
+        description: 'Container registry and repository to pull the Unity editor image from. Only applies if customImage is not set.',
+        type: 'string',
+        demandOption: false,
+        default: 'unityci/editor',
+      })
+      .option('containerRegistryImageVersion', {
+        description: 'Container registry image rolling version. Only applies if customImage is not set.',
+        type: 'string',
+        demandOption: false,
+        default: '3',
+      })
+      .option('sshPublicKeysDirectoryPath', {
+        description: 'Path to a directory containing SSH public keys to forward to the container.',
         type: 'string',
         demandOption: false,
         default: '',

--- a/src/model/docker.test.ts
+++ b/src/model/docker.test.ts
@@ -69,6 +69,79 @@ describe('Docker', () => {
     expect(command).not.toContain('should-not-be-used');
   });
 
+  it('applies docker resource limits and host networking when set', () => {
+    const command = (Docker as any).getLinuxCommand('game-ci/unity-editor-stub:latest', {
+      hostOS: 'linux',
+      currentWorkDir: '/home/runner/work/cli/cli',
+      homeDir: '/home/runner',
+      cliDistPath: '/home/runner/work/cli/cli/dist',
+      sshAgent: '',
+      gitPrivateToken: '',
+      dockerWorkspacePath: '/github/workspace',
+      engine: 'unity',
+      dockerCpuLimit: '4',
+      dockerMemoryLimit: '8192m',
+      useHostNetwork: true,
+    });
+
+    expect(command).toContain('--cpus=4');
+    expect(command).toContain('--memory=8192m');
+    expect(command).toContain('--net=host');
+  });
+
+  it('mounts a custom SSH public keys directory instead of the known_hosts fallback', () => {
+    const command = (Docker as any).getLinuxCommand('game-ci/unity-editor-stub:latest', {
+      hostOS: 'linux',
+      currentWorkDir: '/home/runner/work/cli/cli',
+      homeDir: '/home/runner',
+      cliDistPath: '/home/runner/work/cli/cli/dist',
+      sshAgent: '/ssh-agent',
+      sshPublicKeysDirectoryPath: '/home/runner/.ssh/keys',
+      gitPrivateToken: '',
+      dockerWorkspacePath: '/github/workspace',
+      engine: 'unity',
+    });
+
+    expect(command).toContain('--volume /home/runner/.ssh/keys:/root/.ssh:ro');
+    expect(command).not.toContain('known_hosts');
+  });
+
+  it('mounts sshPublicKeysDirectoryPath even without sshAgent set, matching unity-builder', () => {
+    const command = (Docker as any).getLinuxCommand('game-ci/unity-editor-stub:latest', {
+      hostOS: 'linux',
+      currentWorkDir: '/home/runner/work/cli/cli',
+      homeDir: '/home/runner',
+      cliDistPath: '/home/runner/work/cli/cli/dist',
+      sshAgent: '',
+      sshPublicKeysDirectoryPath: '/home/runner/.ssh/keys',
+      gitPrivateToken: '',
+      dockerWorkspacePath: '/github/workspace',
+      engine: 'unity',
+    });
+
+    expect(command).toContain('--volume /home/runner/.ssh/keys:/root/.ssh:ro');
+  });
+
+  it('applies docker resource limits and isolation mode on Windows', () => {
+    const command = (Docker as any).getWindowsCommand('game-ci/unity-editor-stub:latest', {
+      currentWorkDir: 'C:/work/cli',
+      homeDir: 'C:/Users/runner',
+      cliDistPath: 'C:/work/cli/dist',
+      cliStoragePath: 'C:/work/.game-ci',
+      unitySerial: '',
+      gitPrivateToken: '',
+      dockerWorkspacePath: '/github/workspace',
+      engine: 'unity',
+      dockerCpuLimit: '4',
+      dockerMemoryLimit: '8192m',
+      dockerIsolationMode: 'process',
+    });
+
+    expect(command).toContain('--cpus=4');
+    expect(command).toContain('--memory=8192m');
+    expect(command).toContain('--isolation=process');
+  });
+
   it.skip('runs', async () => {
     const image = 'unity-builder:2019.2.11f1-webgl';
     const parameters = {

--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -61,8 +61,21 @@ class Docker {
   }
 
   private static getLinuxCommand(image: string, options: Options): string {
-    const { currentWorkDir, homeDir, cliDistPath, runnerTempPath, sshAgent, gitPrivateToken, dockerWorkspacePath, commands, engine } =
-      options as Options & { commands?: string };
+    const {
+      currentWorkDir,
+      homeDir,
+      cliDistPath,
+      runnerTempPath,
+      sshAgent,
+      sshPublicKeysDirectoryPath,
+      gitPrivateToken,
+      dockerWorkspacePath,
+      commands,
+      engine,
+      useHostNetwork,
+      dockerCpuLimit,
+      dockerMemoryLimit,
+    } = options as Options & { commands?: string };
 
     const home = homeDir;
     const envVarString = ImageEnvironmentFactory.getEnvVarString(options, engineEnvVars(options)).replace(/ \\\n/g, ' ');
@@ -83,6 +96,9 @@ class Docker {
       `--env GITHUB_WORKSPACE=${dockerWorkspacePath}`,
       gitPrivateToken ? `--env GIT_PRIVATE_TOKEN="${gitPrivateToken}"` : '',
       sshAgent ? '--env SSH_AUTH_SOCK=/ssh-agent' : '',
+      dockerCpuLimit ? `--cpus=${dockerCpuLimit}` : '',
+      dockerMemoryLimit ? `--memory=${dockerMemoryLimit}` : '',
+      useHostNetwork ? '--net=host' : '',
       `--volume "${home}":"/root:z"`,
       `--volume "${currentWorkDir}":"${dockerWorkspacePath}:z"`,
       isUnityDefaultFlow ? `--volume "${cliDistPath}/default-build-script:/UnityBuilderAction:z"` : '',
@@ -90,7 +106,8 @@ class Docker {
       isUnityDefaultFlow ? `--volume "${cliDistPath}/platforms/ubuntu/entrypoint.sh:/entrypoint.sh:z"` : '',
       isUnityDefaultFlow ? `--volume "${cliDistPath}/unity-config:/usr/share/unity3d/config:z"` : '',
       sshAgent ? `--volume ${sshAgent}:/ssh-agent` : '',
-      sshAgent ? '--volume /home/runner/.ssh/known_hosts:/root/.ssh/known_hosts:ro' : '',
+      sshAgent && !sshPublicKeysDirectoryPath ? '--volume /home/runner/.ssh/known_hosts:/root/.ssh/known_hosts:ro' : '',
+      sshPublicKeysDirectoryPath ? `--volume ${sshPublicKeysDirectoryPath}:/root/.ssh:ro` : '',
       image,
       isUnityDefaultFlow ? '/bin/bash /entrypoint.sh' : commands!,
     ]
@@ -99,8 +116,20 @@ class Docker {
   }
 
   private static getWindowsCommand(image: string, options: Options): string {
-    const { currentWorkDir, homeDir, cliDistPath, unitySerial, gitPrivateToken, cliStoragePath, dockerWorkspacePath, commands, engine } =
-      options as Options & { commands?: string };
+    const {
+      currentWorkDir,
+      homeDir,
+      cliDistPath,
+      unitySerial,
+      gitPrivateToken,
+      cliStoragePath,
+      dockerWorkspacePath,
+      commands,
+      engine,
+      dockerCpuLimit,
+      dockerMemoryLimit,
+      dockerIsolationMode,
+    } = options as Options & { commands?: string };
 
     // Same "don't force Unity's flow onto a non-Unity engine" fix as
     // getLinuxCommand — see the comment there. No engine currently ships a
@@ -119,6 +148,9 @@ class Docker {
       isUnityDefaultFlow ? `  --env UNITY_SERIAL="${unitySerial}" \`` : '',
       `  --env GITHUB_WORKSPACE=c:${dockerWorkspacePath} \``,
       `  --env GIT_PRIVATE_TOKEN="${gitPrivateToken}" \``,
+      dockerCpuLimit ? `  --cpus=${dockerCpuLimit} \`` : '',
+      dockerMemoryLimit ? `  --memory=${dockerMemoryLimit} \`` : '',
+      dockerIsolationMode ? `  --isolation=${dockerIsolationMode} \`` : '',
       `  --volume="${currentWorkDir}":"c:${dockerWorkspacePath}" \``,
       isUnityDefaultFlow ? `  --volume="${cliStoragePath}/registry-keys":"c:/registry-keys" \`` : '',
       isUnityDefaultFlow

--- a/src/model/unity/runner/runner-image-tag.test.ts
+++ b/src/model/unity/runner/runner-image-tag.test.ts
@@ -45,6 +45,9 @@ describe('RunnerImageTag', () => {
   });
 
   describe('toString', () => {
+    // Rolling version defaults to "3", matching unity-builder's production
+    // default (Input.containerRegistryImageVersion) - this used to be
+    // hardcoded to "1" here, which meant cli resolved a stale image tag.
     it('returns the correct version', () => {
       const image = new RunnerImageTag({
         engineVersion: '2099.1.1111',
@@ -53,10 +56,10 @@ describe('RunnerImageTag', () => {
       });
       switch (process.platform) {
         case 'win32':
-          expect(image.toString()).toStrictEqual(`${defaults.image}:windows-2099.1.1111-1`);
+          expect(image.toString()).toStrictEqual(`${defaults.image}:windows-2099.1.1111-3`);
           break;
         case 'linux':
-          expect(image.toString()).toStrictEqual(`${defaults.image}:ubuntu-2099.1.1111-1`);
+          expect(image.toString()).toStrictEqual(`${defaults.image}:ubuntu-2099.1.1111-3`);
           break;
       }
     });
@@ -80,10 +83,10 @@ describe('RunnerImageTag', () => {
 
       switch (process.platform) {
         case 'win32':
-          expect(image.toString()).toStrictEqual(`${defaults.image}:windows-2019.2.11f1-webgl-1`);
+          expect(image.toString()).toStrictEqual(`${defaults.image}:windows-2019.2.11f1-webgl-3`);
           break;
         case 'linux':
-          expect(image.toString()).toStrictEqual(`${defaults.image}:ubuntu-2019.2.11f1-webgl-1`);
+          expect(image.toString()).toStrictEqual(`${defaults.image}:ubuntu-2019.2.11f1-webgl-3`);
           break;
       }
     });
@@ -96,12 +99,33 @@ describe('RunnerImageTag', () => {
 
       switch (process.platform) {
         case 'win32':
-          expect(image.toString()).toStrictEqual(`${defaults.image}:windows-2019.2.11f1-1`);
+          expect(image.toString()).toStrictEqual(`${defaults.image}:windows-2019.2.11f1-3`);
           break;
         case 'linux':
-          expect(image.toString()).toStrictEqual(`${defaults.image}:ubuntu-2019.2.11f1-1`);
+          expect(image.toString()).toStrictEqual(`${defaults.image}:ubuntu-2019.2.11f1-3`);
           break;
       }
+    });
+
+    it('honors an overridden containerRegistryRepository, keeping a host+path prefix intact', () => {
+      const image = new RunnerImageTag({
+        targetPlatform: 'NoTarget',
+        hostPlatform: process.platform,
+        containerRegistryRepository: 'ghcr.io/example/editor',
+      });
+
+      expect(image.repository).toStrictEqual('ghcr.io/example');
+      expect(image.name).toStrictEqual('editor');
+    });
+
+    it('honors an overridden containerRegistryImageVersion', () => {
+      const image = new RunnerImageTag({
+        targetPlatform: 'NoTarget',
+        hostPlatform: process.platform,
+        containerRegistryImageVersion: '5',
+      });
+
+      expect(image.imageRollingVersion).toStrictEqual(5);
     });
   });
 });

--- a/src/model/unity/runner/runner-image-tag.ts
+++ b/src/model/unity/runner/runner-image-tag.ts
@@ -17,15 +17,25 @@ class RunnerImageTag {
       hostPlatform,
       targetPlatform,
       customImage,
+      containerRegistryRepository = 'unityci/editor',
+      containerRegistryImageVersion = '3',
     } = options;
 
     if (!RunnerImageTag.versionPattern.test(engineVersion)) {
       throw new Error(`Invalid version "${engineVersion}".`);
     }
 
+    // Split on the last '/' so registries with a host+path prefix (e.g.
+    // ghcr.io/example/editor) keep that whole prefix as the repository,
+    // with only the final segment treated as the image name.
+    const registryString = String(containerRegistryRepository);
+    const lastSlashIndex = registryString.lastIndexOf('/');
+    const repository = lastSlashIndex === -1 ? 'unityci' : registryString.slice(0, lastSlashIndex);
+    const name = lastSlashIndex === -1 ? registryString : registryString.slice(lastSlashIndex + 1);
+
     this.customImage = customImage;
-    this.repository = 'unityci';
-    this.name = 'editor';
+    this.repository = repository;
+    this.name = name;
     this.engineVersion = engineVersion;
     this.targetPlatform = targetPlatform;
     this.imagePlatformPrefix = RunnerImageTag.getImagePlatformPrefixes(hostPlatform);
@@ -34,7 +44,8 @@ class RunnerImageTag {
       targetPlatform,
       engineVersion,
     );
-    this.imageRollingVersion = 1; // Will automatically roll to the latest non-breaking version.
+    // Rolls forward automatically within the pinned major (non-breaking updates).
+    this.imageRollingVersion = Number(containerRegistryImageVersion);
   }
 
   static get versionPattern() {

--- a/src/model/unity/target-platform/unity-target-platform.test.ts
+++ b/src/model/unity/target-platform/unity-target-platform.test.ts
@@ -30,4 +30,42 @@ describe('UnityTargetPlatform', () => {
       expect(UnityTargetPlatform.isAndroid(UnityTargetPlatform.StandaloneWindows64)).toStrictEqual(false);
     });
   });
+
+  describe('determineBuildFileName', () => {
+    it('appends .exe for windows targets', () => {
+      expect(UnityTargetPlatform.determineBuildFileName('Game', UnityTargetPlatform.StandaloneWindows64, '')).toStrictEqual(
+        'Game.exe',
+      );
+    });
+
+    it('appends .apk for androidPackage', () => {
+      expect(
+        UnityTargetPlatform.determineBuildFileName('Game', UnityTargetPlatform.Android, 'androidPackage'),
+      ).toStrictEqual('Game.apk');
+    });
+
+    it('appends .aab for androidAppBundle', () => {
+      expect(
+        UnityTargetPlatform.determineBuildFileName('Game', UnityTargetPlatform.Android, 'androidAppBundle'),
+      ).toStrictEqual('Game.aab');
+    });
+
+    it('appends .x86_64 for StandaloneLinux64 by default, matching unity-builder', () => {
+      expect(
+        UnityTargetPlatform.determineBuildFileName('Game', UnityTargetPlatform.StandaloneLinux64, ''),
+      ).toStrictEqual('Game.x86_64');
+    });
+
+    it('omits the .x86_64 extension when linux64RemoveExecutableExtension is true', () => {
+      expect(
+        UnityTargetPlatform.determineBuildFileName('Game', UnityTargetPlatform.StandaloneLinux64, '', true),
+      ).toStrictEqual('Game');
+    });
+
+    it('leaves other platforms unmodified', () => {
+      expect(UnityTargetPlatform.determineBuildFileName('Game', UnityTargetPlatform.StandaloneOSX, '')).toStrictEqual(
+        'Game',
+      );
+    });
+  });
 });

--- a/src/model/unity/target-platform/unity-target-platform.ts
+++ b/src/model/unity/target-platform/unity-target-platform.ts
@@ -45,7 +45,12 @@ class UnityTargetPlatform {
     }
   }
 
-  static determineBuildFileName(buildName: string, platform: string, androidExportType: string) {
+  static determineBuildFileName(
+    buildName: string,
+    platform: string,
+    androidExportType: string,
+    linux64RemoveExecutableExtension = false,
+  ) {
     if (UnityTargetPlatform.isWindows(platform)) {
       return `${buildName}.exe`;
     }
@@ -59,6 +64,11 @@ class UnityTargetPlatform {
         case 'androidStudioProject':
           return `${buildName}`;
       }
+    }
+
+    // Unity appends .x86_64 to StandaloneLinux64 builds by default.
+    if (platform === UnityTargetPlatform.StandaloneLinux64 && !linux64RemoveExecutableExtension) {
+      return `${buildName}.x86_64`;
     }
 
     return buildName;


### PR DESCRIPTION
## Why

Converting `unity-builder` to invoke `cli build` (the same actions-invoke-cli migration already landed for `unity-activate` - #68) needs `cli build` to actually cover `unity-builder`'s real feature surface first. Comparing `unity-builder`'s `action.yml`/`Input.ts` against `cli`'s `build-options.ts`/`docker.ts` line by line turned up several gaps that would have silently dropped functionality for anyone relying on them today. This closes those gaps - verified against `unity-builder`'s actual source, not guessed.

## What

- **`linux64RemoveExecutableExtension`** - `UnityTargetPlatform.determineBuildFileName` never appended the `.x86_64` extension Unity gives `StandaloneLinux64` builds by default; it unconditionally behaved as if this flag were always `true`. Now matches `unity-builder`'s real default (`false` - extension kept), with the flag able to remove it.
- **`dockerCpuLimit` / `dockerMemoryLimit` / `dockerIsolationMode` / `useHostNetwork`** - Docker resource/networking flags were entirely unavailable. `Docker.run` now applies `--cpus`/`--memory` (both platforms), `--net=host` (Linux) and `--isolation` (Windows) - default values for CPU/memory limits mirror `unity-builder`'s own dynamic host-based defaults (all cores; 95%/80%/75% of total memory depending on OS).
- **`containerRegistryRepository` / `containerRegistryImageVersion`** - `RunnerImageTag` hardcoded the image to `unityci/editor` at rolling version `1`. The version turned out to be a real latent bug: `unity-builder`'s production-validated default is `3`, so `cli` was likely resolving a stale/non-existent tag. Both are now overridable (repository split on the *last* `/`, so host+path registries like `ghcr.io/example/editor` work correctly), and the rolling-version default is corrected.
- **`sshPublicKeysDirectoryPath`** - lets you mount known SSH public keys from a custom directory, instead of only the `known_hosts` fallback.

## Testing

- `bun test` - 139 pass (up from 125; new coverage for every option above, including the corrected `-3` rolling-version tag format).
- `bun run build` - succeeds.

## Scope note

This still isn't full parity with `unity-builder` - `providerStrategy`/remote builds go through `orchestrate` already, but there are smaller gaps (e.g. exact `androidExportType`/`androidAppBundle` interplay edge cases) not covered here. This PR closes the gaps significant enough to cause a real functional regression if `unity-builder` converted today; it's the prerequisite, not the conversion itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)