### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "GameCI CLI - automation for game engines",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Version bump ahead of cutting a v0.1.1 release with the `activate` command (#68) and build-command feature parity (#70), which `unity-activate`/`unity-builder`'s new thin wrappers (currently on `cliVersion: latest`) depend on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)