### PR TITLE
fix: compiled binaries never had their static assets on a real path

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -20,23 +20,28 @@ jobs:
           - target: linux-x64
             runner: ubuntu-latest
             bun-target: bun-linux-x64
-            asset: game-ci-linux-x64
+            binary: game-ci
+            asset: game-ci-linux-x64.tar.gz
           - target: linux-arm64
             runner: ubuntu-latest
             bun-target: bun-linux-arm64
-            asset: game-ci-linux-arm64
+            binary: game-ci
+            asset: game-ci-linux-arm64.tar.gz
           - target: macos-x64
             runner: macos-latest
             bun-target: bun-darwin-x64
-            asset: game-ci-macos-x64
+            binary: game-ci
+            asset: game-ci-macos-x64.tar.gz
           - target: macos-arm64
             runner: macos-latest
             bun-target: bun-darwin-arm64
-            asset: game-ci-macos-arm64
+            binary: game-ci
+            asset: game-ci-macos-arm64.tar.gz
           - target: windows-x64
             runner: windows-latest
             bun-target: bun-windows-x64
-            asset: game-ci-windows-x64.exe
+            binary: game-ci.exe
+            asset: game-ci-windows-x64.zip
     steps:
       - uses: actions/checkout@v4
 
@@ -47,7 +52,17 @@ jobs:
         run: bun install
 
       - name: Build standalone binary
-        run: bun build src/index.ts --compile --target ${{ matrix.bun-target }} --outfile ${{ matrix.asset }}
+        run: bun build src/index.ts --compile --target ${{ matrix.bun-target }} --outfile pkg/${{ matrix.binary }}
+
+      # The binary alone isn't self-contained: cli.ts resolves its own
+      # static assets (default-build-script/, platforms/*,
+      # unity-config/services-config.json.template - all needed for Docker
+      # volume mounts) relative to its own directory on disk. Those assets
+      # aren't bundled into the compiled binary, so dist/ has to ship as
+      # its sibling in the same archive - see game-ci/cli#73.
+      - name: Copy static assets alongside the binary
+        shell: bash
+        run: cp -r dist pkg/dist
 
       - name: Verify binary (native only)
         if: >-
@@ -55,8 +70,18 @@ jobs:
           (matrix.target == 'macos-x64' && runner.arch == 'X64') ||
           (matrix.target == 'linux-x64') ||
           (matrix.target == 'windows-x64')
-        run: ./${{ matrix.asset }} --help
+        run: ./pkg/${{ matrix.binary }} --help
         shell: bash
+
+      - name: Package archive (unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: tar -czf ${{ matrix.asset }} -C pkg .
+
+      - name: Package archive (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Compress-Archive -Path pkg\* -DestinationPath ${{ matrix.asset }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-import { yaml, yargs, getHomeDir, __dirname, path, process, fs } from './dependencies.ts';
+import { yaml, yargs, getHomeDir, __dirname, isCompiledBinary, path, process, fs } from './dependencies.ts';
 import type { YargsInstance, YargsArguments } from './dependencies.ts';
 import { CommandInterface } from './command/command-interface.ts';
 import { configureLogger } from './middleware/logger-verbosity/index.ts';
@@ -38,9 +38,12 @@ export class Cli {
     this.hostPlatform = process.platform;
     this.hostOS = process.platform === 'win32' ? 'windows' : process.platform;
 
-    // Todo make these variables portable when generating the cli binary
     this.cliPath = __dirname;
-    this.cliDistPath = path.join(path.dirname(__dirname), 'dist');
+    // Dev mode: __dirname is <repo>/src, so dist/ is a sibling of its parent
+    // (<repo>/dist). Compiled binary: __dirname is wherever the standalone
+    // executable itself sits on disk (no src/ nesting) - dist/ must be
+    // shipped as its direct sibling instead. See game-ci/cli#73.
+    this.cliDistPath = isCompiledBinary ? path.join(__dirname, 'dist') : path.join(path.dirname(__dirname), 'dist');
   }
 
   public async setup() {

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -32,7 +32,25 @@ String.dedent = dedent;
 // Errors from yargs can be very verbose and not very descriptive
 Error.stackTraceLimit = 15;
 
-const __filename = fileURLToPath(import.meta.url);
+// import.meta.url resolves correctly for `bun run src/index.ts`, but Bun's
+// `--compile` step virtualizes it for non-entry bundled modules (this one
+// included) to an internal virtual path that doesn't exist on the real
+// filesystem - so any path built from it (e.g. cli.ts's cliDistPath, used
+// to locate static assets like default-build-script/ and platforms/* for
+// Docker volume mounts) silently pointed nowhere real. The exact virtual
+// path format is platform-dependent (seen "/$bunfs/..." on Linux/macOS,
+// "B:\~BUN\..." on Windows) - too fragile to detect by string-matching, so
+// detect the *mode* directly instead: `bun run`/`bun src/index.ts` runs
+// under the bun interpreter itself (process.execPath's basename starts
+// with "bun"); a compiled --compile binary's execPath is itself, under
+// whatever name the release gave it (e.g. "game-ci-linux-x64"), which
+// never starts with "bun". process.execPath is also the one thing that
+// reliably points at the real running binary in compiled mode - in
+// interpreted mode it points at the bun interpreter, the wrong base for
+// resolving this repo's own files, so it's only used as the __filename
+// basis once compiled mode is confirmed.
+const isCompiledBinary = !path.basename(process.execPath).toLowerCase().startsWith('bun');
+const __filename = isCompiledBinary ? process.execPath : fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // base64 compat (replaces Deno std base64)
@@ -84,6 +102,7 @@ export type { YargsArguments, Options, FormatterFunction, LogRecord };
 export {
   __dirname,
   __filename,
+  isCompiledBinary,
   assert,
   base64,
   Buffer,


### PR DESCRIPTION
## What broke

Discovered via real CI failures on `unity-builder`'s and `unity-activate`'s new thin-wrapper PRs (#844, and unity-activate#111), once they were actually downloading and invoking the compiled release binary end-to-end for the first time - `[ERROR] Missing services config /$bunfs/dist/unity-config/services-config.json.template`, and Docker mounting an empty directory where `entrypoint.sh` should be (`/entrypoint.sh: /entrypoint.sh: Is a directory`).

## Root cause

`cli.ts` resolves `cliDistPath` (`default-build-script/`, `platforms/*`, `unity-config/services-config.json.template` - all needed for Docker volume mounts, which require a real host filesystem path) relative to its own `__dirname`. `dependencies.ts` computed that via `fileURLToPath(import.meta.url)`, which resolves correctly under `bun run src/index.ts`, but Bun's `--compile` step virtualizes `import.meta.url` for non-entry bundled modules (this one included) to an internal path that doesn't exist on disk. The exact virtual path format is platform-dependent - confirmed `/$bunfs/...` on Linux/macOS (from CI) and `B:\~BUN\...` on Windows (tested locally) - too fragile to detect by string-matching a specific marker, which is why the fix detects the *mode* instead of the path shape.

Separately, even with correct path resolution, the binary alone was never self-contained: `bun build --compile` only bundles JS/TS reachable via static imports, not the static Unity build-script/shell-script/template assets `dist/` was carrying. Those need to exist as real files regardless of how `__dirname` resolves.

## Fix

- `dependencies.ts`: detect compiled-vs-interpreted mode by checking whether `process.execPath`'s basename starts with `"bun"` (the interpreter, in `bun run` mode) or not (a compiled binary runs as itself, under whatever name the release gave it). Only once compiled mode is confirmed does `__filename` fall back to `process.execPath` - the one thing that reliably points at the real running binary in that mode.
- `cli.ts`: `cliDistPath` computation branches on this - dev mode keeps the existing "two levels up from `__dirname`" math (`__dirname` is `<repo>/src`); compiled mode expects `dist/` as a direct sibling of the binary itself (one level, since the binary is a flat file with no `src/`-style nesting).
- `release-cli.yml`: packages `dist/` alongside each platform's binary into an archive (`.tar.gz` on Linux/macOS, `.zip` on Windows) instead of publishing a bare binary.

## Testing

- `bun test` - all passing, dev-mode behavior unchanged.
- Compiled a real binary locally with `bun build --compile`, placed a copy of `dist/` as its sibling, and confirmed `cliDistPath` now resolves to that real path and `services-config.json.template` is found there (previously: `Missing services config /$bunfs/...`).
- Not able to test the actual Docker build path end-to-end locally (no Docker in this environment) - that's what the downstream action PRs' CI will confirm once this merges and a new release is cut.

## Downstream impact

`unity-activate`'s and `unity-builder`'s `download-cli.ts` need matching changes (download+extract the new archive instead of a bare binary) - included in their respective PRs, gated on this one merging + a new release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Release packages now include the required static assets alongside each platform-specific executable.
  * Downloads are provided in platform-appropriate archive formats for Unix and Windows systems.
  * Packaged command-line builds now locate their bundled assets correctly when launched.
  * Release verification has been updated to validate the generated platform packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->