### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "GameCI CLI - automation for game engines",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Version bump ahead of cutting a v0.1.2 release with the compiled-binary dist-path fix (#73), which unity-activate/unity-builder's thin wrappers (currently on `cliVersion: latest`) depend on to actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)