### PR TITLE
fix: buildMethod must default to empty, not the built-in class name

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14247,7 +14247,7 @@ import * as path from "node:path";
 import * as process2 from "node:process";
 import { Buffer as Buffer2 } from "node:buffer";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-var semver, import_dotenv, __filename2, __dirname3, base64, fsSyncCompat, getHomeDir = () => {
+var semver, import_dotenv, isCompiledBinary, __filename2, __dirname3, base64, fsSyncCompat, getHomeDir = () => {
   return process2.env.HOME || process2.env.USERPROFILE || null;
 };
 var init_dependencies = __esm(() => {
@@ -14260,7 +14260,8 @@ var init_dependencies = __esm(() => {
   import_dotenv = __toESM(require_main(), 1);
   String.dedent = dedent;
   Error.stackTraceLimit = 15;
-  __filename2 = fileURLToPath2(import.meta.url);
+  isCompiledBinary = !path.basename(process2.execPath).toLowerCase().startsWith("bun");
+  __filename2 = isCompiledBinary ? process2.execPath : fileURLToPath2(import.meta.url);
   __dirname3 = path.dirname(__filename2);
   base64 = {
     encode: (data) => Buffer2.from(data).toString("base64"),
@@ -17389,10 +17390,13 @@ class BuildOptions {
       argv.buildFile = UnityTargetPlatform.determineBuildFileName(resolvedBuildName, targetPlatform, resolvedAndroidExportType, Boolean(linux64RemoveExecutableExtension));
     }).option("buildMethod", {
       alias: "m",
-      description: "Build method to use",
+      description: String.dedent`Build method to use, in <Namespace.Class.StaticMethod> form. Leave unset to use
+        the built-in UnityBuilderAction.Builder.BuildProject method, which builds the scenes enabled in the
+        project - the platform entrypoint scripts only copy that built-in build script into the project when this
+        is empty (see game-ci/cli#75), so it must stay empty rather than defaulting to that class name here.`,
       type: "string",
       demandOption: false,
-      default: "UnityBuilderAction.Builder.BuildProject"
+      default: ""
     }).option("dockerWorkspacePath", {
       description: String.dedent`The path to mount the workspace inside the docker container. For windows, leave out the drive letter. For example
         c:/github/workspace should be defined as /github/workspace`,
@@ -18285,7 +18289,7 @@ class Cli {
     this.hostPlatform = process2.platform;
     this.hostOS = process2.platform === "win32" ? "windows" : process2.platform;
     this.cliPath = __dirname3;
-    this.cliDistPath = path.join(path.dirname(__dirname3), "dist");
+    this.cliDistPath = isCompiledBinary ? path.join(__dirname3, "dist") : path.join(path.dirname(__dirname3), "dist");
   }
   async setup() {
     await this.configureLogger();

--- a/src/command-options/build-options.test.ts
+++ b/src/command-options/build-options.test.ts
@@ -34,6 +34,27 @@ describe('BuildOptions', () => {
     expect(argv.buildFile).toBe('StandaloneLinux64');
   });
 
+  it('defaults buildMethod to empty, not the built-in class name', async () => {
+    // Real bug, caught by live CI (game-ci/cli#75): the platform entrypoint
+    // scripts (build.sh/build.ps1) only copy the built-in
+    // UnityBuilderAction.Builder.BuildProject script into the project when
+    // BUILD_METHOD is empty. If cli defaulted buildMethod to that class
+    // name itself, the copy step never ran and Unity failed with
+    // "executeMethod class 'Builder' could not be found" - the class name
+    // was passed, but the .cs file backing it was never actually copied in.
+    const parser = yargs(['--targetPlatform', 'StandaloneLinux64'])
+      .exitProcess(false)
+      .fail((message, error) => {
+        throw error || new Error(message);
+      });
+
+    BuildOptions.configure(parser);
+
+    const argv = await parser.parseAsync();
+
+    expect(argv.buildMethod).toBe('');
+  });
+
   it('uses android export type when deriving Android buildFile', async () => {
     const parser = yargs([
       '--targetPlatform',

--- a/src/command-options/build-options.ts
+++ b/src/command-options/build-options.ts
@@ -56,10 +56,13 @@ export class BuildOptions implements IOptions {
       })
       .option('buildMethod', {
         alias: 'm',
-        description: 'Build method to use',
+        description: String.dedent`Build method to use, in <Namespace.Class.StaticMethod> form. Leave unset to use
+        the built-in UnityBuilderAction.Builder.BuildProject method, which builds the scenes enabled in the
+        project - the platform entrypoint scripts only copy that built-in build script into the project when this
+        is empty (see game-ci/cli#75), so it must stay empty rather than defaulting to that class name here.`,
         type: 'string',
         demandOption: false,
-        default: 'UnityBuilderAction.Builder.BuildProject',
+        default: '',
       })
       .option('dockerWorkspacePath', {
         description: String.dedent`The path to mount the workspace inside the docker container. For windows, leave out the drive letter. For example


### PR DESCRIPTION
## The actual root cause

`unity-builder`'s new thin-wrapper PR (#844) has been failing every real Docker build in CI with `Aborting batchmode due to failure: executeMethod class 'Builder' could not be found`. I'd initially assumed this was the chronic Unity license "Access token unavailable" flakiness this org has hit before - it isn't. Traced the actual logs: that message self-recovers 2 seconds later (`Successfully updated license`, serial assigned) and is a red herring. The real failure is a genuine bug in `BuildOptions`.

All three platform entrypoint scripts (`build.sh` for ubuntu/mac, `build.ps1` for windows) only copy the built-in `UnityBuilderAction.Builder.BuildProject` script into the project when `BUILD_METHOD` is empty:

```bash
if [ -z "$BUILD_METHOD" ]; then
  cp -R "/UnityBuilderAction/Assets/Editor/" "$UNITY_PROJECT_PATH/Assets/Editor/"
  BUILD_METHOD="UnityBuilderAction.Builder.BuildProject"
fi
```

`BuildOptions.buildMethod` defaulted to that exact class name itself, so `BUILD_METHOD` was never empty and the copy step never ran - Unity was asked to `-executeMethod` a class whose `.cs` file was never actually placed in the project.

## Confirming this isn't unity-builder's fault, or the #73 fix

- The `linux-x64` release archive does contain `Builder.cs` at the expected `default-build-script` path.
- Docker's volume mount for it resolves correctly post-#73 (confirmed via the same log: the container starts, project loads, activation succeeds - the mount itself works).
- The original `unity-builder` action's own `Input.buildMethod` getter defaults to `''` with the comment `// Processed in docker file` - confirming this was always meant to be an empty-string sentinel that downstream scripts interpret, not a real default value to send through.

## Fix

`buildMethod` now defaults to `''`, matching the original semantics. Added a regression test.

## Testing

- `bun test` - 144 pass (up from 143).
- `bun run build` - succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)