### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "GameCI CLI - automation for game engines",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Version bump ahead of cutting a v0.1.3 release with the buildMethod default fix (#75), which fixes the actual root cause of unity-builder's live CI failures (Unity couldn't find the built-in Builder.cs class because the copy-into-project step was silently skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)