### PR TITLE
fix: activate defaulted to a build target platform, and errors printed as {}

### DIFF
--- a/src/command/activate/activate-command.test.ts
+++ b/src/command/activate/activate-command.test.ts
@@ -4,6 +4,7 @@ import { Docker } from '../../model/index.ts';
 import { MacBuilder } from '../../model/mac-builder.ts';
 import { PlatformSetup } from '../../logic/unity/platform-setup/index.ts';
 import { PlatformValidation } from '../../logic/unity/platform-validation/platform-validation.ts';
+import { yargs } from '../../dependencies.ts';
 
 const originalDockerRun = Docker.run;
 const originalMacBuilderRun = MacBuilder.run;
@@ -61,5 +62,37 @@ describe('ActivateCommand', () => {
     await command.execute(baseOptions);
 
     expect(baseOptions.activateOnly).toBeUndefined();
+  });
+
+  it('defaults targetPlatform to NoTarget, not the build-oriented StandaloneWindows64 default', async () => {
+    // Real bug (game-ci/unity-activate#111 thin-wrapper CI): `game-ci
+    // activate <path>` with no --target-platform inherited UnityOptions'
+    // build default of StandaloneWindows64, which threw "Windows-based
+    // builds are only supported on 2019.3.X+" for older Unity versions even
+    // though activation doesn't build anything. NoTarget maps to the
+    // generic image and skips that check entirely.
+    const parser = yargs([]).exitProcess(false).fail((message, error) => {
+      throw error || new Error(message);
+    });
+
+    const command = new ActivateCommand('activate');
+    await command.configureOptions(parser as any);
+
+    const argv = await parser.parseAsync();
+
+    expect(argv.targetPlatform).toBe('NoTarget');
+  });
+
+  it('still honors an explicitly passed targetPlatform', async () => {
+    const parser = yargs(['--targetPlatform', 'StandaloneLinux64']).exitProcess(false).fail((message, error) => {
+      throw error || new Error(message);
+    });
+
+    const command = new ActivateCommand('activate');
+    await command.configureOptions(parser as any);
+
+    const argv = await parser.parseAsync();
+
+    expect(argv.targetPlatform).toBe('StandaloneLinux64');
   });
 });

--- a/src/command/activate/activate-command.ts
+++ b/src/command/activate/activate-command.ts
@@ -7,6 +7,7 @@ import { UnityOptions } from '../../command-options/unity-options.ts';
 import type { YargsInstance, Options } from '../../dependencies.ts';
 import { PlatformValidation } from '../../logic/unity/platform-validation/platform-validation.ts';
 import { ProjectOptions } from '../../command-options/project-options.ts';
+import { UnityTargetPlatform } from '../../model/unity/target-platform/unity-target-platform.ts';
 
 /**
  * Activates (and only activates) a Unity license, leaving it active for a
@@ -44,6 +45,15 @@ export class ActivateCommand extends CommandBase implements CommandInterface {
   public async configureOptions(yargs: YargsInstance): Promise<void> {
     await ProjectOptions.configure(yargs);
     await UnityOptions.configure(yargs);
+    // UnityOptions.configure() defaults targetPlatform to StandaloneWindows64
+    // (a build-oriented default). Activation doesn't build anything - it
+    // just needs *an* editor image to run license activation inside - so
+    // override the default to NoTarget, which RunnerImageTag maps to the
+    // generic image and skips build-target validation entirely (e.g. the
+    // "Windows builds need 2019.3+" check, which has nothing to do with
+    // activating a license). Callers can still pass --target-platform
+    // explicitly if they have a reason to.
+    yargs.option('targetPlatform', { default: UnityTargetPlatform.NoTarget });
     // Needed by Docker.run() for the container mount path - normally comes
     // from BuildOptions, but `activate` intentionally doesn't pull in
     // BuildOptions' build-specific flags (buildName, buildMethod, etc.),

--- a/src/core/logger/index.test.ts
+++ b/src/core/logger/index.test.ts
@@ -61,3 +61,31 @@ describe('logger groups', () => {
     expect(result).toBe(42);
   });
 });
+
+describe('logger error formatting', () => {
+  const originalConsoleError = console.error;
+  let errorLines: string[] = [];
+
+  beforeEach(async () => {
+    errorLines = [];
+    console.error = mock((...args: any[]) => {
+      errorLines.push(args.join(' '));
+    });
+    await configureLogger(Verbosity.normal);
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+  });
+
+  it('prints an Error object\'s message and stack, not "{}"', () => {
+    // Real bug: Error's message/stack/name are non-enumerable own
+    // properties, so JSON.stringify(error) - the previous fallback for any
+    // non-string value - silently produced '{}', masking every uncaught
+    // failure's actual message (see game-ci/unity-activate#111).
+    (globalThis as any).log.error(new Error('something specific broke'));
+
+    expect(errorLines.some((line) => line.includes('something specific broke'))).toBe(true);
+    expect(errorLines.some((line) => line.trim() === '[ERROR] {}')).toBe(false);
+  });
+});

--- a/src/core/logger/index.ts
+++ b/src/core/logger/index.ts
@@ -48,6 +48,13 @@ export const configureLogger = async (verbosity: Verbosity) => {
     if (value === undefined) return 'undefined';
     if (value === null) return 'null';
     if (typeof value === 'string') return value;
+    // Error's message/stack/name are non-enumerable own properties, so
+    // JSON.stringify(error) below silently produces '{}' for any bare Error
+    // - masking every uncaught failure's actual message. Must be handled
+    // before the JSON.stringify fallback, not caught by it.
+    if (value instanceof Error) {
+      return value.stack || `${value.name}: ${value.message}`;
+    }
     try {
       return JSON.stringify(value, null, 2);
     } catch {


### PR DESCRIPTION
Found and fixed while investigating why [unity-activate#111](https://github.com/game-ci/unity-activate/pull/111)'s thin-wrapper CI was failing on every job.

## Two real bugs

**1. `activate` inherited a build-oriented `targetPlatform` default.**

`ActivateCommand.configureOptions()` calls `UnityOptions.configure()`, which defaults `targetPlatform` to `StandaloneWindows64` — a sensible default for `build`, meaningless for `activate` (which doesn't build anything, just needs *an* editor image to run activation inside). A bare `game-ci activate <path>` — exactly what unity-activate's thin wrapper calls, with no `--target-platform` flag — hit `RunnerImageTag`'s Windows/il2cpp version gate and threw:

```
Windows-based builds are only supported on 2019.3.X+ versions of Unity.
```

...for any older Unity version, on every host. `NoTarget` already exists and maps to the generic image, skipping that check entirely — it's what `unity-engine-core`'s extracted activate logic uses for exactly this case. `activate` now defaults to it; an explicit `--target-platform` still overrides.

**2. `log.error()` printed `[ERROR] {}` for any bare `Error`.**

This is what made bug #1 nearly impossible to see from CI logs. `inspect()`'s fallback for non-string values is `JSON.stringify(value)` — but `Error`'s `message`/`stack`/`name` are non-enumerable own properties, so `JSON.stringify(new Error('anything'))` is always `'{}'`. Every uncaught error in the CLI — not just this one — was printing as a useless empty object. `Error` instances are now special-cased to print their stack.

## How I found it

Reproduced locally: `bun run src/index.ts activate <path-to-a-fake-2019.2.14f1-project>` on a fresh git repo reproduced the exact `[ERROR] {}` from CI. Fixing bug #2 first turned that into the real message (bug #1), which then explained every failing job in unity-activate#111 (all older Unity versions — the "Tests" job, which doesn't shell out to a real Unity version, was the only one that passed).

## Testing

- New test: `activate-command.test.ts` — `configureOptions()` defaults `targetPlatform` to `NoTarget`, and still honors an explicit `--target-platform`.
- New test: `logger/index.test.ts` — `log.error(new Error(...))` prints the message, not `{}`.
- `bun run test` — 147 pass, 3 skip, 0 fail (144 pass, 3 skip before this PR — 3 new tests, no regressions).
- Manually verified locally past both bugs: `activate` now reaches the real `docker run` invocation (fails only because Docker isn't installed in my sandbox, which is expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)