### PR TITLE
feat: add dockerShmSize option to raise Docker's /dev/shm limit

### DIFF
--- a/src/command-options/build-options.ts
+++ b/src/command-options/build-options.ts
@@ -144,6 +144,15 @@ export class BuildOptions implements IOptions {
         demandOption: false,
         default: defaultDockerMemoryLimit(),
       })
+      .option('dockerShmSize', {
+        description: String.dedent`Size of /dev/shm to assign the docker container, using the format <number><unit>
+        (m or g). Unity 6.6 beta / 6.7 alpha editors have been reported to fail with "Insufficient shared memory
+        available" against Docker's 64m default (see game-ci/unity-test-runner#307); leave unset to use Docker's
+        own default on older/stable editors that don't need it.`,
+        type: 'string',
+        demandOption: false,
+        default: '',
+      })
       .option('dockerIsolationMode', {
         description: String.dedent`Windows only. Isolation mode to use for the docker container. Can be one of
         process, hyperv, or default. Default will pick the default mode as described by Microsoft where server

--- a/src/model/docker.test.ts
+++ b/src/model/docker.test.ts
@@ -81,12 +81,29 @@ describe('Docker', () => {
       engine: 'unity',
       dockerCpuLimit: '4',
       dockerMemoryLimit: '8192m',
+      dockerShmSize: '1024m',
       useHostNetwork: true,
     });
 
     expect(command).toContain('--cpus=4');
     expect(command).toContain('--memory=8192m');
+    expect(command).toContain('--shm-size=1024m');
     expect(command).toContain('--net=host');
+  });
+
+  it('omits --shm-size when dockerShmSize is not set (game-ci/unity-test-runner#307)', () => {
+    const command = (Docker as any).getLinuxCommand('game-ci/unity-editor-stub:latest', {
+      hostOS: 'linux',
+      currentWorkDir: '/home/runner/work/cli/cli',
+      homeDir: '/home/runner',
+      cliDistPath: '/home/runner/work/cli/cli/dist',
+      sshAgent: '',
+      gitPrivateToken: '',
+      dockerWorkspacePath: '/github/workspace',
+      engine: 'unity',
+    });
+
+    expect(command).not.toContain('--shm-size');
   });
 
   it('mounts a custom SSH public keys directory instead of the known_hosts fallback', () => {
@@ -134,11 +151,13 @@ describe('Docker', () => {
       engine: 'unity',
       dockerCpuLimit: '4',
       dockerMemoryLimit: '8192m',
+      dockerShmSize: '1024m',
       dockerIsolationMode: 'process',
     });
 
     expect(command).toContain('--cpus=4');
     expect(command).toContain('--memory=8192m');
+    expect(command).toContain('--shm-size=1024m');
     expect(command).toContain('--isolation=process');
   });
 

--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -75,6 +75,7 @@ class Docker {
       useHostNetwork,
       dockerCpuLimit,
       dockerMemoryLimit,
+      dockerShmSize,
     } = options as Options & { commands?: string };
 
     const home = homeDir;
@@ -98,6 +99,7 @@ class Docker {
       sshAgent ? '--env SSH_AUTH_SOCK=/ssh-agent' : '',
       dockerCpuLimit ? `--cpus=${dockerCpuLimit}` : '',
       dockerMemoryLimit ? `--memory=${dockerMemoryLimit}` : '',
+      dockerShmSize ? `--shm-size=${dockerShmSize}` : '',
       useHostNetwork ? '--net=host' : '',
       `--volume "${home}":"/root:z"`,
       `--volume "${currentWorkDir}":"${dockerWorkspacePath}:z"`,
@@ -128,6 +130,7 @@ class Docker {
       engine,
       dockerCpuLimit,
       dockerMemoryLimit,
+      dockerShmSize,
       dockerIsolationMode,
     } = options as Options & { commands?: string };
 
@@ -150,6 +153,7 @@ class Docker {
       `  --env GIT_PRIVATE_TOKEN="${gitPrivateToken}" \``,
       dockerCpuLimit ? `  --cpus=${dockerCpuLimit} \`` : '',
       dockerMemoryLimit ? `  --memory=${dockerMemoryLimit} \`` : '',
+      dockerShmSize ? `  --shm-size=${dockerShmSize} \`` : '',
       dockerIsolationMode ? `  --isolation=${dockerIsolationMode} \`` : '',
       `  --volume="${currentWorkDir}":"c:${dockerWorkspacePath}" \``,
       isUnityDefaultFlow ? `  --volume="${cliStoragePath}/registry-keys":"c:/registry-keys" \`` : '',


### PR DESCRIPTION
Brings the fix from [unity-test-runner#308](https://github.com/game-ci/unity-test-runner/pull/308) (mob-sakai) into the CLI, since build/test logic now lives here rather than in the action repos directly.

## What

Unity 6.6 beta / 6.7 alpha editors have been reported to fail against Docker's 64MB default `/dev/shm`:

```
Error: Requested 1073741824 bytes, but only 67108864 bytes available
Error: Insufficient shared memory available - if using Docker, please run the container with --shm-size=1025M
```

Adds a `dockerShmSize` option (empty/unset by default — matches Docker's own default and doesn't change behavior for editors that don't need it), following the exact pattern of the existing `dockerCpuLimit`/`dockerMemoryLimit` options. Wired into both the Linux and Windows `docker run` command builders in `Docker`.

## Why not port the original PR's unconditional `--shm-size=1025m`

The original fix hardcoded `--shm-size=1025m` on every run. Making it an opt-in flag (`--docker-shm-size 1025m`) instead avoids silently changing resource allocation for every user on every Unity version, while still giving people hitting this specific error (older/beta editors) a documented way to fix it — same shape as the other Docker resource options already here.

## Testing

- New tests in `docker.test.ts`: `--shm-size` appears on both Linux and Windows commands when `dockerShmSize` is set, and is omitted entirely when unset.
- `bun run test` — 148 pass, 3 skip, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)