### PR TITLE
fix: NoTarget resolved to a Docker tag unityci/editor never publishes

### DIFF
--- a/src/model/unity/runner/runner-image-tag.test.ts
+++ b/src/model/unity/runner/runner-image-tag.test.ts
@@ -91,7 +91,11 @@ describe('RunnerImageTag', () => {
       }
     });
 
-    it('returns no specific build platform for generic targetPlatforms', () => {
+    // Real bug (game-ci/unity-activate#111): this used to resolve to an
+    // empty suffix, producing "ubuntu-2019.2.11f1-3" - a tag unityci/editor
+    // never publishes ("manifest unknown" on docker pull). NoTarget/generic
+    // now resolves to the same 'base' image StandaloneLinux64 uses.
+    it("resolves generic targetPlatforms to the 'base' image, not an empty suffix", () => {
       const image = new RunnerImageTag({
         targetPlatform: 'NoTarget',
         hostPlatform: process.platform,
@@ -99,10 +103,10 @@ describe('RunnerImageTag', () => {
 
       switch (process.platform) {
         case 'win32':
-          expect(image.toString()).toStrictEqual(`${defaults.image}:windows-2019.2.11f1-3`);
+          expect(image.toString()).toStrictEqual(`${defaults.image}:windows-2019.2.11f1-base-3`);
           break;
         case 'linux':
-          expect(image.toString()).toStrictEqual(`${defaults.image}:ubuntu-2019.2.11f1-3`);
+          expect(image.toString()).toStrictEqual(`${defaults.image}:ubuntu-2019.2.11f1-base-3`);
           break;
       }
     });

--- a/src/model/unity/runner/runner-image-tag.ts
+++ b/src/model/unity/runner/runner-image-tag.ts
@@ -54,7 +54,17 @@ class RunnerImageTag {
 
   static get targetPlatformSuffixes() {
     return {
+      // Used only by the internal 'Test' targetPlatform (unit-test
+      // scaffolding, never a real Docker pull) - kept as-is.
       generic: '',
+      // unityci/editor never publishes a bare "ubuntu-<version>-<n>" tag -
+      // every real image has a module suffix. 'base' is the same image
+      // StandaloneLinux64 (pre-il2cpp) resolves to, and is what NoTarget
+      // actually needs: an editor image, not tied to any build target.
+      // Found via unity-activate#111's thin-wrapper CI: `game-ci activate`
+      // (which defaults targetPlatform to NoTarget, see #79) tried to pull
+      // "unityci/editor:ubuntu-2019.2.17f1-3" - manifest unknown.
+      noTarget: 'base',
       webgl: 'webgl',
       mac: 'mac-mono',
       windows: 'windows-mono',
@@ -82,8 +92,21 @@ class RunnerImageTag {
 
   static getTargetPlatformToTargetPlatformSuffixMap(hostPlatform: string, targetPlatform: string, version: string) {
     log.info(hostPlatform, targetPlatform, version);
-    const { generic, webgl, mac, windows, windowsIl2cpp, wsaPlayer, linux, linuxIl2cpp, android, ios, tvos, facebook } =
-      RunnerImageTag.targetPlatformSuffixes;
+    const {
+      generic,
+      noTarget,
+      webgl,
+      mac,
+      windows,
+      windowsIl2cpp,
+      wsaPlayer,
+      linux,
+      linuxIl2cpp,
+      android,
+      ios,
+      tvos,
+      facebook,
+    } = RunnerImageTag.targetPlatformSuffixes;
 
     const [major, minor] = version.split('.').map(Number);
 
@@ -148,7 +171,7 @@ class RunnerImageTag {
       case UnityTargetPlatform.Facebook:
         return facebook;
       case UnityTargetPlatform.NoTarget:
-        return generic;
+        return noTarget;
 
       // Test specific
       case UnityTargetPlatform.Test:


### PR DESCRIPTION
Third bug in the same chain as #79, found by actually re-running unity-activate#111's CI against the new v0.1.4 release.

## The bug

`RunnerImageTag.targetPlatformSuffixes.generic` was `''`. Both `NoTarget` and the internal `Test` targetPlatform resolved through it, producing tags like `unityci/editor:ubuntu-2019.2.17f1-3`. Every real `unityci/editor` image has a module suffix (`base`, `webgl`, `android`, `windows-mono`, etc.) — this tag has never existed, so `docker pull` failed with `manifest unknown` on every single job.

```
Unable to find image 'unityci/editor:ubuntu-2019.2.17f1-3' locally
docker: Error response from daemon: manifest for unityci/editor:ubuntu-2019.2.17f1-3 not found: manifest unknown: manifest unknown
```

## The fix

`NoTarget` now resolves to `'base'` — the same image `StandaloneLinux64` (pre-il2cpp) already uses. That's the right image for "just give me an editor, not tied to any build target," which is exactly what `activate` needs.

Split into its own `noTarget` suffix key rather than just fixing `generic` in place, because `Test` (unit-test scaffolding, never a real Docker pull) also went through `generic` — changing that value broke several existing test assertions that don't care about real Docker Hub tags. `Test` keeps the old empty-suffix behavior; only `NoTarget` changes.

## How I found it

Re-ran unity-activate#111's CI once v0.1.4 (with #79's fixes) was published. #79 got it past engine detection and the target-platform validation; this is what showed up next.

## Testing

- Updated `runner-image-tag.test.ts`'s existing `NoTarget` test, which had codified the buggy `ubuntu-2019.2.11f1-3` tag as expected output — now asserts `ubuntu-2019.2.11f1-base-3` / `windows-2019.2.11f1-base-3`.
- `bun run test` — 147 pass, 3 skip, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)