### PR TITLE
chore: bump version to 0.1.5 for the NoTarget image-tag and shm-size fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "GameCI CLI - automation for game engines",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Prerequisite for cutting a release with #81 and #82 so `cliVersion: latest` picks them up (unity-activate#111 is still blocked on the NoTarget tag fix from #82).