### PR TITLE
chore: bump version to 0.1.6 for the System.run stderr-vs-exit-code fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "GameCI CLI - automation for game engines",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Prerequisite for cutting a release with #84 so `cliVersion: latest` picks it up — hopefully the last blocker in the unity-activate#111 chain (#79 → #81/#82 → #84).