### PR TITLE
fix: activate-only runs failed build-output validation

### DIFF
--- a/src/model/docker.test.ts
+++ b/src/model/docker.test.ts
@@ -1,7 +1,61 @@
+import { describe, it, expect, mock, afterEach } from 'bun:test';
 import { Action } from './action.ts';
 import { Docker } from './docker.ts';
+import { System } from './system/system.ts';
+import { UnityBuildValidation } from './unity/build-validation/unity-build-validation.ts';
 
 describe('Docker', () => {
+  const originalSystemRun = System.run;
+  const originalValidateBuild = UnityBuildValidation.validateBuild;
+
+  afterEach(() => {
+    System.run = originalSystemRun;
+    UnityBuildValidation.validateBuild = originalValidateBuild;
+  });
+
+  it('skips build-output validation for activate-only runs (game-ci/unity-activate#111)', async () => {
+    // Real bug: validateBuild() requires a "# Build results #" section,
+    // which only a real build ever produces - it threw on every successful
+    // activation, since there's nothing to build.
+    System.run = mock(() => Promise.resolve({ output: 'Activation complete.', error: '' }));
+    const validateBuildMock = mock(() => {});
+    UnityBuildValidation.validateBuild = validateBuildMock;
+
+    await Docker.run('game-ci/unity-editor-stub:latest', {
+      hostOS: 'linux',
+      hostPlatform: 'linux',
+      currentWorkDir: '/home/runner/work/cli/cli',
+      homeDir: '/home/runner',
+      cliDistPath: '/home/runner/work/cli/cli/dist',
+      sshAgent: '',
+      gitPrivateToken: '',
+      dockerWorkspacePath: '/github/workspace',
+      engine: 'unity',
+      activateOnly: true,
+    } as any);
+
+    expect(validateBuildMock).not.toHaveBeenCalled();
+  });
+
+  it('still validates build output for real (non-activate-only) builds', async () => {
+    System.run = mock(() => Promise.resolve({ output: '# Build results #\nErrors: 0\nSize:', error: '' }));
+    const validateBuildMock = mock(() => {});
+    UnityBuildValidation.validateBuild = validateBuildMock;
+
+    await Docker.run('game-ci/unity-editor-stub:latest', {
+      hostOS: 'linux',
+      hostPlatform: 'linux',
+      currentWorkDir: '/home/runner/work/cli/cli',
+      homeDir: '/home/runner',
+      cliDistPath: '/home/runner/work/cli/cli/dist',
+      sshAgent: '',
+      gitPrivateToken: '',
+      dockerWorkspacePath: '/github/workspace',
+      engine: 'unity',
+    } as any);
+
+    expect(validateBuildMock).toHaveBeenCalled();
+  });
   it('builds a continuous Linux docker command', () => {
     const command = (Docker as any).getLinuxCommand('game-ci/unity-editor-stub:latest', {
       hostOS: 'linux',

--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -12,7 +12,7 @@ function engineEnvVars(options: Options) {
 
 class Docker {
   static async run(image: string, options: Options) {
-    const { hostPlatform, hostOS, engine } = options;
+    const { hostPlatform, hostOS, engine, activateOnly } = options;
 
     log.warning(`running docker process for ${hostOS} (${hostPlatform})`);
 
@@ -35,9 +35,16 @@ class Docker {
 
       const dockerRun = await System.run(command);
 
+      // Real bug (game-ci/unity-activate#111): validateBuild() requires a
+      // "# Build results #" section, which only ever appears after a real
+      // build. An activate-only run never produces one - it was throwing
+      // "There was an error building the project" on every successful
+      // activation, because there's no build to validate in the first place.
       switch (engine) {
         case 'unity':
-          UnityBuildValidation.validateBuild(dockerRun.output);
+          if (!activateOnly) {
+            UnityBuildValidation.validateBuild(dockerRun.output);
+          }
           break;
       }
     } catch (error: any) {


### PR DESCRIPTION
Fifth bug in the same chain as #79/#81/#82/#84, found by re-running unity-activate#111's CI against v0.1.6.

## The bug

`Docker.run()` unconditionally calls `UnityBuildValidation.validateBuild(dockerRun.output)` for the `unity` engine. That method requires a `# Build results #` section in the output — something only a real `build` ever produces — and throws `There was an error building the project` if it's missing.

Every `activate`-only run (`activateOnly: true`) hit this, right after activation itself genuinely succeeded:

```
Requesting activation (personal license)
Activation complete.
[ERROR] Error: There was an error building the project. Please read the logs for details.
```

There's nothing to validate — `activate` never builds anything.

## The fix

Skip `validateBuild` when `options.activateOnly` is set.

## How I found it

v0.1.6 (with #84) got unity-activate#111 past the last silent-failure bug (System.run swallowing a successful run). This is what showed up immediately after — activation itself worked, the CLI just failed it anyway afterward.

## Testing

- New tests in `docker.test.ts`: `validateBuild` is skipped for `activateOnly: true`, still runs for real builds.
- `bun run test` — 153 pass, 3 skip, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)