### PR TITLE
chore: bump version to 0.1.7 for the activate build-validation skip fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "GameCI CLI - automation for game engines",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Prerequisite for cutting a release with #86 so `cliVersion: latest` picks it up — this should finally get unity-activate#111's CI green.