### PR TITLE
fix: Windows platform scripts hardcoded the wrong Unity install path

### DIFF
--- a/dist/platforms/windows/activate.ps1
+++ b/dist/platforms/windows/activate.ps1
@@ -8,7 +8,8 @@ if ($env:UNITY_LICENSING_SERVER) {
   #
   Write-Host "Adding licensing server config"
 
-  & "C:\Program Files\Unity\Hub\Editor\$Env:UNITY_VERSION\Editor\Data\Resources\Licensing\Client\Unity.Licensing.Client.exe" --acquire-floating | Out-File -FilePath license.txt -Encoding UTF8 # Note: using Out-File instead of redirection
+  # See build.ps1 for why UNITY_PATH (game-ci/cli#77), not Hub's default install location.
+  & "$Env:UNITY_PATH\Editor\Data\Resources\Licensing\Client\Unity.Licensing.Client.exe" --acquire-floating | Out-File -FilePath license.txt -Encoding UTF8 # Note: using Out-File instead of redirection
 
   $PARSEDFILE = Select-String -Path license.txt -Pattern '\".*?\"' | ForEach-Object { $_.Matches.Value -replace '"' }
   $global:FLOATING_LICENSE = $($PARSEDFILE[1])
@@ -19,7 +20,7 @@ if ($env:UNITY_LICENSING_SERVER) {
   $global:UNITY_EXIT_CODE = $LASTEXITCODE
 }
 else {
-  & "C:\Program Files\Unity\Hub\Editor\$Env:UNITY_VERSION\Editor\Unity.exe" -batchmode -quit -nographics `
+  & "$Env:UNITY_PATH\Editor\Unity.exe" -batchmode -quit -nographics `
                                                                             -username $Env:UNITY_EMAIL `
                                                                             -password $Env:UNITY_PASSWORD `
                                                                             -serial $Env:UNITY_SERIAL `

--- a/dist/platforms/windows/build.ps1
+++ b/dist/platforms/windows/build.ps1
@@ -139,7 +139,12 @@ if ($Env:BUILD_PROFILE) {
   $BuildProfileArgs = @('-activeBuildProfile', $Env:BUILD_PROFILE)
 }
 
-& "C:\Program Files\Unity\Hub\Editor\$Env:UNITY_VERSION\Editor\Unity.exe" @QuitArgs -batchmode -nographics `
+# UNITY_PATH is baked into unityci/editor windows images at build time
+# (setx -M UNITY_PATH "C:/UnityEditor/$version" - see game-ci/docker's
+# images/windows/editor/Dockerfile). Unity Hub's default install location
+# ("C:\Program Files\Unity\Hub\Editor\<version>") is never used - these
+# images install to C:/UnityEditor instead (game-ci/cli#77).
+& "$Env:UNITY_PATH\Editor\Unity.exe" @QuitArgs -batchmode -nographics `
                                                                           -projectPath $Env:UNITY_PROJECT_PATH `
                                                                           -executeMethod $Env:BUILD_METHOD `
                                                                           @BuildTargetArgs `

--- a/dist/platforms/windows/install_llvmpipe.ps1
+++ b/dist/platforms/windows/install_llvmpipe.ps1
@@ -1,7 +1,8 @@
 $Private:repo = "mmozeiko/build-mesa"
 $Private:downloadPath = "$Env:TEMP\mesa.zip"
 $Private:extractPath = "$Env:TEMP\mesa"
-$Private:destinationPath = "C:\Program Files\Unity\Hub\Editor\$Env:UNITY_VERSION\Editor\"
+# See build.ps1 for why UNITY_PATH (game-ci/cli#77), not Hub's default install location.
+$Private:destinationPath = "$Env:UNITY_PATH\Editor\"
 $Private:version = "25.1.0"
 
 $LLVMPIPE_INSTALLED = "false"

--- a/dist/platforms/windows/return_license.ps1
+++ b/dist/platforms/windows/return_license.ps1
@@ -7,14 +7,17 @@ if ($env:UNITY_LICENSING_SERVER) {
   # Return any floating license used.
   #
   Write-Host "Returning floating license: `"$($global:FLOATING_LICENSE)`""
-  & 'C:\Program Files\Unity\Hub\Editor\$Env:UNITY_VERSION\Editor\Data\Resources\Licensing\Client\Unity.Licensing.Client.exe' --return-floating $global:FLOATING_LICENSE
+  # Was single-quoted, so $Env:UNITY_VERSION was never interpolated at all
+  # (literal text) on top of pointing at the wrong install location -
+  # see build.ps1 for why UNITY_PATH (game-ci/cli#77).
+  & "$Env:UNITY_PATH\Editor\Data\Resources\Licensing\Client\Unity.Licensing.Client.exe" --return-floating $global:FLOATING_LICENSE
 }
 else {
   # -projectPath points at the scratch activation directory, not the built
   # project, so Unity doesn't reopen the real project (and reimport its
   # library against whatever the editor's default target is) just to
   # return the license (game-ci/cli#33).
-  & "C:\Program Files\Unity\Hub\Editor\$Env:UNITY_VERSION\Editor\Unity.exe" -batchmode -quit -nographics `
+  & "$Env:UNITY_PATH\Editor\Unity.exe" -batchmode -quit -nographics `
                                                                             -username $Env:UNITY_EMAIL `
                                                                             -password $Env:UNITY_PASSWORD `
                                                                             -returnlicense `


### PR DESCRIPTION
Closes #77.

## Root cause

Confirmed by reading `game-ci/docker`'s actual Dockerfile (`images/windows/editor/Dockerfile`), not guessed: `unityci/editor` windows images install Unity via `Unity Hub.exe -- --headless install-path --set C:/UnityEditor`, then bake the result in as an env var: `setx -M UNITY_PATH "C:/UnityEditor/$version"`. Unity Hub's default install location, `C:\Program Files\Unity\Hub\Editor\<version>`, is **never used** by these images.

Every windows script in `dist/platforms/windows/` hardcoded that wrong default location:

```
& : The term 'C:\Program Files\Unity\Hub\Editor\2021.3.45f1\Editor\Unity.exe'
is not recognized as the name of a cmdlet, function, script file, or operable
program.
```

## Fix

Use `$Env:UNITY_PATH` (already present in the container's environment — no new env var needs to be set by the CLI) instead of the hardcoded path, in:
- `build.ps1` — the actual build invocation
- `activate.ps1` — both the floating-license-server branch and the personal/serial branch
- `return_license.ps1` — same two branches
- `install_llvmpipe.ps1` — Mesa llvmpipe driver install destination (`--enableGpu`)

## Bonus bug in the same file

`return_license.ps1`'s `UNITY_LICENSING_SERVER` branch had the path **single-quoted** (`'...'`), so `$Env:UNITY_VERSION` was never interpolated at all — literal text in the path — independent of which install location it pointed at. Fixed alongside the path itself.

## Testing

- `bun run test` — 153 pass, 3 skip, 0 fail (these are static `.ps1` assets with no existing unit coverage — verified by reading `game-ci/docker`'s Dockerfile directly and cross-checking every remaining `Program Files.*Unity` occurrence in `dist/platforms/windows/` is gone except my own explanatory comment).
- Not live-tested against a real Windows Docker container (not available in my environment) — the fix is grounded in the actual image build source, not speculation, but a maintainer with Windows Docker access re-running unity-builder#844's Windows jobs would be the real confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)