### PR TITLE
chore: bump version to 0.1.8 for the Windows Unity path fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "GameCI CLI - automation for game engines",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Prerequisite for cutting a release with #88 so `cliVersion: latest` picks it up — should unblock unity-builder#844's Windows jobs.