### PR TITLE
Propose: Unity integration ownership for @webbertakken/@GabLeRoux

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,9 +9,7 @@
 #
 # Paths NOT listed below are deliberately left unowned. Unowned paths
 # trigger no code-owner requirement at all, which is what keeps the
-# CLI core, Unity integration, and release workflows on a fast,
-# self-merge path for now. Ownership of those areas is proposed
-# separately, not assigned yet.
+# CLI core and release workflows on a fast, self-merge path for now.
 #
 # Last matching pattern wins, so order matters: broad patterns first,
 # specific exceptions after.
@@ -20,3 +18,42 @@
 # Orchestrator — brought in-repo from game-ci/orchestrator (now archived).
 # ---------------------------------------------------------------------
 /plugins/orchestrator/                              @frostebite
+
+# ---------------------------------------------------------------------
+# Unity integration — proposed here for @webbertakken/@GabLeRoux to
+# accept on their own terms. This PR is a draft and this ownership is
+# NOT yet in effect (still unowned on main) until it's reviewed and
+# merged deliberately, not unilaterally assigned.
+#
+# Rationale for the scope: Unity carries the licensing flows, the
+# Docker/platform entrypoint scripts, and the Android signing paths.
+# It's also the highest-blast-radius surface (nearly every user hits
+# it) and the hardest to validate locally, so changes here would get
+# a second reviewer.
+# ---------------------------------------------------------------------
+
+# Unity engine logic
+/src/logic/unity/                                   @webbertakken @GabLeRoux
+/src/model/unity/                                   @webbertakken @GabLeRoux
+/src/model/unity-*.ts                               @webbertakken @GabLeRoux
+/src/plugin/builtin/unity-plugin.ts                 @webbertakken @GabLeRoux
+/src/middleware/engine-detection/unity-version-detector.ts  @webbertakken @GabLeRoux
+
+# Unity-specific commands and options
+/src/command/activate/                              @webbertakken @GabLeRoux
+/src/command/**/unity-*.ts                          @webbertakken @GabLeRoux
+/src/command-options/unity-*.ts                     @webbertakken @GabLeRoux
+
+# Unity runtime assets: the in-container build/licensing scripts and the
+# default build script. These are only exercised inside a real Unity
+# container, so they are the least testable and most breakage-prone
+# files in the repo - see game-ci/cli#75 and game-ci/cli#77 for bugs
+# that lived exactly here.
+/dist/platforms/                                    @webbertakken @GabLeRoux
+/dist/default-build-script/                         @webbertakken @GabLeRoux
+/dist/unity-config/                                 @webbertakken @GabLeRoux
+/dist/BlankProject/                                 @webbertakken @GabLeRoux
+
+# plugins/unity/ (the archived unity-engine-core content, not yet wired
+# into src/'s shipping Unity plugin - see docs/architecture/plugin-interface.md)
+/plugins/unity/                                      @webbertakken @GabLeRoux


### PR DESCRIPTION
Draft — not for merging as-is. This proposes the same Unity-path ownership scope that was originally (and incorrectly) assigned unilaterally in #78, this time as an explicit proposal for you two to review and accept on your own terms rather than have it silently in effect. See [#90](https://github.com/game-ci/cli/pull/90) — that pulled the unilateral assignment back out; Unity paths are currently unowned on `main`.

## Scope being proposed

- `/src/logic/unity/`, `/src/model/unity/`, `/src/model/unity-*.ts`, `/src/plugin/builtin/unity-plugin.ts`, `/src/middleware/engine-detection/unity-version-detector.ts` — Unity engine logic
- `/src/command/activate/`, `/src/command/**/unity-*.ts`, `/src/command-options/unity-*.ts` — Unity-specific commands/options
- `/dist/platforms/`, `/dist/default-build-script/`, `/dist/unity-config/`, `/dist/BlankProject/` — the in-container build/licensing scripts, where [#75](https://github.com/game-ci/cli/issues/75) and [#77](https://github.com/game-ci/cli/issues/77) both lived
- `/plugins/unity/` — the archived unity-engine-core content (not yet wired into `src/`'s shipping plugin)

## Why this scope

Unity carries the licensing flows, the Docker/platform entrypoint scripts, and the Android signing paths — the highest-blast-radius surface in the repo (nearly every user hits it) and the hardest to validate locally. Two real bugs (#75, #77) have already lived exactly in this seam.

Orchestrator ownership (`@frostebite`, already merged in #90) is unaffected by this proposal either way.

Mark this ready for review (or just comment) whenever/however you'd like to respond — happy to adjust scope, add yourselves with different terms, or drop it entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)