### PR TITLE
fix: port --shm-size=1025m to unity-test-runner's extracted Docker logic

### DIFF
--- a/plugins/unity/dist/unity-test-runner/model/docker.js
+++ b/plugins/unity/dist/unity-test-runner/model/docker.js
@@ -58,6 +58,7 @@ const Docker = {
         const cidfile = containerIdFilePath(parameters);
         const testPlatforms = (testMode === 'all' ? ['playmode', 'editmode', 'COMBINE_RESULTS'] : [testMode]).join(';');
         return `docker run \
+            --shm-size=1025m \
             --workdir /github/workspace \
             --cidfile "${cidfile}" \
             --rm \
@@ -98,6 +99,7 @@ const Docker = {
             (0, fs_1.mkdirSync)(githubWorkflow);
         const testPlatforms = (testMode === 'all' ? ['playmode', 'editmode', 'COMBINE_RESULTS'] : [testMode]).join(';');
         return `docker run \
+                --shm-size=1025m \
                 --workdir c:/github/workspace \
                 --cidfile "${cidfile}" \
                 --rm \

--- a/plugins/unity/src/unity-test-runner/model/docker.ts
+++ b/plugins/unity/src/unity-test-runner/model/docker.ts
@@ -75,6 +75,7 @@ const Docker = {
     ).join(';');
 
     return `docker run \
+            --shm-size=1025m \
             --workdir /github/workspace \
             --cidfile "${cidfile}" \
             --rm \
@@ -133,6 +134,7 @@ const Docker = {
     ).join(';');
 
     return `docker run \
+                --shm-size=1025m \
                 --workdir c:/github/workspace \
                 --cidfile "${cidfile}" \
                 --rm \


### PR DESCRIPTION
`unity-test-runner#308` added `--shm-size=1025m` to both `docker run` commands to fix "Insufficient shared memory available" crashes on Unity 6.6 beta/6.7 alpha. That landed on `unity-test-runner`'s `main` *after* `plugins/unity/src/unity-test-runner/model/docker.ts` was extracted from it here (`unity-test-runner#310`, the thin-wrapper migration) — the extraction predates the fix and never picked it up.

Surfaced while resolving `unity-test-runner#310`'s merge conflict against its own `main`: that PR deleted the file the fix landed on, so merging main in wasn't enough — the fix needed porting to where the logic actually lives now.

Verified `typecheck`, `build` (zero unrelated `dist/` drift — only the two `--shm-size` lines changed), and `test` (443 pass, 5 skip, unchanged) all pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)