### PR TITLE
fix: retry transient docker-launch failures in unity-test-runner's extracted logic

### DIFF
--- a/plugins/unity/dist/unity-test-runner/model/docker.js
+++ b/plugins/unity/dist/unity-test-runner/model/docker.js
@@ -1,4 +1,37 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -7,6 +40,7 @@ const image_environment_factory_1 = __importDefault(require("./image-environment
 const fs_1 = require("fs");
 const licensing_server_setup_1 = __importDefault(require("./licensing-server-setup"));
 const exec_1 = require("@actions/exec");
+const core = __importStar(require("@actions/core"));
 const path_1 = __importDefault(require("path"));
 /**
  * Build a path for a docker --cidfile parameter. Docker will store the the created container.
@@ -27,8 +61,17 @@ const Docker = {
             return;
         }
         const container = (0, fs_1.readFileSync)(cidfile, 'ascii').trim();
-        await (0, exec_1.exec)(`docker`, ['rm', '--force', '--volumes', container], { silent: true });
-        (0, fs_1.rmSync)(cidfile);
+        try {
+            if (container !== '') {
+                await (0, exec_1.exec)(`docker`, ['rm', '--force', '--volumes', container], { silent: true });
+            }
+        }
+        finally {
+            // Always drop the cidfile, even if `docker rm` failed or there was nothing to
+            // remove (a docker run that failed before writing a container ID still creates
+            // the file - `--cidfile` refuses to run again while a stale file is present).
+            (0, fs_1.rmSync)(cidfile);
+        }
     },
     async run(image, parameters, silent = false) {
         let runCommand = '';
@@ -45,7 +88,34 @@ const Docker = {
             default:
                 throw new Error(`Operation system, ${process.platform}, is not supported yet.`);
         }
-        await (0, exec_1.exec)(runCommand, undefined, { silent });
+        // With a githubToken set, the container runs with USE_EXIT_CODE=false (see
+        // getLinuxCommand/getWindowsCommand) - test results are reported through GitHub
+        // Checks, not the process exit code, so in that mode a nonzero exit here can only
+        // mean the docker/container launch itself failed (e.g. the intermittent Windows
+        // runner "docker.exe failed with exit code 1" flake - unity-test-runner#314),
+        // never a real test failure. Retrying is only safe in that mode: without a token,
+        // USE_EXIT_CODE=true and a nonzero exit IS how test failures are signaled, so a
+        // retry there would silently re-run (and could mask) a real failure.
+        const launchFailuresAreRetryable = Boolean(parameters.githubToken);
+        const maxAttempts = launchFailuresAreRetryable ? 3 : 1;
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                await (0, exec_1.exec)(runCommand, undefined, { silent });
+                return;
+            }
+            catch (error) {
+                if (attempt === maxAttempts)
+                    throw error;
+                core.warning(`Docker run failed (attempt ${attempt}/${maxAttempts}): ${error instanceof Error ? error.message : String(error)}. Retrying...`);
+                try {
+                    await this.ensureContainerRemoval(parameters);
+                }
+                catch (cleanupError) {
+                    core.warning(`Cleanup before retry failed, continuing anyway: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`);
+                }
+                await new Promise((resolve) => setTimeout(resolve, 5000));
+            }
+        }
     },
     getLinuxCommand(image, parameters) {
         const { actionFolder, workspace, testMode, useHostNetwork, sshAgent, sshPublicKeysDirectoryPath, githubToken, runnerTemporaryPath, dockerCpuLimit, dockerMemoryLimit, } = parameters;

--- a/plugins/unity/src/unity-test-runner/model/docker.test.ts
+++ b/plugins/unity/src/unity-test-runner/model/docker.test.ts
@@ -1,17 +1,147 @@
-import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll, test } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import Action from './action';
-import Docker from './docker';
 
-describe('Docker', () => {
-  it.skip('runs', async () => {
-    const image = 'unity-builder:2022.3.7f1-webgl';
-    const parameters = {
-      workspace: Action.rootFolder,
-      projectPath: `${Action.rootFolder}/test-project`,
-      buildName: 'someBuildName',
-      buildsPath: 'build',
-      method: '',
-    };
-    await Docker.run(image, parameters);
+const execMock = vi.fn();
+vi.mock('@actions/exec', () => ({
+  exec: (...arguments_: unknown[]) => execMock(...arguments_),
+}));
+
+const fsState = { cidfileExists: false, cidfileContent: 'container-id' };
+vi.mock('fs', () => ({
+  existsSync: vi.fn(() => fsState.cidfileExists),
+  mkdirSync: vi.fn(),
+  readFileSync: vi.fn(() => fsState.cidfileContent),
+  rmSync: vi.fn(() => {
+    fsState.cidfileExists = false;
+  }),
+}));
+
+const { existsSync, mkdirSync, readFileSync, rmSync } = await import('fs');
+const Docker = (await import('./docker')).default;
+
+function buildParameters(overrides: Record<string, unknown> = {}) {
+  return {
+    workspace: Action.rootFolder,
+    actionFolder: Action.actionFolder,
+    projectPath: `${Action.rootFolder}/test-project`,
+    testMode: 'all',
+    useHostNetwork: false,
+    sshAgent: undefined,
+    sshPublicKeysDirectoryPath: undefined,
+    githubToken: undefined,
+    runnerTemporaryPath: '/tmp',
+    dockerCpuLimit: '2',
+    dockerMemoryLimit: '4g',
+    dockerIsolationMode: 'process',
+    unityLicensingServer: '',
+    githubAction: 'test-action',
+    ...overrides,
+  };
+}
+
+describe('Docker.run retry behavior', () => {
+  beforeEach(() => {
+    execMock.mockReset();
+    fsState.cidfileExists = false;
+    fsState.cidfileContent = 'container-id';
+    vi.mocked(existsSync).mockClear();
+    vi.mocked(mkdirSync).mockClear();
+    vi.mocked(readFileSync).mockClear();
+    vi.mocked(rmSync).mockClear();
+    vi.stubGlobal(
+      'setTimeout',
+      ((fn: () => void) => {
+        fn();
+        return 0;
+      }) as unknown as typeof setTimeout,
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('retries a launch failure when a githubToken is set (USE_EXIT_CODE=false, exit code cannot mean a test failure)', async () => {
+    execMock
+      .mockRejectedValueOnce(new Error('docker.exe failed with exit code 1'))
+      .mockRejectedValueOnce(new Error('docker.exe failed with exit code 1'))
+      .mockResolvedValueOnce(0);
+
+    await Docker.run('some-image', buildParameters({ githubToken: 'gh-token' }));
+
+    expect(execMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('gives up after exhausting retries when a githubToken is set', async () => {
+    execMock.mockRejectedValue(new Error('docker.exe failed with exit code 1'));
+
+    await expect(
+      Docker.run('some-image', buildParameters({ githubToken: 'gh-token' })),
+    ).rejects.toThrow('docker.exe failed with exit code 1');
+
+    expect(execMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry when no githubToken is set (a nonzero exit there means a real test failure)', async () => {
+    execMock.mockRejectedValue(new Error('tests failed'));
+
+    await expect(
+      Docker.run('some-image', buildParameters({ githubToken: undefined })),
+    ).rejects.toThrow('tests failed');
+
+    expect(execMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up a stale cidfile between retry attempts so --cidfile does not immediately fail again', async () => {
+    fsState.cidfileExists = true;
+    execMock
+      .mockRejectedValueOnce(new Error('docker.exe failed with exit code 1'))
+      .mockResolvedValueOnce(0);
+
+    await Docker.run('some-image', buildParameters({ githubToken: 'gh-token' }));
+
+    // ensureContainerRemoval should have run docker rm and dropped the cidfile
+    expect(execMock).toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining(['rm', '--force', '--volumes', 'container-id']),
+      expect.anything(),
+    );
+    expect(rmSync).toHaveBeenCalled();
+  });
+});
+
+describe('Docker.ensureContainerRemoval', () => {
+  beforeEach(() => {
+    execMock.mockReset();
+    fsState.cidfileExists = false;
+    fsState.cidfileContent = 'container-id';
+    vi.mocked(rmSync).mockClear();
+  });
+
+  it('is a no-op when there is no cidfile', async () => {
+    fsState.cidfileExists = false;
+    await Docker.ensureContainerRemoval(buildParameters() as any);
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  it('still removes the cidfile even when docker rm fails', async () => {
+    fsState.cidfileExists = true;
+    execMock.mockRejectedValueOnce(new Error('no such container'));
+
+    await expect(Docker.ensureContainerRemoval(buildParameters() as any)).rejects.toThrow(
+      'no such container',
+    );
+
+    expect(rmSync).toHaveBeenCalled();
+  });
+
+  it('skips docker rm entirely when the cidfile is empty, but still removes it', async () => {
+    fsState.cidfileExists = true;
+    fsState.cidfileContent = '';
+
+    await Docker.ensureContainerRemoval(buildParameters() as any);
+
+    expect(execMock).not.toHaveBeenCalled();
+    expect(rmSync).toHaveBeenCalled();
   });
 });

--- a/plugins/unity/src/unity-test-runner/model/docker.ts
+++ b/plugins/unity/src/unity-test-runner/model/docker.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync } from 'fs';
 import LicensingServerSetup from './licensing-server-setup';
 import type { RunnerContext } from './action';
 import { exec } from '@actions/exec';
+import * as core from '@actions/core';
 import path from 'path';
 
 /**
@@ -26,8 +27,16 @@ const Docker = {
       return;
     }
     const container = readFileSync(cidfile, 'ascii').trim();
-    await exec(`docker`, ['rm', '--force', '--volumes', container], { silent: true });
-    rmSync(cidfile);
+    try {
+      if (container !== '') {
+        await exec(`docker`, ['rm', '--force', '--volumes', container], { silent: true });
+      }
+    } finally {
+      // Always drop the cidfile, even if `docker rm` failed or there was nothing to
+      // remove (a docker run that failed before writing a container ID still creates
+      // the file - `--cidfile` refuses to run again while a stale file is present).
+      rmSync(cidfile);
+    }
   },
 
   async run(image, parameters, silent = false) {
@@ -48,7 +57,40 @@ const Docker = {
         throw new Error(`Operation system, ${process.platform}, is not supported yet.`);
     }
 
-    await exec(runCommand, undefined, { silent });
+    // With a githubToken set, the container runs with USE_EXIT_CODE=false (see
+    // getLinuxCommand/getWindowsCommand) - test results are reported through GitHub
+    // Checks, not the process exit code, so in that mode a nonzero exit here can only
+    // mean the docker/container launch itself failed (e.g. the intermittent Windows
+    // runner "docker.exe failed with exit code 1" flake - unity-test-runner#314),
+    // never a real test failure. Retrying is only safe in that mode: without a token,
+    // USE_EXIT_CODE=true and a nonzero exit IS how test failures are signaled, so a
+    // retry there would silently re-run (and could mask) a real failure.
+    const launchFailuresAreRetryable = Boolean(parameters.githubToken);
+    const maxAttempts = launchFailuresAreRetryable ? 3 : 1;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        await exec(runCommand, undefined, { silent });
+        return;
+      } catch (error) {
+        if (attempt === maxAttempts) throw error;
+        core.warning(
+          `Docker run failed (attempt ${attempt}/${maxAttempts}): ${
+            error instanceof Error ? error.message : String(error)
+          }. Retrying...`,
+        );
+        try {
+          await this.ensureContainerRemoval(parameters);
+        } catch (cleanupError) {
+          core.warning(
+            `Cleanup before retry failed, continuing anyway: ${
+              cleanupError instanceof Error ? cleanupError.message : String(cleanupError)
+            }`,
+          );
+        }
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+      }
+    }
   },
 
   getLinuxCommand(image, parameters): string {


### PR DESCRIPTION
Addresses [unity-test-runner#314](https://github.com/game-ci/unity-test-runner/issues/314): Windows CI jobs intermittently fail with `docker.exe failed with exit code 1` even after the existing Docker-daemon readiness check passes — the failure is in the actual `docker run` invocation itself (a transient runner-image/container-launch issue), not Unity or this action's own logic. Confirmed pre-existing on `unity-test-runner`'s `main`, unrelated to any of its recent code changes.

## Why fix it here, not in the workflow

`unity-test-runner`'s `main.yml` has ~15 near-identical `uses: ./` steps spread across dozens of matrix jobs. Wrapping each with a retry action would be a broad, risky change to make unreviewed, and `nick-fields/retry`-style actions can't wrap a `uses:` composite-action step directly anyway (only raw shell commands). Fixed it once at the source instead, in `plugins/unity/src/unity-test-runner/model/docker.ts` — this fixes it for every consumer of the action, not just this repo's own CI matrix.

## What changed

- `Docker.run` now retries up to 2 additional times on failure, but **only** when a `githubToken` is set. With a token, the container runs with `USE_EXIT_CODE=false` (see `getLinuxCommand`/`getWindowsCommand`) — test results are reported through GitHub Checks, not the process exit code, so a nonzero exit in that mode can only mean the docker/container launch failed, never a real test failure. Without a token, `USE_EXIT_CODE=true` and a nonzero exit IS how test failures are signaled — no retry happens there, so a real failure is never silently re-run or masked.
- Hardened `ensureContainerRemoval` to always drop the stale `cidfile` even if `docker rm` fails or there's nothing to remove. This was needed because `--cidfile` refuses to run again while a stale file from the previous attempt is still present — without this, every retry from the fix above would fail immediately regardless.
- Added real test coverage for the retry/cleanup behavior — the existing test file only had a single `it.skip`, unmockable stub.

## Testing

- `typecheck`, `build` (zero unrelated `dist/` drift beyond the compiled `docker.js`), full `plugins/unity` test suite: 450 pass, 4 skip (was 443/5 — net +7 real tests replacing the 1 skipped stub).
- New tests cover: retry-then-succeed, retry-exhaustion, no-retry-without-token, and cidfile cleanup between attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)