### PR TITLE
chore: bump version to 0.1.9 for the game-ci test --docker feature (#95)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "GameCI CLI - automation for game engines",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Real gap found while converting `unity-test-runner` to a thin wrapper: `cliVersion=latest` resolves to whatever GitHub Release is marked latest, not `main` — #95 merged to `main` but no release was ever cut for it, so every consumer defaulting to `"latest"` was still getting `v0.1.8`'s binary, which has no `--docker`/`--local` flags on `test` at all. Confirmed via a real CI run on `unity-test-runner`'s thin-wrapper PR: yargs reported them as unknown arguments and every job failed.

This just bumps the version; a GitHub Release (`v0.1.9`) needs to be cut from this commit once merged to actually publish the binaries.