### PR TITLE
fix: test.sh's eval invocation dropped all but one coverage flag, and was a real injection risk

### DIFF
--- a/dist/platforms/ubuntu/steps/test.sh
+++ b/dist/platforms/ubuntu/steps/test.sh
@@ -202,7 +202,7 @@ for platform in ${TEST_PLATFORMS//;/ }; do
     ls -Ralph "$UNITY_PROJECT_PATH/Assets/Editor/"
     ls -Ralph "$UNITY_PROJECT_PATH/Assets/Player/"
 
-    runTests="-runTests -testPlatform StandaloneLinux64 -builtTestRunnerPath $UNITY_PROJECT_PATH/Build/UnityTestRunner-Standalone"
+    runTests=(-runTests -testPlatform StandaloneLinux64 -builtTestRunnerPath "$UNITY_PROJECT_PATH/Build/UnityTestRunner-Standalone")
   else
     echo ""
     echo "###########################"
@@ -211,18 +211,26 @@ for platform in ${TEST_PLATFORMS//;/ }; do
     echo ""
 
     if [[ "$platform" != "COMBINE_RESULTS" ]]; then
-      runTests="-runTests -testPlatform $platform -testResults $FULL_ARTIFACTS_PATH/$platform-results.xml"
+      runTests=(-runTests -testPlatform "$platform" -testResults "$FULL_ARTIFACTS_PATH/$platform-results.xml")
     else
-      runTests="-quit"
+      runTests=(-quit)
     fi
   fi
 
-  eval unity-editor \
+  # CUSTOM_PARAMETERS is a single string of space-separated Unity CLI args
+  # (e.g. "-profile Foo -someBoolean") - deliberately left unquoted below so
+  # it word-splits into separate argv entries, same as the rest of this
+  # array-based invocation. No eval anywhere here: an earlier version of
+  # this script used eval to get the same word-splitting, which would have
+  # let CUSTOM_PARAMETERS (user-controlled, via the action's own input)
+  # inject arbitrary shell syntax - array expansion gets the same splitting
+  # without that risk.
+  unity-editor \
     -batchmode \
-    -logFile "\"$FULL_ARTIFACTS_PATH/$platform.log\"" \
-    -projectPath "\"$UNITY_PROJECT_PATH\"" \
-    $runTests \
-    $COVERAGE_FLAGS \
+    -logFile "$FULL_ARTIFACTS_PATH/$platform.log" \
+    -projectPath "$UNITY_PROJECT_PATH" \
+    "${runTests[@]}" \
+    "${COVERAGE_FLAGS[@]}" \
     $CUSTOM_PARAMETERS
 
   # Catch exit code


### PR DESCRIPTION
Found via a real CI failure on `unity-test-runner`'s thin-wrapper PR ([#310](https://github.com/game-ci/unity-test-runner/pull/310)): after fixing the version-pin gap ([#96](https://github.com/game-ci/cli/pull/96)), every single Docker test run still produced no results file at all.

Two bugs, both introduced in #95:

1. `COVERAGE_FLAGS` was converted to a bash array (to avoid the `eval` below), but the `unity-editor` invocation still referenced it as plain `$COVERAGE_FLAGS` instead of `"${COVERAGE_FLAGS[@]}"` — unquoted, unsubscripted array expansion in bash only yields element `[0]`. Every run silently dropped `-enableCodeCoverage`/`-coverageOptions` and the `coverageResultsPath` *value*, leaving a bare `-coverageResultsPath` flag that then swallowed the next token (`customParameters`' first word) as its argument — corrupting the whole Unity command line.
2. The invocation used `eval` to get `CUSTOM_PARAMETERS` to word-split into separate argv entries. `CUSTOM_PARAMETERS` is user-controlled (the action's own `customParameters` input) — `eval` would interpret any shell metacharacters in it (`;`, `$()`, backticks) as real shell syntax, a real command-injection surface.

## Fix

Converted the whole invocation to a plain bash array (`runTests`, `COVERAGE_FLAGS`) with proper `"${array[@]}"` expansion. `CUSTOM_PARAMETERS` is still deliberately left unquoted for its intended word-splitting into separate args, but with `eval` gone entirely, that splitting can no longer be abused as shell syntax.

## Testing

- `bash -n` syntax check passes.
- Full `bun test ./src`: 156 pass, 0 fail (this file isn't bundled into `dist/index.js` — it's a static asset mounted into the container at runtime, so nothing else needed rebuilding).
- Will re-verify against a real Docker test run once this + a new release land (this exact script is what `unity-test-runner`'s failing CI run was exercising).

🤖 Generated with [Claude Code](https://claude.com/claude-code)