### PR TITLE
chore: bump version to 0.1.10 for the test.sh eval/array bug fix (#97)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "GameCI CLI - automation for game engines",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Bumps the version so a release can be cut for #97 (test.sh's coverage-flag/eval bug, found via a real CI failure on unity-test-runner's thin-wrapper PR).