### PR TITLE
debug: trace runsteps.sh execution to diagnose a real CI failure

### DIFF
--- a/dist/platforms/ubuntu/steps/runsteps.sh
+++ b/dist/platforms/ubuntu/steps/runsteps.sh
@@ -11,6 +11,12 @@
 #
 STEPS_DIR="${STEPS_DIR:-/steps}"
 
+# TEMPORARY: tracing every command to stderr while diagnosing a real CI
+# failure where a Docker test run produces zero visible stdout before
+# failing near-instantly (game-ci/cli - see the PR this landed in for
+# context). Remove once root-caused.
+set -x
+
 source "$STEPS_DIR/set_extra_git_configs.sh"
 source "$STEPS_DIR/set_gitcredential.sh"
 


### PR DESCRIPTION
Temporary diagnostic commit — see commit message. `game-ci test --docker` runs on `unity-test-runner`'s thin-wrapper PR ([#310](https://github.com/game-ci/unity-test-runner/pull/310)) fail near-instantly with zero visible stdout, only two `cat: no such file` stderr lines from the very end of `test.sh`'s loop body — meaning the script reaches its last lines but nothing earlier is visible, and the whole run completes in well under a second per job-log timestamps, too fast for Unity to have actually launched.

Ruled out so far: the version-pin gap (#96, fixed), the eval/array coverage-flags bug (#97, fixed) — this is a third, still-unidentified issue. `set -x` traces every command to stderr, which is rendering promptly in the CI log (unlike stdout so far), to find the actual failure point. Will remove this once root-caused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)