### PR TITLE
chore: bump version to 0.1.11 for the debug tracing (#99)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "GameCI CLI - automation for game engines",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Bumps the version so a release can be cut with the diagnostic `set -x` tracing from #99.