### PR TITLE
fix: game-ci test --docker defaulted to an image that can't actually run tests

### DIFF
--- a/dist/platforms/ubuntu/steps/runsteps.sh
+++ b/dist/platforms/ubuntu/steps/runsteps.sh
@@ -11,12 +11,6 @@
 #
 STEPS_DIR="${STEPS_DIR:-/steps}"
 
-# TEMPORARY: tracing every command to stderr while diagnosing a real CI
-# failure where a Docker test run produces zero visible stdout before
-# failing near-instantly (game-ci/cli - see the PR this landed in for
-# context). Remove once root-caused.
-set -x
-
 source "$STEPS_DIR/set_extra_git_configs.sh"
 source "$STEPS_DIR/set_gitcredential.sh"
 

--- a/src/command/test/unity-test-command.test.ts
+++ b/src/command/test/unity-test-command.test.ts
@@ -80,7 +80,11 @@ describe('UnityTestCommand', () => {
     expect(isAvailableMock).not.toHaveBeenCalled();
     expect(dockerRunMock).toHaveBeenCalledTimes(1);
     const [image, options] = dockerRunMock.mock.calls[0] as unknown as [string, any];
-    expect(image).toContain('base'); // NoTarget resolves to the 'base' editor image
+    // Defaults to this host's native Standalone target (StandaloneLinux64 on
+    // Linux), which resolves to the linux-il2cpp module for Unity 2020+ -
+    // NOT the 'base'/NoTarget image, which lacks what's needed to actually
+    // compile and run test assemblies (see defaultTestTargetPlatform).
+    expect(image).toContain('linux-il2cpp');
     expect(options.runTests).toBe(true);
   });
 

--- a/src/command/test/unity-test-command.ts
+++ b/src/command/test/unity-test-command.ts
@@ -11,6 +11,27 @@ import { PlatformSetup } from '../../logic/unity/platform-setup/index.ts';
 import type { YargsInstance, Options } from '../../dependencies.ts';
 
 /**
+ * Real bug found via a live CI run: defaulting to NoTarget (RunnerImageTag's
+ * 'base' module) seemed like the obvious no-target-platform-being-built
+ * choice, but 'base' apparently lacks whatever's needed to actually compile
+ * and run test assemblies - `-runTests` exited instantly with no log output
+ * at all against it. unity-test-runner's own original ImageTag defaulted to
+ * this host's native Standalone target instead (see its
+ * getImagePlatformType) - StandaloneLinux64 resolves to the linux-il2cpp
+ * module for Unity 2020+, which does have what's needed. Matching that
+ * here, rather than NoTarget.
+ */
+function defaultTestTargetPlatform(hostPlatform: string = process.platform): string {
+  switch (hostPlatform) {
+    case 'win32':
+      return 'StandaloneWindows';
+    case 'linux':
+    default:
+      return 'StandaloneLinux64';
+  }
+}
+
+/**
  * `game-ci test` — two independent ways to run Unity tests, chosen via
  * --docker:
  *
@@ -91,13 +112,10 @@ export class UnityTestCommand extends CommandBase implements CommandInterface {
       );
     }
 
-    // No target platform is being built - resolves to the 'base' editor
-    // image, same one activate/NoTarget already uses (see RunnerImageTag's
-    // targetPlatformSuffixes.noTarget). UnityOptions.configure() defaults
-    // targetPlatform to StandaloneWindows64 (build's default, not test's) -
-    // overridden back to NoTarget in configureOptions() below, so this
-    // should already be NoTarget unless a caller explicitly passed one.
-    const testOptions = { ...options, targetPlatform: options.targetPlatform || 'NoTarget' };
+    const testOptions = {
+      ...options,
+      targetPlatform: options.targetPlatform || defaultTestTargetPlatform(hostPlatform),
+    };
 
     const image = new RunnerImageTag(testOptions);
     if (log.isVerbose) log.debug('Using image:', image);
@@ -114,11 +132,13 @@ export class UnityTestCommand extends CommandBase implements CommandInterface {
   public async configureOptions(yargs: YargsInstance): Promise<void> {
     await ProjectOptions.configure(yargs);
     await UnityOptions.configure(yargs);
-    // UnityOptions defaults targetPlatform to StandaloneWindows64 (a build
-    // concern) - tests don't build anything, so default to NoTarget's
-    // 'base' editor image instead. A caller can still pass --targetPlatform
-    // explicitly (e.g. for --testPlatforms=standalone scenarios).
-    yargs.default('targetPlatform', 'NoTarget');
+    // UnityOptions defaults targetPlatform to StandaloneWindows64
+    // unconditionally (a build concern) - override to this host's own
+    // native target, matching unity-test-runner's original default (see
+    // defaultTestTargetPlatform's comment for why NoTarget doesn't work
+    // here). A caller can still pass --targetPlatform explicitly (e.g. for
+    // --testPlatforms=standalone scenarios targeting a different platform).
+    yargs.default('targetPlatform', defaultTestTargetPlatform());
     await UnityTestOptions.configure(yargs);
     await DockerTestOptions.configure(yargs);
   }


### PR DESCRIPTION
Root cause found via `set -x` tracing (#99) on a real CI failure: every Docker test run on `unity-test-runner`'s thin-wrapper PR ([#310](https://github.com/game-ci/unity-test-runner/pull/310)) exited near-instantly with exit code 1 and zero log output, even though activation succeeded fine moments earlier in the same run.

## Root cause

`--docker` defaulted `targetPlatform` to `NoTarget`, resolving to `RunnerImageTag`'s `base` editor module — the same image `activate`/`build`'s `NoTarget` path already uses successfully. But activation only needs the editor to launch and exit; running tests needs it to actually **compile and execute test assemblies**, which `base` apparently can't do (no Unity log output was ever written at all, meaning it failed before even initializing far enough to open the log file).

`unity-test-runner`'s own original `ImageTag` never defaulted to `NoTarget` — it defaulted to **this host's native Standalone target** (`getImagePlatformType`: `StandaloneLinux64` on Linux, `StandaloneWindows` on Windows), which resolves to the `linux-il2cpp` module for Unity 2020+. Matching that default here instead.

## Also in this PR

- Removes the temporary `set -x` tracing from `runsteps.sh` (#99) now that it's served its purpose.
- The default now reads from `options.hostPlatform` (already resolved per-invocation) rather than raw `process.platform` directly in `executeDocker` — was also just untestable, not only stylistic.

## Testing

- Full `bun test ./src`: 156 pass, 0 fail (updated one test's assertion from the old, wrong `base` expectation to the correct `linux-il2cpp` one).
- `bun build` succeeds.
- Will re-verify against a real Docker test run once this lands and a release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)