### PR TITLE
chore: bump version to 0.1.12 for the test --docker target-platform fix (#101)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "GameCI CLI - automation for game engines",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Bumps the version so a release can be cut with the real fix from #101 (game-ci test --docker now defaults to a target platform whose image can actually compile and run tests).