### PR TITLE
debug: re-trace runsteps.sh after the target-platform fix

### DIFF
--- a/dist/platforms/ubuntu/steps/runsteps.sh
+++ b/dist/platforms/ubuntu/steps/runsteps.sh
@@ -11,6 +11,12 @@
 #
 STEPS_DIR="${STEPS_DIR:-/steps}"
 
+# TEMPORARY (round 2): re-tracing after the target-platform fix (#101,
+# linux-il2cpp image now pulled correctly) - the Docker test run still
+# fails the same way, need to see whether it's the same or a new symptom
+# against the correct image. Remove once root-caused.
+set -x
+
 source "$STEPS_DIR/set_extra_git_configs.sh"
 source "$STEPS_DIR/set_gitcredential.sh"
 


### PR DESCRIPTION
#101 fixed the wrong default image (`linux-il2cpp` now pulled correctly, confirmed in CI), but the Docker test run on `unity-test-runner`'s thin-wrapper PR ([#310](https://github.com/game-ci/unity-test-runner/pull/310)) still fails the same way (near-instant exit 1, no results file). Need to see if it's the same symptom or a new one against the correct image. Temporary — will remove once root-caused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)