### PR TITLE
chore: bump version to 0.1.13 for the second debug trace (#103)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "GameCI CLI - automation for game engines",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Bumps the version so a release can be cut with the second round of diagnostic tracing from #103.