### PR TITLE
chore: remove diagnostic set -x tracing from runsteps.sh

### DIFF
--- a/dist/platforms/ubuntu/steps/runsteps.sh
+++ b/dist/platforms/ubuntu/steps/runsteps.sh
@@ -11,12 +11,6 @@
 #
 STEPS_DIR="${STEPS_DIR:-/steps}"
 
-# TEMPORARY (round 2): re-tracing after the target-platform fix (#101,
-# linux-il2cpp image now pulled correctly) - the Docker test run still
-# fails the same way, need to see whether it's the same or a new symptom
-# against the correct image. Remove once root-caused.
-set -x
-
 source "$STEPS_DIR/set_extra_git_configs.sh"
 source "$STEPS_DIR/set_gitcredential.sh"
 


### PR DESCRIPTION
Root cause found: the remaining Docker test failures on `unity-test-runner`'s thin-wrapper PR ([#310](https://github.com/game-ci/unity-test-runner/pull/310)) are a pre-existing, known Unity licensing issue — [unity-test-runner#265](https://github.com/game-ci/unity-test-runner/issues/265), open since March 2024, not a bug in this repo.

The activate step succeeds, but a separate `unity-editor` invocation for the actual test run sometimes gets `License is not active (com.unity.editor.headless)` from a fresh licensing daemon. #265 documents this happening ~30% of the time even on the original (pre-thin-wrapper) action, and the reporter suspected it's more frequent under concurrent test runs — which a full CI matrix of ~85 parallel jobs against the same Unity license is exactly.

Not something to chase further in this repo. Tracing has served its purpose (found and helped fix #96, #97, #101).

🤖 Generated with [Claude Code](https://claude.com/claude-code)