### PR TITLE
chore: bump version to 0.1.14, tracing removed (#105)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "GameCI CLI - automation for game engines",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Final version bump for this cycle — clean release with the target-platform fix (#101) and diagnostic tracing removed (#105). This is the version to actually use going forward; v0.1.13 was diagnostic-only.