### PR TITLE
fix: wire orchestrate command to the real orchestrator engine

### DIFF
--- a/plugins/orchestrator/src/model/engine/index.ts
+++ b/plugins/orchestrator/src/model/engine/index.ts
@@ -1,4 +1,4 @@
-export { EnginePlugin } from './engine-plugin';
+export type { EnginePlugin } from './engine-plugin';
 export { UnityPlugin } from './unity-plugin';
 export { GodotPlugin } from './godot-plugin';
 export { UnrealPlugin } from './unreal-plugin';

--- a/plugins/orchestrator/src/model/orchestrator/services/preflight/index.ts
+++ b/plugins/orchestrator/src/model/orchestrator/services/preflight/index.ts
@@ -1,6 +1,6 @@
 export { PreflightService } from './preflight-service';
 export { builtInChecks, listBuiltInCheckIds, listBuiltInChecks } from './built-in-checks';
-export {
+export type {
   PreflightCheck,
   PreflightCategory,
   PreflightScope,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import { PluginLoader } from './plugin/plugin-loader.ts';
 import { unityPlugin } from './plugin/builtin/unity-plugin.ts';
 import { godotPlugin } from './plugin/builtin/godot-plugin.ts';
 import { unrealPlugin } from './plugin/builtin/unreal-plugin.ts';
+import { orchestratorPlugin } from '../plugins/orchestrator/src/cli-plugin/index.ts';
 
 export class Cli {
   private readonly yargs: ReturnType<typeof yargs>;
@@ -57,6 +58,7 @@ export class Cli {
     await PluginRegistry.registerOnce(unityPlugin);
     await PluginRegistry.registerOnce(godotPlugin);
     await PluginRegistry.registerOnce(unrealPlugin);
+    await PluginRegistry.registerOnce(orchestratorPlugin);
 
     const options = await this.getPreCommandOptions();
     const pluginSources = this.getPluginSources(options);

--- a/src/command/orchestrate/unity-orchestrate-command.test.ts
+++ b/src/command/orchestrate/unity-orchestrate-command.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, mock, afterEach } from 'bun:test';
+import { UnityOrchestrateCommand } from './unity-orchestrate-command.ts';
+import { Orchestrator } from '../../../plugins/orchestrator/src/model/index.ts';
+
+const originalOrchestratorRun = Orchestrator.run;
+
+afterEach(() => {
+  // Orchestrator.run is a shared static — restore it so other test files
+  // exercising the real implementation aren't affected by this file's mocks.
+  Orchestrator.run = originalOrchestratorRun;
+});
+
+describe('UnityOrchestrateCommand', () => {
+  it('returns true when the orchestrated build succeeds', async () => {
+    const buildParameters = { providerStrategy: 'local-docker' } as any;
+    const runMock = mock(() =>
+      Promise.resolve({
+        BuildParameters: buildParameters,
+        BuildResults: 'ok',
+        BuildSucceeded: true,
+        BuildFinished: true,
+        LibraryCacheUsed: false,
+      }),
+    );
+    Orchestrator.run = runMock;
+
+    const command = new UnityOrchestrateCommand('orchestrate');
+    const result = await command.execute({ providerStrategy: 'local-docker', projectPath: '.' } as any);
+
+    expect(result).toBe(true);
+    expect(runMock).toHaveBeenCalled();
+  });
+
+  it('returns false when the orchestrated build fails', async () => {
+    const buildParameters = { providerStrategy: 'local-docker' } as any;
+    const runMock = mock(() =>
+      Promise.resolve({
+        BuildParameters: buildParameters,
+        BuildResults: 'failed',
+        BuildSucceeded: false,
+        BuildFinished: true,
+        LibraryCacheUsed: false,
+      }),
+    );
+    Orchestrator.run = runMock;
+
+    const command = new UnityOrchestrateCommand('orchestrate');
+    const result = await command.execute({ providerStrategy: 'local-docker', projectPath: '.' } as any);
+
+    expect(result).toBe(false);
+  });
+
+  it('builds BuildParameters from the CLI options and passes them, with an ImageTag string, to Orchestrator.run', async () => {
+    const runMock = mock(() =>
+      Promise.resolve({
+        BuildParameters: {},
+        BuildResults: '',
+        BuildSucceeded: true,
+        BuildFinished: true,
+        LibraryCacheUsed: false,
+      }),
+    );
+    Orchestrator.run = runMock;
+
+    const command = new UnityOrchestrateCommand('orchestrate');
+    await command.execute({
+      providerStrategy: 'local',
+      projectPath: '.',
+      engineVersion: '2022.3.20f1',
+      targetPlatform: 'StandaloneLinux64',
+    } as any);
+
+    expect(runMock).toHaveBeenCalledTimes(1);
+    const [buildParametersArg, baseImageArg] = runMock.mock.calls[0];
+    expect(buildParametersArg.providerStrategy).toBe('local');
+    expect(buildParametersArg.editorVersion).toBe('2022.3.20f1');
+    expect(typeof baseImageArg).toBe('string');
+  });
+});

--- a/src/command/orchestrate/unity-orchestrate-command.ts
+++ b/src/command/orchestrate/unity-orchestrate-command.ts
@@ -3,42 +3,33 @@ import type { YargsArguments, YargsInstance } from '../../dependencies.ts';
 import { CommandBase } from '../command-base.ts';
 import { RemoteOptions } from '../../command-options/remote-options.ts';
 import { ProjectOptions } from '../../command-options/project-options.ts';
-import { PluginRegistry } from '../../plugin/plugin-registry.ts';
+import { Orchestrator, ImageTag } from '../../../plugins/orchestrator/src/model/index.ts';
+import { createBuildParametersFromCliOptions } from '../../../plugins/orchestrator/src/cli-plugin/index.ts';
 
 /**
  * Provider-backed orchestration command.
  *
- * Delegates to the provider plugin selected by --providerStrategy. The actual
- * job execution (setupWorkflow, runTaskInWorkflow, etc.) is handled by the
- * provider implementation, usually the Orchestrator plugin.
+ * Delegates to the real @game-ci/orchestrator engine (`Orchestrator.run`),
+ * which itself selects and drives the provider matching --providerStrategy
+ * (aws, k8s, local-docker, local-system/local, gcp-cloud-run, azure-aci,
+ * github-actions, gitlab-ci, remote-powershell, ansible, ...) and runs the
+ * full build/test workflow (setupWorkflow -> workflow -> cleanupWorkflow).
  */
 export class UnityOrchestrateCommand extends CommandBase implements CommandInterface {
   public async execute(options: YargsArguments): Promise<boolean> {
-    const { providerStrategy } = options;
+    const buildParameters = createBuildParametersFromCliOptions(options);
+    const baseImage = new ImageTag(buildParameters);
 
-    const provider = PluginRegistry.createProvider(providerStrategy as string, options);
-    if (!provider) {
-      throw new Error(
-        `No provider registered for strategy "${providerStrategy}". ` +
-          `Available: ${PluginRegistry.getAvailableProviders().join(', ') || 'none'}. ` +
-          `Install a provider plugin (e.g. @game-ci/orchestrator-plugin).`,
-      );
-    }
+    log.info(`Using provider strategy: ${buildParameters.providerStrategy}`);
 
-    log.info(`Using provider strategy: ${providerStrategy}`);
+    const result = await Orchestrator.run(buildParameters, baseImage.toString());
 
-    const result = await provider.runTaskInWorkflow(
-      '', // buildGuid — provided by provider
-      '', // image — provider determines this
-      '', // commands
-      '', // mountdir
-      '', // workingdir
-      [], // environment
-      [], // secrets
+    log.info(
+      `Orchestrated job ${result?.BuildFinished ? 'finished' : 'did not finish'} ` +
+        `(succeeded: ${Boolean(result?.BuildSucceeded)}): ${result?.BuildResults ?? ''}`,
     );
 
-    log.info('Orchestrated job result:', result);
-    return true;
+    return Boolean(result?.BuildSucceeded);
   }
 
   public async configureOptions(yargs: YargsInstance): Promise<void> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
-    "rootDir": "./src",
     "types": ["bun-types"]
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## Summary

`game-ci orchestrate` was a non-functional stub. It looked up a provider via `PluginRegistry.createProvider(providerStrategy, options)`, then called `provider.runTaskInWorkflow(buildGuid, image, commands, mountdir, workingdir, environment, secrets)` with **every argument hardcoded to an empty string or empty array**, regardless of which provider strategy was selected. It effectively did nothing useful for any strategy.

The real, mature orchestration engine already lives in-repo at `plugins/orchestrator` (brought in via the earlier monorepo consolidation, #78) - `Orchestrator.run(buildParameters, baseImage)` handles provider selection (including local-emulator auto-detection and fallback), `setupWorkflow`, the full build/test workflow via `WorkflowCompositionRoot`, GitHub Check updates, and `cleanupWorkflow`. This is exactly what orchestrator's own original standalone `orchestrate` command used before archival.

This PR wires `UnityOrchestrateCommand` to that real engine instead of reimplementing orchestration from scratch:

- Build `BuildParameters` via the already-tested `createBuildParametersFromCliOptions` adapter (`plugins/orchestrator/src/cli-plugin/build-parameters-adapter.ts`)
- Build an `ImageTag`
- Call `Orchestrator.run(buildParameters, baseImage.toString())`
- Return `Boolean(result?.BuildSucceeded)`

Also registers `orchestratorPlugin` as a built-in in `src/cli.ts` (alongside the unity/godot/unreal engine plugins), so its ~80 provider-specific yargs options (`--awsStackName`, `--containerMemory`, `--kubeConfig`, etc.) are recognized instead of erroring under yargs `strict(true)`.

Two orchestrator source files re-exported interfaces/type aliases as values (`export { SomeInterface } from ...`), which `tsc`'s commonjs build tolerates but bun's transpiler rejects under isolated-module semantics - this broke immediately on the first cross-workspace import from `cli`. Fixed to `export type { ... }` in both places; no runtime behavior change.

`tsconfig.json`'s `rootDir: "./src"` was removed since it hard-errors (TS6059) once a file under `src/` imports something outside it, which this change requires (the cross-workspace import into `plugins/orchestrator/src/`).

## Verification

- `bun test ./src`: 159 pass / 3 skip / 0 fail, including new tests for `UnityOrchestrateCommand` (success, failure, and that real `BuildParameters`/`ImageTag` values reach `Orchestrator.run`)
- `bun run build`: succeeds
- `plugins/orchestrator`'s own vitest suite (`bun run test:ci`): ~915 pass, same pre-existing flakiness (subprocess-spawn timeouts, a Windows temp-dir `EPERM`) confirmed present on the unmodified baseline too - not caused by this change
- **Live end-to-end run**: `bun run src/index.ts orchestrate --providerStrategy local --projectPath <synthetic Unity project>` went through engine detection, VCS detection, provider selection ("Orchestrator platform selected local"), GitHub Check creation, a real bash-driven build-automation workflow via the `local` (host) provider, and cleanup - exited 0 with `Orchestrated job finished (succeeded: true)`. Also confirmed a non-Unity `projectPath` fails cleanly (`Error: Engine not detected from projectPath`), not with a crash.
- Not independently verified in this sandbox: aws/k8s/gcp-cloud-run/azure-aci/github-actions/gitlab-ci/remote-powershell/ansible provider strategies (no credentials/clusters available) and `local-docker` (no Docker daemon confirmed available) - these go through the identical `Orchestrator.run` code path as the verified `local` strategy, so should work identically given the required infra, but that's inference, not confirmation.

## Test plan

- [x] `bun test ./src` passes
- [x] `bun run build` succeeds
- [x] Live `orchestrate --providerStrategy local` run against a synthetic Unity project succeeds end-to-end
- [ ] Follow-up: validate against a real self-hosted host-execution use case (e.g. as a reference point for whether this is a genuine simplification for repos currently using bespoke self-hosted Unity CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Unity orchestration commands now run builds directly using the selected command-line options.
  - Build image tags are generated automatically for orchestrated runs.
  - Completion status and build results are reported after execution.
  - Orchestration support is now loaded automatically with the CLI.

- **Bug Fixes**
  - Commands now return the actual success or failure status of orchestrated builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->