### PR TITLE
feat: native Windows host execution for build and test --local

### DIFF
--- a/dist/platforms/windows/steps/activate.ps1
+++ b/dist/platforms/windows/steps/activate.ps1
@@ -1,0 +1,108 @@
+# Native Windows host-mode equivalent of ../../ubuntu/steps/activate.sh -
+# see runsteps.ps1's doc comment. Same three activation strategies, checked
+# in the same order, with the same success/failure detection logic (Unity's
+# own stdout/log text doesn't differ by platform, so the strings matched
+# below are identical to the bash version).
+$StepsDir = if ($Env:STEPS_DIR) { $Env:STEPS_DIR } else { $PSScriptRoot }
+. (Join-Path $StepsDir 'resolve_unity_path.ps1')
+
+Write-Host "Changing to `"$Env:ACTIVATE_LICENSE_PATH`" directory."
+Push-Location $Env:ACTIVATE_LICENSE_PATH
+
+$global:UNITY_EXIT_CODE = 1
+
+try {
+  $UnityExePath = Get-UnityEditorExePath
+
+  if ($Env:UNITY_LICENSE -or $Env:UNITY_LICENSE_FILE) {
+    #
+    # PERSONAL LICENSE MODE
+    #
+    # This will activate Unity, using a license file. Note that this is the
+    # ONLY WAY for PERSONAL LICENSES in 2020 - see
+    # https://gitlab.com/gableroux/unity3d-gitlab-ci-example/issues/5#note_72815478
+    #
+    # The license file can be acquired using
+    # `webbertakken/request-manual-activation-file` action.
+    #
+    Write-Host 'Requesting activation (personal license)'
+
+    $FilePath = 'UnityLicenseFile.ulf'
+    $LogPath = Join-Path $Env:ACTIVATE_LICENSE_PATH 'activate.log'
+
+    if ($Env:UNITY_LICENSE) {
+      ($Env:UNITY_LICENSE -replace "`r", '') | Set-Content -Path $FilePath -NoNewline
+    } elseif ($Env:UNITY_LICENSE_FILE) {
+      ((Get-Content -Raw $Env:UNITY_LICENSE_FILE) -replace "`r", '') | Set-Content -Path $FilePath -NoNewline
+    }
+
+    & $UnityExePath -logFile $LogPath -quit -manualLicenseFile $FilePath | Out-Host
+    $global:UNITY_EXIT_CODE = $LASTEXITCODE
+
+    # The exit code for personal activation is always 1; determine whether
+    # activation was successful from the log instead. Successful output
+    # should include a line like:
+    #   "LICENSE SYSTEM [2020120 18:51:20] Next license update check is after 2019-11-25T18:23:38"
+    $LogContent = if (Test-Path $LogPath) { Get-Content -Raw $LogPath } else { '' }
+    if ($LogContent -match 'Next license update check is after') {
+      $global:UNITY_EXIT_CODE = 0
+    }
+
+    Remove-Item -Force $FilePath -ErrorAction SilentlyContinue
+  } elseif ($Env:UNITY_SERIAL -and $Env:UNITY_EMAIL -and $Env:UNITY_PASSWORD) {
+    #
+    # PROFESSIONAL (SERIAL) LICENSE MODE
+    #
+    Write-Host 'Requesting activation (professional license)'
+
+    $LogPath = Join-Path $Env:ACTIVATE_LICENSE_PATH 'activate.log'
+    & $UnityExePath -logFile $LogPath -quit -serial $Env:UNITY_SERIAL -username $Env:UNITY_EMAIL -password $Env:UNITY_PASSWORD | Out-Host
+    $global:UNITY_EXIT_CODE = $LASTEXITCODE
+    if (Test-Path $LogPath) { Get-Content $LogPath | Out-Host }
+  } elseif ($Env:UNITY_LICENSING_SERVER) {
+    #
+    # Custom Unity License Server
+    #
+    Write-Host 'Adding licensing server config'
+
+    $LicensingClientPath = Get-UnityLicensingClientExePath
+    $LicenseTextPath = Join-Path $Env:ACTIVATE_LICENSE_PATH 'license.txt'
+    & $LicensingClientPath --acquire-floating | Out-File -FilePath $LicenseTextPath -Encoding UTF8
+    $global:UNITY_EXIT_CODE = $LASTEXITCODE
+
+    $ParsedFile = Select-String -Path $LicenseTextPath -Pattern '"[^"]*"' -AllMatches |
+      ForEach-Object { $_.Matches } | ForEach-Object { $_.Value -replace '"', '' }
+    $global:FLOATING_LICENSE = $ParsedFile[1]
+    $global:FLOATING_LICENSE_TIMEOUT = $ParsedFile[3]
+
+    Write-Host "Acquired floating license: `"$($global:FLOATING_LICENSE)`" with timeout $($global:FLOATING_LICENSE_TIMEOUT)"
+  } else {
+    #
+    # NO LICENSE ACTIVATION STRATEGY MATCHED
+    #
+    Write-Host 'License activation strategy could not be determined.'
+    Write-Host ''
+    Write-Host 'Visit https://game.ci/docs/github/getting-started for more'
+    Write-Host 'details on how to set up one of the possible activation strategies.'
+
+    Pop-Location
+    exit 1
+  }
+} catch {
+  Write-Host "Unity Editor could not be run: $($_.Exception.Message)"
+  $global:UNITY_EXIT_CODE = 1
+}
+
+#
+# Display information about the result
+#
+if ($global:UNITY_EXIT_CODE -eq 0) {
+  Write-Host 'Activation complete.'
+} else {
+  Write-Host 'Unclassified error occured while trying to activate license.'
+  Write-Host "Exit code was: $($global:UNITY_EXIT_CODE)"
+  Pop-Location
+  exit $global:UNITY_EXIT_CODE
+}
+
+Pop-Location

--- a/dist/platforms/windows/steps/build.ps1
+++ b/dist/platforms/windows/steps/build.ps1
@@ -1,0 +1,160 @@
+# Native Windows host-mode equivalent of ../../ubuntu/steps/build.sh - see
+# runsteps.ps1's doc comment. chown/chmod calls from the Linux version are
+# dropped entirely (no Windows equivalent, and were only ever meaningful
+# for a container's root-owned files in the first place).
+$StepsDir = if ($Env:STEPS_DIR) { $Env:STEPS_DIR } else { $PSScriptRoot }
+. (Join-Path $StepsDir 'resolve_unity_path.ps1')
+
+#
+# Set project path
+#
+$Env:UNITY_PROJECT_PATH = Join-Path $Env:GITHUB_WORKSPACE $Env:PROJECT_PATH
+Write-Host "Using project path `"$($Env:UNITY_PROJECT_PATH)`"."
+
+Write-Host "Using build name `"$($Env:BUILD_NAME)`"."
+Write-Host "Using build target `"$($Env:BUILD_TARGET)`"."
+
+if (-not $Env:BUILD_PROFILE) {
+  Write-Host "Doing a default `"$($Env:BUILD_TARGET)`" platform build."
+} else {
+  Write-Host "Using build profile `"$($Env:BUILD_PROFILE)`" relative to `"$($Env:UNITY_PROJECT_PATH)`"."
+}
+
+Write-Host "Using build path `"$($Env:BUILD_PATH)`" to save file `"$($Env:BUILD_FILE)`"."
+$BuildPathFull = Join-Path $Env:GITHUB_WORKSPACE $Env:BUILD_PATH
+$CustomBuildPath = Join-Path $BuildPathFull $Env:BUILD_FILE
+
+#
+# Set the build method, must reference one of:
+#   - <NamespaceName.ClassName.MethodName>
+#   - <ClassName.MethodName>
+# For example: `BuildCommand.PerformBuild`
+# The method must be declared static and placed in project/Assets/Editor
+#
+if ($Env:BUILD_METHOD) {
+  Write-Host "Using build method `"$($Env:BUILD_METHOD)`"."
+} else {
+  Write-Host 'Using built-in build method.'
+
+  $EditorDir = Join-Path $Env:UNITY_PROJECT_PATH 'Assets\Editor'
+  if (-not (Test-Path $EditorDir)) {
+    New-Item -ItemType Directory -Force -Path $EditorDir | Out-Null
+  }
+
+  # Copy the build script of Unity Builder action - dist/default-build-script
+  # is the native (non-container) equivalent of the Docker image's
+  # /UnityBuilderAction, mirroring MacBuilder's own native build.sh, which
+  # already uses this same source.
+  Copy-Item -Path (Join-Path $Env:ACTION_FOLDER 'default-build-script\Assets\Editor\*') -Destination $EditorDir -Recurse -Force
+
+  $Env:BUILD_METHOD = 'UnityBuilderAction.Builder.BuildProject'
+
+  Get-ChildItem -Path $EditorDir -Recurse
+}
+
+Write-Host ''
+Write-Host '###########################'
+Write-Host '#    Custom parameters    #'
+Write-Host '###########################'
+Write-Host ''
+Write-Host "$($Env:CUSTOM_PARAMETERS)"
+
+Write-Host ''
+Write-Host '###########################'
+Write-Host '#    Current build dir    #'
+Write-Host '###########################'
+Write-Host ''
+Write-Host "Creating `"$BuildPathFull`" if it does not exist."
+if (-not (Test-Path $BuildPathFull)) {
+  New-Item -ItemType Directory -Force -Path $BuildPathFull | Out-Null
+}
+Get-ChildItem $BuildPathFull
+
+Write-Host ''
+Write-Host '###########################'
+Write-Host '#    Project directory    #'
+Write-Host '###########################'
+Write-Host ''
+Get-ChildItem $Env:UNITY_PROJECT_PATH
+
+#
+# Build
+#
+Write-Host ''
+Write-Host '###########################'
+Write-Host '#    Building project     #'
+Write-Host '###########################'
+Write-Host ''
+
+# Reference: https://docs.unity3d.com/2019.3/Documentation/Manual/CommandLineArguments.html
+
+# MANUAL_EXIT=true skips -quit so the build method can stay in play mode and
+# call EditorApplication.Exit(0) itself (see game-ci/cli#13).
+$QuitArgs = @('-quit')
+if ($Env:MANUAL_EXIT -eq 'true') {
+  $QuitArgs = @()
+}
+
+# BUILD_PROFILE (Unity 6) determines the target itself, so -buildTarget is
+# omitted when one is set - matches real unity-builder's own handling.
+$BuildTargetArgs = @('-buildTarget', $Env:BUILD_TARGET)
+$BuildProfileArgs = @()
+if ($Env:BUILD_PROFILE) {
+  $BuildTargetArgs = @()
+  $BuildProfileArgs = @('-activeBuildProfile', $Env:BUILD_PROFILE)
+}
+
+# CUSTOM_PARAMETERS is a single string of space-separated Unity CLI args -
+# split into an array so it argv-splits the same way the bash version's
+# unquoted $CUSTOM_PARAMETERS does, without going through Invoke-Expression
+# (which would risk shell-injecting CUSTOM_PARAMETERS, a user-controlled
+# input - same reasoning as the bash version's own comment on this).
+$CustomParametersArray = @()
+if ($Env:CUSTOM_PARAMETERS) {
+  $CustomParametersArray = $Env:CUSTOM_PARAMETERS -split '\s+' | Where-Object { $_ -ne '' }
+}
+
+try {
+  $UnityExePath = Get-UnityEditorExePath
+  $LogPath = Join-Path $BuildPathFull 'build.log'
+
+  & $UnityExePath @QuitArgs -batchmode -nographics `
+    -logFile $LogPath `
+    -customBuildName $Env:BUILD_NAME `
+    -projectPath $Env:UNITY_PROJECT_PATH `
+    @BuildTargetArgs `
+    -customBuildTarget $Env:BUILD_TARGET `
+    -customBuildPath $CustomBuildPath `
+    -customBuildProfile $Env:BUILD_PROFILE `
+    @BuildProfileArgs `
+    -executeMethod $Env:BUILD_METHOD `
+    -buildVersion $Env:VERSION `
+    -androidVersionCode $Env:ANDROID_VERSION_CODE `
+    -androidKeystoreName $Env:ANDROID_KEYSTORE_NAME `
+    -androidKeystorePass $Env:ANDROID_KEYSTORE_PASS `
+    -androidKeyaliasName $Env:ANDROID_KEYALIAS_NAME `
+    -androidKeyaliasPass $Env:ANDROID_KEYALIAS_PASS `
+    -androidTargetSdkVersion $Env:ANDROID_TARGET_SDK_VERSION `
+    -androidExportType $Env:ANDROID_EXPORT_TYPE `
+    -androidSymbolType $Env:ANDROID_SYMBOL_TYPE `
+    @CustomParametersArray | Out-Host
+
+  $global:BUILD_EXIT_CODE = $LASTEXITCODE
+  if (Test-Path $LogPath) { Get-Content $LogPath | Out-Host }
+} catch {
+  Write-Host "Unity Editor could not be run: $($_.Exception.Message)"
+  $global:BUILD_EXIT_CODE = 1
+}
+
+if ($global:BUILD_EXIT_CODE -eq 0) {
+  Write-Host 'Build succeeded'
+} else {
+  Write-Host "Build failed, with exit code $($global:BUILD_EXIT_CODE)"
+}
+
+Write-Host ''
+Write-Host '###########################'
+Write-Host '#       Build output      #'
+Write-Host '###########################'
+Write-Host ''
+Get-ChildItem $BuildPathFull

--- a/dist/platforms/windows/steps/resolve_unity_path.ps1
+++ b/dist/platforms/windows/steps/resolve_unity_path.ps1
@@ -1,0 +1,57 @@
+# Resolves the Unity Editor install location for a native (non-Docker,
+# non-Hub-container) Windows host, for HostRunner's steps scripts.
+#
+# Unlike dist/platforms/windows/*.ps1 (the Docker-container script set,
+# where UNITY_PATH is a fixed, image-baked value pointing at
+# C:/UnityEditor/<version> - see build.ps1's own comment there, and
+# game-ci/cli#77), a self-hosted machine has Unity installed by a human (or
+# automation) via Unity Hub, so the version-specific install directory has
+# to be resolved dynamically instead of assumed. Mirrors
+# src/logic/unity/platform-setup/setup-mac.ts's own hardcoded
+# `/Applications/Unity/Hub/Editor/$version` for the same reason on macOS -
+# there is no existing "find the Unity executable on Windows" helper in
+# src/ to reuse (UnityCliAdapter shells out to Unity Technologies' separate
+# `unity` CLI tool, which is unrelated and doesn't resolve an Editor path
+# either).
+#
+# $Env:UNITY_PATH, if set, overrides the Hub default entirely and is used
+# as-is (the directory containing Editor\Unity.exe) - lets a runner operator
+# point at a non-default install location without code changes.
+function Get-UnityEditorRoot {
+  if ($Env:UNITY_PATH) {
+    return $Env:UNITY_PATH
+  }
+
+  if (-not $Env:UNITY_VERSION) {
+    throw 'UNITY_VERSION is not set and UNITY_PATH was not provided - cannot locate the Unity Editor install.'
+  }
+
+  return "C:\Program Files\Unity\Hub\Editor\$Env:UNITY_VERSION"
+}
+
+function Get-UnityEditorExePath {
+  $root = Get-UnityEditorRoot
+  $exePath = Join-Path $root 'Editor\Unity.exe'
+
+  if (-not (Test-Path $exePath)) {
+    throw (
+      "Unity Editor not found at `"$exePath`". Install Unity $Env:UNITY_VERSION via Unity Hub " +
+      '(the default self-hosted-runner install location is used automatically), or set the ' +
+      'UNITY_PATH environment variable to the Editor root directory (the one containing Editor\Unity.exe) ' +
+      'if Unity is installed somewhere else.'
+    )
+  }
+
+  return $exePath
+}
+
+function Get-UnityLicensingClientExePath {
+  $root = Get-UnityEditorRoot
+  $exePath = Join-Path $root 'Editor\Data\Resources\Licensing\Client\Unity.Licensing.Client.exe'
+
+  if (-not (Test-Path $exePath)) {
+    throw "Unity Licensing Client not found at `"$exePath`"."
+  }
+
+  return $exePath
+}

--- a/dist/platforms/windows/steps/return_license.ps1
+++ b/dist/platforms/windows/steps/return_license.ps1
@@ -1,0 +1,35 @@
+# Native Windows host-mode equivalent of ../../ubuntu/steps/return_license.sh -
+# see runsteps.ps1's doc comment.
+$StepsDir = if ($Env:STEPS_DIR) { $Env:STEPS_DIR } else { $PSScriptRoot }
+. (Join-Path $StepsDir 'resolve_unity_path.ps1')
+
+Write-Host "Changing to `"$Env:ACTIVATE_LICENSE_PATH`" directory."
+Push-Location $Env:ACTIVATE_LICENSE_PATH
+
+try {
+  if ($Env:UNITY_LICENSING_SERVER) {
+    #
+    # Return any floating license used.
+    #
+    Write-Host "Returning floating license: `"$($global:FLOATING_LICENSE)`""
+    $LicensingClientPath = Get-UnityLicensingClientExePath
+    & $LicensingClientPath --return-floating $global:FLOATING_LICENSE
+  } elseif ($Env:UNITY_SERIAL) {
+    #
+    # PROFESSIONAL (SERIAL) LICENSE MODE
+    #
+    # -projectPath points at the scratch activation directory, not the
+    # built project, so Unity doesn't reopen the real project (and
+    # reimport its library against whatever the editor's default target
+    # is) just to return the license (game-ci/cli#33).
+    #
+    $UnityExePath = Get-UnityEditorExePath
+    $LogPath = Join-Path $Env:ACTIVATE_LICENSE_PATH 'return_license.log'
+    & $UnityExePath -logFile $LogPath -quit -returnlicense -projectPath $Env:ACTIVATE_LICENSE_PATH | Out-Host
+    if (Test-Path $LogPath) { Get-Content $LogPath | Out-Host }
+  }
+} catch {
+  Write-Host "Could not return license: $($_.Exception.Message)"
+}
+
+Pop-Location

--- a/dist/platforms/windows/steps/runsteps.ps1
+++ b/dist/platforms/windows/steps/runsteps.ps1
@@ -1,0 +1,84 @@
+#
+# Run steps (native Windows host-mode equivalent of ../../ubuntu/steps/runsteps.sh)
+#
+# Genuinely native: no Docker container involved. Run directly by
+# HostRunner (src/model/host-runner.ts, see its class doc comment) against
+# a self-hosted Windows machine with Unity already installed via Unity Hub
+# - NOT the dist/platforms/windows/*.ps1 Docker-container script set one
+# directory up, which assumes a container-baked $Env:UNITY_PATH and has no
+# RUN_TESTS support at all.
+#
+# $PSScriptRoot is this script's own directory, so sibling steps are always
+# resolved correctly regardless of where dist/ was copied to - STEPS_DIR is
+# only honored as an explicit override, matching the bash scripts' own
+# STEPS_DIR-defaults-but-overridable convention.
+#
+$StepsDir = if ($Env:STEPS_DIR) { $Env:STEPS_DIR } else { $PSScriptRoot }
+
+. (Join-Path $StepsDir 'set_extra_git_configs.ps1')
+. (Join-Path $StepsDir 'set_gitcredential.ps1')
+
+if ($Env:SKIP_ACTIVATION -ne 'true') {
+  . (Join-Path $StepsDir 'activate.ps1')
+
+  # If we didn't activate successfully, exit with the exit code from the activation step.
+  if ($global:UNITY_EXIT_CODE -ne 0) {
+    exit $global:UNITY_EXIT_CODE
+  }
+} else {
+  Write-Host 'Skipping activation'
+}
+
+# ACTIVATE_ONLY=true (used by `game-ci activate`, see game-ci/cli's
+# ActivateCommand) activates and stops here - no build, and the license is
+# deliberately left active for a later step to use, so no
+# return_license.ps1 either.
+if ($Env:ACTIVATE_ONLY -eq 'true') {
+  Remove-Item -Recurse -Force $Env:ACTIVATE_LICENSE_PATH -ErrorAction SilentlyContinue
+  exit $global:UNITY_EXIT_CODE
+}
+
+# RUN_TESTS=true (used by `game-ci test --docker --local`, see game-ci/cli's
+# UnityTestCommand) runs the classic batchmode test flow instead of a
+# build - same activation/license-return steps either way, only the middle
+# step differs.
+if ($Env:RUN_TESTS -eq 'true') {
+  . (Join-Path $StepsDir 'test.ps1')
+  $StepExitCode = $global:TEST_RUNNER_EXIT_CODE
+} else {
+  . (Join-Path $StepsDir 'build.ps1')
+  $StepExitCode = $global:BUILD_EXIT_CODE
+}
+
+if ($Env:SKIP_ACTIVATION -ne 'true') {
+  . (Join-Path $StepsDir 'return_license.ps1')
+}
+
+#
+# Remove license activation directory
+#
+
+Remove-Item -Recurse -Force $Env:ACTIVATE_LICENSE_PATH -ErrorAction SilentlyContinue
+
+#
+# Instructions for debugging
+#
+
+if ($StepExitCode -gt 0) {
+  Write-Host ''
+  Write-Host '###########################'
+  Write-Host '#         Failure         #'
+  Write-Host '###########################'
+  Write-Host ''
+  Write-Host 'Please note that the exit code is not very descriptive.'
+  Write-Host 'Most likely it will not help you solve the issue.'
+  Write-Host ''
+  Write-Host 'To find the reason for failure: please search for errors in the log above.'
+  Write-Host ''
+}
+
+#
+# Exit with code from the build/test step.
+#
+
+exit $StepExitCode

--- a/dist/platforms/windows/steps/set_extra_git_configs.ps1
+++ b/dist/platforms/windows/steps/set_extra_git_configs.ps1
@@ -1,0 +1,27 @@
+# Ported from ../../ubuntu/steps/set_extra_git_configs.sh (same behavior,
+# native Windows host-mode script set - see runsteps.ps1's doc comment).
+# GIT_CONFIG_EXTENSIONS is a newline-separated list of "key=value" pairs.
+if ([string]::IsNullOrEmpty($Env:GIT_CONFIG_EXTENSIONS)) {
+  Write-Host 'GIT_CONFIG_EXTENSIONS unset skipping'
+} else {
+  Write-Host 'GIT_CONFIG_EXTENSIONS is set configuring extra git configs'
+
+  $lines = $Env:GIT_CONFIG_EXTENSIONS -split "`n" | Where-Object { $_.Trim() -ne '' }
+  foreach ($line in $lines) {
+    $separatorIndex = $line.IndexOf('=')
+    if ($separatorIndex -lt 0) {
+      Write-Host "Error parsing config: $line"
+      exit 1
+    }
+    $key = $line.Substring(0, $separatorIndex)
+    $value = $line.Substring($separatorIndex + 1)
+    Write-Host "Adding extra git config: `"$key`" = `"$value`""
+    git config --global --add $key $value
+  }
+}
+
+Write-Host '---------- git config --list -------------'
+git config --list
+
+Write-Host '---------- git config --list --show-origin -------------'
+git config --list --show-origin

--- a/dist/platforms/windows/steps/set_gitcredential.ps1
+++ b/dist/platforms/windows/steps/set_gitcredential.ps1
@@ -1,0 +1,21 @@
+# Ported from ../../ubuntu/steps/set_gitcredential.sh (same behavior,
+# native Windows host-mode script set - see runsteps.ps1's doc comment).
+if ([string]::IsNullOrEmpty($env:GIT_PRIVATE_TOKEN)) {
+  Write-Host 'GIT_PRIVATE_TOKEN unset skipping'
+} else {
+  Write-Host 'GIT_PRIVATE_TOKEN is set configuring git credentials'
+
+  git config --global credential.helper store
+  git config --global --replace-all "url.https://token:$env:GIT_PRIVATE_TOKEN@github.com/".insteadOf 'ssh://git@github.com/'
+  git config --global --add "url.https://token:$env:GIT_PRIVATE_TOKEN@github.com/".insteadOf 'git@github.com'
+  git config --global --add "url.https://token:$env:GIT_PRIVATE_TOKEN@github.com/".insteadOf 'https://github.com/'
+
+  git config --global "url.https://ssh:$env:GIT_PRIVATE_TOKEN@github.com/".insteadOf 'ssh://git@github.com/'
+  git config --global "url.https://git:$env:GIT_PRIVATE_TOKEN@github.com/".insteadOf 'git@github.com:'
+}
+
+Write-Host '---------- git config --list -------------'
+git config --list
+
+Write-Host '---------- git config --list --show-origin -------------'
+git config --list --show-origin

--- a/dist/platforms/windows/steps/test.ps1
+++ b/dist/platforms/windows/steps/test.ps1
@@ -1,0 +1,251 @@
+# Native Windows host-mode equivalent of ../../ubuntu/steps/test.sh - see
+# runsteps.ps1's doc comment.
+#
+# Standalone sub-flow: the Linux version wraps the built standalone test
+# player in `xvfb-run` to give it a virtual X display. Windows has a real
+# display session on an interactive self-hosted runner, so no virtual-
+# display wrapper is used - the player is invoked directly, the same way
+# build.ps1 invokes the Editor directly. KNOWN LIMITATION: on a headless
+# Windows Server box with no interactive session (e.g. running as a
+# Windows service with no desktop), the standalone player may still fail
+# to start for the same fundamental reason `-nographics` alone doesn't
+# always suffice on Linux without Xvfb - this is not handled here and has
+# no Windows equivalent implemented.
+$StepsDir = if ($Env:STEPS_DIR) { $Env:STEPS_DIR } else { $PSScriptRoot }
+. (Join-Path $StepsDir 'resolve_unity_path.ps1')
+
+$Env:UNITY_PROJECT_PATH = Join-Path $Env:GITHUB_WORKSPACE $Env:PROJECT_PATH
+Write-Host "Using project path `"$($Env:UNITY_PROJECT_PATH)`"."
+
+Write-Host "Using artifacts path `"$($Env:ARTIFACTS_PATH)`" to save test results."
+$FullArtifactsPath = Join-Path $Env:GITHUB_WORKSPACE $Env:ARTIFACTS_PATH
+
+Write-Host "Using coverage results path `"$($Env:COVERAGE_RESULTS_PATH)`" to save test coverage results."
+$FullCoverageResultsPath = Join-Path $Env:GITHUB_WORKSPACE $Env:COVERAGE_RESULTS_PATH
+
+Write-Host "Using custom parameters $($Env:CUSTOM_PARAMETERS)."
+Write-Host "Using Unity version `"$($Env:UNITY_VERSION)`" to test."
+
+#
+# Setup token for private package registry.
+#
+if ($Env:PRIVATE_REGISTRY_TOKEN) {
+  Write-Host 'Private registry token detected, creating .upmconfig.toml'
+
+  $UpmConfigTomlPath = Join-Path $HOME '.upmconfig.toml'
+  Write-Host "Creating toml at path: $UpmConfigTomlPath"
+
+  $toml = "[npmAuth.`"$($Env:SCOPED_REGISTRY_URL)`"]`ntoken = `"$($Env:PRIVATE_REGISTRY_TOKEN)`"`nalwaysAuth = true`n"
+  if ($Env:PRIVATE_REGISTRY_USER) {
+    Write-Host "Adding user = $($Env:PRIVATE_REGISTRY_USER)"
+    $toml += "user = `"$($Env:PRIVATE_REGISTRY_USER)`"`n"
+  }
+  Set-Content -Path $UpmConfigTomlPath -Value $toml
+}
+
+#
+# Create an empty project for testing if in package mode
+#
+try {
+  $UnityExePath = Get-UnityEditorExePath
+} catch {
+  Write-Host "Unity Editor could not be located: $($_.Exception.Message)"
+  $global:TEST_RUNNER_EXIT_CODE = 1
+  return
+}
+
+if ($Env:PACKAGE_MODE -eq 'true') {
+  Write-Host 'Running tests on a Unity package rather than a Unity project.'
+
+  Write-Host ''
+  Write-Host '###########################'
+  Write-Host '#    Package Folder       #'
+  Write-Host '###########################'
+  Write-Host ''
+  Get-ChildItem $Env:UNITY_PROJECT_PATH
+
+  Write-Host "Creating an empty Unity project to add the package $($Env:PACKAGE_NAME) to."
+  $TempProjectPath = Join-Path (Get-Location) 'TempProject'
+
+  & $UnityExePath -batchmode -createProject $TempProjectPath -quit | Out-Host
+
+  Write-Host 'Adding package to the temporary project''s dependencies and testables...'
+  Write-Host ''
+
+  $PackageManifestPath = Join-Path $TempProjectPath 'Packages\manifest.json'
+  if (-not (Test-Path $PackageManifestPath)) {
+    Write-Host 'Packages/manifest.json was not created properly. This indicates a problem with the CLI, not with your package. Logging directories and aborting...'
+
+    Write-Host ''
+    Write-Host '###########################'
+    Write-Host '#   Temp Project Folder   #'
+    Write-Host '###########################'
+    Write-Host ''
+    if (Test-Path $TempProjectPath) { Get-ChildItem -Force $TempProjectPath }
+
+    Write-Host ''
+    Write-Host '################################'
+    Write-Host '# Temp Project Packages Folder #'
+    Write-Host '################################'
+    Write-Host ''
+    $PackagesDir = Join-Path $TempProjectPath 'Packages'
+    if (Test-Path $PackagesDir) { Get-ChildItem -Force $PackagesDir }
+
+    $global:TEST_RUNNER_EXIT_CODE = 1
+    return
+  }
+
+  $Manifest = Get-Content -Raw $PackageManifestPath | ConvertFrom-Json -AsHashtable
+  if (-not $Manifest.dependencies) { $Manifest.dependencies = @{} }
+  $Manifest.dependencies['com.unity.testtools.codecoverage'] = '1.1.1'
+  $Manifest.dependencies[$Env:PACKAGE_NAME] = "file:$($Env:UNITY_PROJECT_PATH)"
+  $Manifest.testables = @($Env:PACKAGE_NAME)
+
+  if ($Env:SCOPED_REGISTRY_URL -and $Env:REGISTRY_SCOPES) {
+    $Manifest.scopedRegistries = @(
+      @{ name = 'dependency'; url = $Env:SCOPED_REGISTRY_URL; scopes = @($Env:REGISTRY_SCOPES -split ',') }
+    )
+  }
+
+  $Manifest | ConvertTo-Json -Depth 10 | Set-Content -Path $PackageManifestPath
+
+  $Env:UNITY_PROJECT_PATH = $TempProjectPath
+}
+
+Write-Host ''
+Write-Host '###########################'
+Write-Host '#    Artifacts folder     #'
+Write-Host '###########################'
+Write-Host ''
+Write-Host "Creating `"$FullArtifactsPath`" if it does not exist."
+if (-not (Test-Path $FullArtifactsPath)) {
+  New-Item -ItemType Directory -Force -Path $FullArtifactsPath | Out-Null
+}
+
+Write-Host ''
+Write-Host '###########################'
+Write-Host '#    Project directory    #'
+Write-Host '###########################'
+Write-Host ''
+Get-ChildItem $Env:UNITY_PROJECT_PATH
+
+#
+# coverageEnabled gates the code-coverage flags entirely (game-ci/unity-test-runner#311):
+# some Unity versions/configurations crash or fail to compile with
+# com.unity.testtools.codecoverage's instrumentation enabled. Default true
+# to match prior behavior when unset.
+#
+$CoverageFlags = @()
+if (-not $Env:COVERAGE_ENABLED -or $Env:COVERAGE_ENABLED -eq 'true') {
+  $CoverageFlags = @('-coverageResultsPath', $FullCoverageResultsPath, '-enableCodeCoverage', '-debugCodeOptimization', '-coverageOptions', $Env:COVERAGE_OPTIONS)
+} else {
+  Write-Host 'Code coverage disabled (coverageEnabled=false).'
+}
+
+$CustomParametersArray = @()
+if ($Env:CUSTOM_PARAMETERS) {
+  $CustomParametersArray = $Env:CUSTOM_PARAMETERS -split '\s+' | Where-Object { $_ -ne '' }
+}
+
+$TestRunnerExitCode = 0
+
+$Platforms = $Env:TEST_PLATFORMS -split ';' | Where-Object { $_ -ne '' }
+foreach ($Platform in $Platforms) {
+  $RunTestsArgs = @()
+
+  if ($Platform -eq 'standalone') {
+    Write-Host ''
+    Write-Host '###########################'
+    Write-Host '#   Building Standalone   #'
+    Write-Host '###########################'
+    Write-Host ''
+
+    $EditorDir = Join-Path $Env:UNITY_PROJECT_PATH 'Assets\Editor'
+    $PlayerDir = Join-Path $Env:UNITY_PROJECT_PATH 'Assets\Player'
+    New-Item -ItemType Directory -Force -Path $EditorDir | Out-Null
+    New-Item -ItemType Directory -Force -Path $PlayerDir | Out-Null
+
+    $TestRunnerActionDir = if ($Env:TEST_RUNNER_ACTION_DIR) { $Env:TEST_RUNNER_ACTION_DIR } else { Join-Path $Env:ACTION_FOLDER 'test-standalone-scripts' }
+    Copy-Item -Path (Join-Path $TestRunnerActionDir 'Assets\Editor\*') -Destination $EditorDir -Recurse -Force
+    Copy-Item -Path (Join-Path $TestRunnerActionDir 'Assets\Player\*') -Destination $PlayerDir -Recurse -Force
+
+    Get-ChildItem -Recurse $EditorDir
+    Get-ChildItem -Recurse $PlayerDir
+
+    $BuiltTestRunnerPath = Join-Path $Env:UNITY_PROJECT_PATH 'Build\UnityTestRunner-Standalone.exe'
+    $RunTestsArgs = @('-runTests', '-testPlatform', 'StandaloneWindows64', '-builtTestRunnerPath', $BuiltTestRunnerPath)
+  } else {
+    Write-Host ''
+    Write-Host "###########################"
+    Write-Host "#   Testing in $Platform  #"
+    Write-Host "###########################"
+    Write-Host ''
+
+    if ($Platform -ne 'COMBINE_RESULTS') {
+      $ResultsPath = Join-Path $FullArtifactsPath "$Platform-results.xml"
+      $RunTestsArgs = @('-runTests', '-testPlatform', $Platform, '-testResults', $ResultsPath)
+    } else {
+      $RunTestsArgs = @('-quit')
+    }
+  }
+
+  $LogPath = Join-Path $FullArtifactsPath "$Platform.log"
+
+  & $UnityExePath -batchmode -logFile $LogPath -projectPath $Env:UNITY_PROJECT_PATH @RunTestsArgs @CoverageFlags @CustomParametersArray | Out-Host
+  $TestExitCode = $LASTEXITCODE
+
+  if (Test-Path $LogPath) { Get-Content $LogPath | Out-Host }
+
+  if ($TestExitCode -eq 0 -and $Platform -eq 'standalone') {
+    Write-Host ''
+    Write-Host '###########################'
+    Write-Host '#    Testing Standalone   #'
+    Write-Host '###########################'
+    Write-Host ''
+
+    # Code Coverage currently only supports code ran in the Editor and not in Standalone/Player.
+    $PlayerLogPath = Join-Path $FullArtifactsPath "$Platform-player.log"
+    $PlayerResultsPath = Join-Path $FullArtifactsPath "$Platform-results.xml"
+
+    & $BuiltTestRunnerPath -batchmode -nographics -logFile $PlayerLogPath -testResults $PlayerResultsPath | Out-Host
+    $TestExitCode = $LASTEXITCODE
+
+    if (Test-Path $PlayerLogPath) { Get-Content $PlayerLogPath | Out-Host }
+  }
+
+  if ($TestExitCode -eq 0) {
+    Write-Host 'Run succeeded, no failures occurred'
+  } elseif ($TestExitCode -eq 2) {
+    Write-Host 'Run succeeded, some tests failed'
+  } elseif ($TestExitCode -eq 3) {
+    Write-Host 'Run failure (other failure)'
+  } else {
+    Write-Host "Unexpected exit code $TestExitCode"
+  }
+
+  if ($TestExitCode -ne 0) {
+    $TestRunnerExitCode = $TestExitCode
+  }
+
+  Write-Host ''
+  Write-Host "###########################"
+  Write-Host "#    $Platform Results    #"
+  Write-Host "###########################"
+  Write-Host ''
+
+  if ($Platform -ne 'COMBINE_RESULTS') {
+    $ResultsPath = Join-Path $FullArtifactsPath "$Platform-results.xml"
+    if (Test-Path $ResultsPath) {
+      Get-Content $ResultsPath | Out-Host
+      Get-Content $ResultsPath | Select-String 'test-run' | Select-String 'Passed'
+    }
+  }
+}
+
+$global:TEST_RUNNER_EXIT_CODE = $TestRunnerExitCode
+
+if (Test-Path $FullCoverageResultsPath) {
+  # nothing further to do - matches bash version's read-permission step, N/A on Windows
+} elseif (-not $Env:COVERAGE_ENABLED -or $Env:COVERAGE_ENABLED -eq 'true') {
+  Write-Host 'Coverage results directory does not exist. If you are expecting coverage results, please make sure the Code Coverage package is installed in your unity project and that it is set up correctly.'
+}

--- a/src/command/test/unity-test-command.ts
+++ b/src/command/test/unity-test-command.ts
@@ -89,14 +89,21 @@ export class UnityTestCommand extends CommandBase implements CommandInterface {
     const { hostPlatform, local } = options;
 
     if (local) {
+      // HostRunner itself now supports both Linux and Windows natively
+      // (dist/platforms/{ubuntu,windows}/steps/{runsteps,test}.{sh,ps1}) -
+      // this no longer needs a platform gate the way the container path
+      // below still does.
       await HostRunner.run({ ...options, runTests: true });
       return true;
     }
 
-    // Docker test mode is currently only wired up for Linux containers -
-    // dist/platforms/ubuntu/steps/test.sh + runsteps.sh's RUN_TESTS branch.
-    // Windows' entrypoint.ps1 doesn't know about RUN_TESTS yet (it always
-    // runs build.ps1), so running this on a Windows host today would
+    // Docker (container) test mode is currently only wired up for Linux
+    // containers - dist/platforms/ubuntu/steps/test.sh + runsteps.sh's
+    // RUN_TESTS branch. Windows' entrypoint.ps1 (the unityci/editor
+    // Windows *container* image's entrypoint - see HostRunner's doc comment
+    // for why that's a different script set from HostRunner's own native
+    // dist/platforms/windows/steps/) doesn't know about RUN_TESTS yet (it
+    // always runs build.ps1), so running this on a Windows host today would
     // silently attempt a BUILD instead of a test rather than failing
     // loudly - reject it explicitly instead. macOS has no Unity Editor
     // Docker images at all. Checked before PlatformSetup.setup runs, so

--- a/src/model/host-runner.test.ts
+++ b/src/model/host-runner.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, mock, afterEach } from 'bun:test';
+import { HostRunner } from './host-runner.ts';
+import { System } from './system/system.ts';
+import { path } from '../dependencies.ts';
+
+describe('HostRunner', () => {
+  const originalSystemRun = System.run;
+
+  afterEach(() => {
+    System.run = originalSystemRun;
+  });
+
+  describe('buildEnv (private, accessed via any-cast)', () => {
+    const buildEnv = (options: any): Record<string, string> => (HostRunner as any).buildEnv(options);
+
+    it('sets ACTION_FOLDER from cliDistPath (needed by build scripts default-build-script fallback)', () => {
+      const env = buildEnv({
+        currentWorkDir: '/work/repo',
+        cliDistPath: '/work/repo/dist',
+        hostPlatform: 'linux',
+      });
+
+      expect(env.ACTION_FOLDER).toBe('/work/repo/dist');
+    });
+
+    it('points STEPS_DIR at the ubuntu steps dir for linux', () => {
+      const env = buildEnv({
+        currentWorkDir: '/work/repo',
+        cliDistPath: '/work/repo/dist',
+        hostPlatform: 'linux',
+      });
+
+      expect(env.STEPS_DIR).toBe(path.join('/work/repo/dist', 'platforms', 'ubuntu', 'steps'));
+    });
+
+    it('points STEPS_DIR at the native windows steps dir (not the Docker-container script set) for win32', () => {
+      const env = buildEnv({
+        currentWorkDir: 'C:\\work\\repo',
+        cliDistPath: 'C:\\work\\repo\\dist',
+        hostPlatform: 'win32',
+      });
+
+      expect(env.STEPS_DIR).toBe(path.join('C:\\work\\repo\\dist', 'platforms', 'windows', 'steps'));
+    });
+  });
+
+  describe('stepsDir (private, accessed via any-cast)', () => {
+    const stepsDir = (hostPlatform: string, cliDistPath: string): string =>
+      (HostRunner as any).stepsDir(hostPlatform, cliDistPath);
+
+    it('resolves the windows steps dir under platforms/windows/steps', () => {
+      expect(stepsDir('win32', '/dist')).toBe(path.join('/dist', 'platforms', 'windows', 'steps'));
+    });
+
+    it('resolves the ubuntu steps dir under platforms/ubuntu/steps', () => {
+      expect(stepsDir('linux', '/dist')).toBe(path.join('/dist', 'platforms', 'ubuntu', 'steps'));
+    });
+  });
+
+  describe('run', () => {
+    it('rejects unsupported host platforms (e.g. darwin) with a clear error', async () => {
+      await expect(
+        HostRunner.run({ hostPlatform: 'darwin', cliDistPath: '/dist', currentWorkDir: '/work' } as any),
+      ).rejects.toThrow(/only supported when running on Linux or Windows/);
+    });
+
+    it('no longer throws the old "Windows host-mode support is tracked separately" rejection for win32', async () => {
+      const runMock = mock(() => Promise.resolve({ output: '', error: '', status: { success: true, code: 0 } }));
+      System.run = runMock as any;
+
+      await HostRunner.run({
+        hostPlatform: 'win32',
+        cliDistPath: 'C:\\dist',
+        currentWorkDir: 'C:\\work',
+      } as any);
+
+      expect(runMock).toHaveBeenCalled();
+    });
+
+    it('on win32, shells out via a nested powershell -File invocation of runsteps.ps1 and re-propagates its exit code', async () => {
+      let capturedCommand = '';
+      const runMock = mock((command: string) => {
+        capturedCommand = command;
+        return Promise.resolve({ output: '', error: '', status: { success: true, code: 0 } });
+      });
+      System.run = runMock as any;
+
+      await HostRunner.run({
+        hostPlatform: 'win32',
+        cliDistPath: 'C:\\dist',
+        currentWorkDir: 'C:\\work',
+      } as any);
+
+      expect(capturedCommand).toContain('powershell');
+      expect(capturedCommand).toContain('-File');
+      expect(capturedCommand).toContain(path.join('platforms', 'windows', 'steps', 'runsteps.ps1'));
+      expect(capturedCommand).toContain('exit $LASTEXITCODE');
+    });
+
+    it('on linux, shells out via bash to runsteps.sh (unchanged behavior)', async () => {
+      let capturedCommand = '';
+      const runMock = mock((command: string) => {
+        capturedCommand = command;
+        return Promise.resolve({ output: '', error: '', status: { success: true, code: 0 } });
+      });
+      System.run = runMock as any;
+
+      await HostRunner.run({
+        hostPlatform: 'linux',
+        cliDistPath: '/dist',
+        currentWorkDir: '/work',
+      } as any);
+
+      expect(capturedCommand).toBe(`bash "${path.join('/dist', 'platforms', 'ubuntu', 'steps', 'runsteps.sh')}"`);
+    });
+  });
+});

--- a/src/model/host-runner.test.ts
+++ b/src/model/host-runner.test.ts
@@ -1,7 +1,16 @@
 import { describe, it, expect, mock, afterEach } from 'bun:test';
 import { HostRunner } from './host-runner.ts';
 import { System } from './system/system.ts';
-import { path } from '../dependencies.ts';
+import { path, fsSync as fs } from '../dependencies.ts';
+import os from 'node:os';
+
+// buildEnv/run both do a real fs.mkdirSync for ACTIVATE_LICENSE_PATH (see
+// host-runner.ts) - previously these tests passed hardcoded paths like
+// '/work/repo', which happened to succeed on a couple of local dev
+// sandboxes but is not guaranteed writable (and reliably isn't, e.g.
+// EACCES on GitHub's own Linux runners, which can't mkdir at filesystem
+// root). Use a real, writable temp directory instead.
+const scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'host-runner-test-'));
 
 describe('HostRunner', () => {
   const originalSystemRun = System.run;
@@ -14,23 +23,25 @@ describe('HostRunner', () => {
     const buildEnv = (options: any): Record<string, string> => (HostRunner as any).buildEnv(options);
 
     it('sets ACTION_FOLDER from cliDistPath (needed by build scripts default-build-script fallback)', () => {
+      const cliDistPath = path.join(scratchDir, 'dist');
       const env = buildEnv({
-        currentWorkDir: '/work/repo',
-        cliDistPath: '/work/repo/dist',
+        currentWorkDir: scratchDir,
+        cliDistPath,
         hostPlatform: 'linux',
       });
 
-      expect(env.ACTION_FOLDER).toBe('/work/repo/dist');
+      expect(env.ACTION_FOLDER).toBe(cliDistPath);
     });
 
     it('points STEPS_DIR at the ubuntu steps dir for linux', () => {
+      const cliDistPath = path.join(scratchDir, 'dist');
       const env = buildEnv({
-        currentWorkDir: '/work/repo',
-        cliDistPath: '/work/repo/dist',
+        currentWorkDir: scratchDir,
+        cliDistPath,
         hostPlatform: 'linux',
       });
 
-      expect(env.STEPS_DIR).toBe(path.join('/work/repo/dist', 'platforms', 'ubuntu', 'steps'));
+      expect(env.STEPS_DIR).toBe(path.join(cliDistPath, 'platforms', 'ubuntu', 'steps'));
     });
 
     it('points STEPS_DIR at the native windows steps dir (not the Docker-container script set) for win32', () => {
@@ -60,7 +71,7 @@ describe('HostRunner', () => {
   describe('run', () => {
     it('rejects unsupported host platforms (e.g. darwin) with a clear error', async () => {
       await expect(
-        HostRunner.run({ hostPlatform: 'darwin', cliDistPath: '/dist', currentWorkDir: '/work' } as any),
+        HostRunner.run({ hostPlatform: 'darwin', cliDistPath: '/dist', currentWorkDir: scratchDir } as any),
       ).rejects.toThrow(/only supported when running on Linux or Windows/);
     });
 
@@ -70,8 +81,8 @@ describe('HostRunner', () => {
 
       await HostRunner.run({
         hostPlatform: 'win32',
-        cliDistPath: 'C:\\dist',
-        currentWorkDir: 'C:\\work',
+        cliDistPath: path.join(scratchDir, 'dist'),
+        currentWorkDir: scratchDir,
       } as any);
 
       expect(runMock).toHaveBeenCalled();
@@ -87,8 +98,8 @@ describe('HostRunner', () => {
 
       await HostRunner.run({
         hostPlatform: 'win32',
-        cliDistPath: 'C:\\dist',
-        currentWorkDir: 'C:\\work',
+        cliDistPath: path.join(scratchDir, 'dist'),
+        currentWorkDir: scratchDir,
       } as any);
 
       expect(capturedCommand).toContain('powershell');
@@ -105,13 +116,14 @@ describe('HostRunner', () => {
       });
       System.run = runMock as any;
 
+      const cliDistPath = path.join(scratchDir, 'dist');
       await HostRunner.run({
         hostPlatform: 'linux',
-        cliDistPath: '/dist',
-        currentWorkDir: '/work',
+        cliDistPath,
+        currentWorkDir: scratchDir,
       } as any);
 
-      expect(capturedCommand).toBe(`bash "${path.join('/dist', 'platforms', 'ubuntu', 'steps', 'runsteps.sh')}"`);
+      expect(capturedCommand).toBe(`bash "${path.join(cliDistPath, 'platforms', 'ubuntu', 'steps', 'runsteps.sh')}"`);
     });
   });
 });

--- a/src/model/host-runner.ts
+++ b/src/model/host-runner.ts
@@ -13,12 +13,24 @@ import { path, fsSync as fs } from '../dependencies.ts';
  * `local` provider, which runs the equivalent build/test commands directly
  * on the host rather than dispatching to a container/cloud provider.
  *
- * Deliberately does NOT invoke entrypoint.sh: that script does
- * container-only setup (randomizing /etc/machine-id, creating a matching
- * host user via useradd/groupadd) that would mutate a real, persistent
- * self-hosted machine rather than a throwaway container - genuinely
- * dangerous outside Docker. Goes straight to runsteps.sh (activate -> test
- * or build -> return license), the same core steps.sh scripts already use.
+ * Deliberately does NOT invoke entrypoint.sh/entrypoint.ps1: those scripts
+ * do container-only setup (Linux: randomizing /etc/machine-id, creating a
+ * matching host user via useradd/groupadd; Windows: registry imports,
+ * registering the container's own Visual Studio installation) that would
+ * mutate a real, persistent self-hosted machine rather than a throwaway
+ * container - genuinely dangerous outside Docker. Goes straight to
+ * runsteps.sh/runsteps.ps1 (activate -> test or build -> return license),
+ * the same core step scripts already use.
+ *
+ * Windows note: dist/platforms/windows/*.ps1 (activate.ps1, build.ps1,
+ * entrypoint.ps1, ...) are the *Docker container* scripts for
+ * `unityci/editor` Windows images - they assume a baked-in $Env:UNITY_PATH
+ * and container-only setup, and have no RUN_TESTS support at all. This
+ * class instead uses a separate, genuinely native script set under
+ * dist/platforms/windows/steps/ (mirroring dist/platforms/ubuntu/steps/),
+ * which resolve Unity's install location dynamically from Unity Hub's
+ * default install directory (or $Env:UNITY_PATH if set) rather than
+ * assuming a container-baked path.
  */
 class HostRunner {
   private static buildEnv(options: Options): Record<string, string> {
@@ -31,13 +43,19 @@ class HostRunner {
       env[name] = value.toString();
     }
     if (currentWorkDir) env.GITHUB_WORKSPACE = currentWorkDir;
+    // Used by the native build scripts' default build-method fallback (no
+    // BUILD_METHOD set) to locate dist/default-build-script - mirrors
+    // MacBuilder.buildEnv's own ACTION_FOLDER, which mac/steps/build.sh
+    // already relies on for the same purpose.
+    env.ACTION_FOLDER = cliDistPath;
 
     const stepsDir = HostRunner.stepsDir(hostPlatform, cliDistPath);
     env.STEPS_DIR = stepsDir;
     env.TEST_RUNNER_ACTION_DIR = path.join(cliDistPath, 'test-standalone-scripts');
 
-    // entrypoint.sh normally creates this before sourcing runsteps.sh -
-    // replicated here since HostRunner bypasses entrypoint.sh entirely.
+    // entrypoint.sh/entrypoint.ps1 normally create this before sourcing
+    // runsteps.sh/runsteps.ps1 - replicated here since HostRunner bypasses
+    // those entrypoints entirely.
     const activateLicensePath = path.join(currentWorkDir || process.cwd(), '_activate-license~');
     if (!fs.existsSync(activateLicensePath)) fs.mkdirSync(activateLicensePath, { recursive: true });
     env.ACTIVATE_LICENSE_PATH = activateLicensePath;
@@ -48,7 +66,10 @@ class HostRunner {
   private static stepsDir(hostPlatform: string, cliDistPath: string): string {
     switch (hostPlatform) {
       case 'win32':
-        return path.join(cliDistPath, 'platforms', 'windows');
+        // Deliberately NOT dist/platforms/windows (the Docker-container
+        // script set - see class doc comment) - a sibling steps/ directory
+        // with genuinely native scripts, mirroring ubuntu's steps/ layout.
+        return path.join(cliDistPath, 'platforms', 'windows', 'steps');
       case 'linux':
       default:
         return path.join(cliDistPath, 'platforms', 'ubuntu', 'steps');
@@ -58,19 +79,38 @@ class HostRunner {
   public static async run(options: Options, silent = false) {
     const { cliDistPath, hostPlatform } = options;
 
-    if (hostPlatform !== 'linux') {
+    if (hostPlatform !== 'linux' && hostPlatform !== 'win32') {
       throw new Error(
-        `--local is currently only supported when running on Linux (got hostPlatform=${hostPlatform}). ` +
-          'macOS already runs natively via MacBuilder without needing --local; Windows host-mode support is tracked separately.',
+        `--local is currently only supported when running on Linux or Windows (got hostPlatform=${hostPlatform}). ` +
+          'macOS already runs natively via MacBuilder without needing --local.',
       );
     }
 
     log.warning('running the process directly on this host (no Docker)');
 
+    const env = HostRunner.buildEnv(options);
+
+    if (hostPlatform === 'win32') {
+      const runstepsPath = path.join(cliDistPath, 'platforms', 'windows', 'steps', 'runsteps.ps1');
+      // Run via a nested `-File` invocation (rather than passing the script
+      // path straight to System.run's own `-Command` shell) so PowerShell's
+      // native argument handling deals with quoting, and so the script's
+      // own `exit $code` calls set that nested process's exit code
+      // directly - then explicitly re-propagate it as this command's own
+      // exit code, since a plain `-Command` invocation does not otherwise
+      // forward a nested process's exit code as its own.
+      await System.run(
+        `powershell -NoProfile -ExecutionPolicy Bypass -File "${runstepsPath}"; exit $LASTEXITCODE`,
+        undefined,
+        { silent, env },
+      );
+      return;
+    }
+
     const runstepsPath = path.join(cliDistPath, 'platforms', 'ubuntu', 'steps', 'runsteps.sh');
     await System.run(`bash "${runstepsPath}"`, undefined, {
       silent,
-      env: HostRunner.buildEnv(options),
+      env,
     });
   }
 }


### PR DESCRIPTION
## Summary

`HostRunner` — the only non-Docker Unity execution path in `game-ci/cli` (used by `test --docker --local`) — threw unconditionally for any host platform other than Linux:

```
--local is currently only supported when running on Linux (got hostPlatform=win32).
```

This is a real, structural gap for self-hosted Windows runners with Unity already installed via Unity Hub and no Docker — a common setup with no working path in `game-ci/cli` at all until now.

## What changed

- New native Windows step-script set: `dist/platforms/windows/steps/{runsteps,activate,build,test,return_license,set_extra_git_configs,set_gitcredential}.ps1`, plus `resolve_unity_path.ps1` for dynamic Unity Hub install-path resolution — mirroring the existing `dist/platforms/ubuntu/steps/` bash chain step-for-step (activate → build/test → return license, `SKIP_ACTIVATION`/`ACTIVATE_ONLY`/`RUN_TESTS` all honored the same way).
- This is a **distinct script set** from the existing `dist/platforms/windows/*.ps1` one directory up, which are the Windows **Docker container** scripts for `unityci/editor` images — those assume a container-baked `$Env:UNITY_PATH` and have no `RUN_TESTS` support at all. Left untouched.
- Unity's install location is resolved dynamically (`C:\Program Files\Unity\Hub\Editor\<version>`, or `$Env:UNITY_PATH` override) rather than assumed, since a self-hosted machine's Unity isn't baked into a fixed image path the way the container scripts can assume.
- `HostRunner.run()` / `stepsDir()` now dispatch to this script set on `win32` instead of throwing.
- All three license-activation strategies (personal file / serial / floating server) implemented with the same success-detection logic as the Linux version.

## Known scope limits (not attempted here, flagged rather than silently gapped)

- Headless/no-display Windows Server for the standalone test sub-flow — no `xvfb-run` equivalent exists on Windows; flagged inline in `test.ps1`.
- Android SDK setup in the native Windows build path — matches an existing gap in the Linux native `build.sh`, not a new omission.
- Package-mode test flow was implemented (native PowerShell JSON handling, no `jq` dependency) but only syntax-checked, not exercised against a real Unity install.

## Verification

- `bun test ./src`: **168 pass, 3 skip, 0 fail**, including new `host-runner.test.ts` coverage for both platforms' `buildEnv`/`stepsDir`/command construction.
- `bun run build` succeeds.
- All 8 new `.ps1` files pass PowerShell tokenizer syntax-check.
- **Live sanity check** (this sandbox is Windows): `bun run src/index.ts test --docker --local --projectPath <synthetic git-initialized Unity-shaped project>` reached real Windows activation logic and failed cleanly with:
  ```
  Unity Editor could not be run: Unity Editor not found at "C:\Program Files\Unity\Hub\Editor\2021.3.16f1\Editor\Unity.exe".
  Install Unity 2021.3.16f1 via Unity Hub (the default self-hosted-runner install location is used automatically),
  or set the UNITY_PATH environment variable ... if Unity is installed somewhere else.
  ```
  Confirms the old blanket platform-rejection is gone and replaced by real, correct Windows-path logic — a clean "Unity not installed" is the expected outcome in a sandbox with no real Unity Editor.

## Test plan

- [x] `bun test ./src` passes
- [x] `bun run build` succeeds
- [x] Live `test --docker --local` run on Windows reaches real activation/build logic instead of the old platform-rejection error
- [ ] Follow-up: validate against a real self-hosted Windows runner with Unity actually installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running local tests natively on Windows hosts.
  * Windows execution now uses PowerShell and dedicated Windows test scripts.
  * Linux execution continues using Bash-based test scripts.
  * Improved environment handling for local build and test execution.

* **Bug Fixes**
  * Unsupported host platforms are now rejected with clearer validation.
  * Windows test exit codes are correctly propagated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->