### PR TITLE
feat: give the orchestrator's local provider a real build path

### DIFF
--- a/plugins/orchestrator/src/cli-plugin/build-parameters-adapter.ts
+++ b/plugins/orchestrator/src/cli-plugin/build-parameters-adapter.ts
@@ -58,6 +58,11 @@ export function createBuildParametersFromCliOptions(options: Record<string, any>
   bp.finalHooks = options.finalHooks ? String(options.finalHooks).split(',') : [];
   bp.skipLfs = options.skipLfs === true || options.skipLfs === 'true';
   bp.skipCache = options.skipCache === true || options.skipCache === 'true';
+  // Skip Unity license activation/return for the local/local-system provider's
+  // generated build script (sets SKIP_ACTIVATION for runsteps.sh) -- for
+  // self-hosted runners with an already-licensed, long-lived Unity Hub
+  // session, distinct from `game-ci activate`'s per-run activation.
+  bp.skipActivation = options.skipActivation === true || options.skipActivation === 'true';
   bp.skipInContainerClone =
     options.skipInContainerClone === true || options.skipInContainerClone === 'true';
   bp.repoPathOverride = options.repoPathOverride || '';

--- a/plugins/orchestrator/src/cli-plugin/cli-plugin.test.ts
+++ b/plugins/orchestrator/src/cli-plugin/cli-plugin.test.ts
@@ -70,6 +70,8 @@ describe('CLI Plugin Adapter', () => {
       expect(registered).toHaveProperty('gitlabProjectId');
       expect(registered).toHaveProperty('remotePowershellHost');
       expect(registered).toHaveProperty('ansibleInventory');
+      expect(registered).toHaveProperty('skipActivation');
+      expect(registered.skipActivation.default).toBe(false);
     });
   });
 
@@ -155,6 +157,25 @@ describe('CLI Plugin Adapter', () => {
       expect(bp.gitlabProjectId).toBe('12345');
       expect(bp.ansibleInventory).toBe('/path/to/hosts');
       expect(bp.remotePowershellHost).toBe('win-server');
+    });
+
+    it('maps skipActivation (true) from boolean and string forms', () => {
+      const fromBoolean = createBuildParametersFromCliOptions({ skipActivation: true });
+      expect(fromBoolean.skipActivation).toBe(true);
+
+      const fromString = createBuildParametersFromCliOptions({ skipActivation: 'true' });
+      expect(fromString.skipActivation).toBe(true);
+    });
+
+    it('defaults skipActivation to false when unset or falsy', () => {
+      const unset = createBuildParametersFromCliOptions({});
+      expect(unset.skipActivation).toBe(false);
+
+      const explicitFalse = createBuildParametersFromCliOptions({ skipActivation: false });
+      expect(explicitFalse.skipActivation).toBe(false);
+
+      const stringFalse = createBuildParametersFromCliOptions({ skipActivation: 'false' });
+      expect(stringFalse.skipActivation).toBe(false);
     });
   });
 });

--- a/plugins/orchestrator/src/cli-plugin/orchestrator-options-plugin.ts
+++ b/plugins/orchestrator/src/cli-plugin/orchestrator-options-plugin.ts
@@ -337,6 +337,15 @@ export function configureOrchestratorOptions(yargs: any): void {
     default: false,
   });
 
+  yargs.option('skipActivation', {
+    description:
+      'Skip Unity license activation/return -- for self-hosted runners with an already-licensed, ' +
+      'long-lived Unity Hub session. Only meaningful for providerStrategy=local(-system). Distinct ' +
+      'from `game-ci activate`, which activates a license per-run and leaves it active for a later step.',
+    type: 'boolean',
+    default: false,
+  });
+
   yargs.option('skipInContainerClone', {
     description:
       'Skip the in-container git clone and reuse a pre-hydrated workspace bind-mounted by the caller. ' +

--- a/plugins/orchestrator/src/model/build-parameters.ts
+++ b/plugins/orchestrator/src/model/build-parameters.ts
@@ -66,6 +66,12 @@ class BuildParameters {
   finalHooks!: string[];
   skipLfs!: boolean;
   skipCache!: boolean;
+  // Skip Unity license activation/return (SKIP_ACTIVATION env var consumed by
+  // dist/platforms/ubuntu/steps/runsteps.sh). Distinct from `game-ci activate`'s
+  // per-run ACTIVATE_ONLY flow -- this is for the `local`/`local-system`
+  // provider's self-hosted-runner use case, where Unity is already licensed via
+  // a long-lived Unity Hub session and per-run activation/return is unwanted.
+  skipActivation!: boolean;
   skipInContainerClone!: boolean;
   repoPathOverride!: string;
   lockedWorkspace!: string;
@@ -242,6 +248,7 @@ class BuildParameters {
     p.finalHooks = [];
     p.skipLfs = false;
     p.skipCache = false;
+    p.skipActivation = Cli.options?.skipActivation ?? Input.getInput('skipActivation') === 'true';
     p.skipInContainerClone =
       Cli.options?.skipInContainerClone ?? Input.getInput('skipInContainerClone') === 'true';
     p.repoPathOverride = Cli.options?.repoPathOverride ?? Input.getInput('repoPathOverride') ?? '';

--- a/plugins/orchestrator/src/model/orchestrator/providers/local/index.test.ts
+++ b/plugins/orchestrator/src/model/orchestrator/providers/local/index.test.ts
@@ -1,0 +1,17 @@
+import LocalOrchestrator from './index';
+
+describe('LocalOrchestrator.garbageCollect', () => {
+  it('resolves successfully instead of throwing "Method not implemented."', async () => {
+    const provider = new LocalOrchestrator();
+
+    await expect(provider.garbageCollect('', true, 24, true, true)).resolves.not.toThrow();
+  });
+
+  it('returns a string result (does not reject)', async () => {
+    const provider = new LocalOrchestrator();
+
+    const result = await provider.garbageCollect('', false, 24, false, false);
+
+    expect(typeof result).toBe('string');
+  });
+});

--- a/plugins/orchestrator/src/model/orchestrator/providers/local/index.ts
+++ b/plugins/orchestrator/src/model/orchestrator/providers/local/index.ts
@@ -18,7 +18,16 @@ class LocalOrchestrator implements ProviderInterface {
   watchWorkflow(): Promise<string> {
     throw new Error('Method not implemented.');
   }
-  garbageCollect(
+  // The `local`/`local-system` provider runs Unity directly on a self-hosted
+  // machine that already exists independently of this process -- it does not
+  // provision or own any cloud resources (ECS tasks, k8s pods/PVCs, S3/EBS
+  // volumes, ...) the way aws/k8s do. There is therefore nothing for this
+  // provider to garbage-collect: no-op success rather than a fabricated
+  // cleanup of resources this provider never owned. Must not throw --
+  // Orchestrator.run()'s constantGarbageCollection path and gcTimeoutMinutes
+  // finally-block both call this unconditionally, and previously this threw
+  // 'Method not implemented.', hard-failing that cleanup path for local runs.
+  async garbageCollect(
     // eslint-disable-next-line no-unused-vars
     filter: string,
     // eslint-disable-next-line no-unused-vars
@@ -30,7 +39,11 @@ class LocalOrchestrator implements ProviderInterface {
     // eslint-disable-next-line no-unused-vars
     baseDependencies: boolean,
   ): Promise<string> {
-    throw new Error('Method not implemented.');
+    OrchestratorLogger.log(
+      'LocalOrchestrator.garbageCollect: no-op (the local/local-system provider owns no cloud resources to clean up)',
+    );
+
+    return 'nothing to garbage-collect for provider=local';
   }
   cleanupWorkflow(
     // eslint-disable-next-line no-unused-vars

--- a/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.test.ts
+++ b/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.test.ts
@@ -1,0 +1,136 @@
+import BuildParameters from '../../build-parameters';
+import Orchestrator from '../orchestrator';
+import { BuildAutomationWorkflow } from './build-automation-workflow';
+
+function makeBuildParameters(overrides: Partial<BuildParameters> = {}): BuildParameters {
+  const bp = new BuildParameters();
+  bp.providerStrategy = 'local';
+  bp.commandHooks = '';
+  bp.cacheKey = 'test-cache-key';
+  bp.projectPath = 'test-project';
+  bp.targetPlatform = 'StandaloneLinux64';
+  bp.buildName = 'StandaloneLinux64';
+  bp.buildPath = 'build/StandaloneLinux64';
+  bp.buildFile = 'StandaloneLinux64';
+  bp.buildMethod = '';
+  bp.buildVersion = '0.0.1';
+  bp.androidVersionCode = '';
+  bp.chownFilesTo = '';
+  bp.manualExit = false;
+  bp.buildProfile = '';
+  bp.skipActivation = false;
+  bp.dockerWorkspacePath = '/github/workspace';
+  bp.orchestratorRepoName = 'game-ci/orchestrator';
+  bp.orchestratorBranch = 'main';
+  bp.gitAuthMode = 'header';
+  bp.logId = 'test-log-id';
+  bp.buildGuid = 'test-build-guid';
+  bp.maxRetainedWorkspaces = 0;
+  bp.repoPathOverride = '';
+
+  return Object.assign(bp, overrides);
+}
+
+// The workflow script generator is a private static getter -- access it the
+// same way the rest of this codebase reaches into internals under test.
+function getBuildWorkflow(): string {
+  return (BuildAutomationWorkflow as any).BuildWorkflow;
+}
+
+describe('BuildAutomationWorkflow.BuildWorkflow (local/local-system branch)', () => {
+  afterEach(() => {
+    Orchestrator.buildParameters = undefined as any;
+  });
+
+  it.each(['local', 'local-system'])(
+    'invokes the shared runsteps.sh/STEPS_DIR chain for providerStrategy=%s instead of the log-stream/post-build-only stub',
+    (providerStrategy) => {
+      Orchestrator.buildParameters = makeBuildParameters({ providerStrategy });
+
+      const script = getBuildWorkflow();
+
+      expect(script).toContain('runsteps.sh');
+      expect(script).toContain('STEPS_DIR');
+      expect(script).toMatch(/platforms[\\/]ubuntu[\\/]steps/);
+      // Must actually reach into the shared step chain, not just the old stub
+      // (log-stream wrapping nothing, then post-build bookkeeping).
+      expect(script).toContain('remote-cli-post-build');
+    },
+  );
+
+  it('does not clone a repo or pull LFS for the local provider (project assumed already on disk)', () => {
+    Orchestrator.buildParameters = makeBuildParameters({ providerStrategy: 'local' });
+
+    const script = getBuildWorkflow();
+
+    expect(script).not.toContain('git clone');
+    expect(script).not.toContain('git lfs pull');
+  });
+
+  it('sets GITHUB_WORKSPACE to the local working directory for the local provider', () => {
+    Orchestrator.buildParameters = makeBuildParameters({ providerStrategy: 'local' });
+
+    const script = getBuildWorkflow();
+
+    expect(script).toContain('export GITHUB_WORKSPACE=');
+    expect(script).toContain('Using local workspace');
+  });
+
+  it('threads skipActivation from BuildParameters into SKIP_ACTIVATION=true in the generated script', () => {
+    Orchestrator.buildParameters = makeBuildParameters({
+      providerStrategy: 'local',
+      skipActivation: true,
+    });
+
+    const script = getBuildWorkflow();
+
+    expect(script).toContain('export SKIP_ACTIVATION="true"');
+  });
+
+  it('leaves SKIP_ACTIVATION unset (empty) when skipActivation is false', () => {
+    Orchestrator.buildParameters = makeBuildParameters({
+      providerStrategy: 'local',
+      skipActivation: false,
+    });
+
+    const script = getBuildWorkflow();
+
+    expect(script).toContain('export SKIP_ACTIVATION=""');
+  });
+
+  it('maps core BuildParameters fields to the env vars build.sh/activate.sh read', () => {
+    Orchestrator.buildParameters = makeBuildParameters({
+      providerStrategy: 'local',
+      projectPath: 'MyUnityProject',
+      targetPlatform: 'StandaloneWindows64',
+      buildName: 'MyBuild',
+      buildMethod: 'MyNamespace.Builder.Build',
+    });
+
+    const script = getBuildWorkflow();
+
+    expect(script).toContain('export PROJECT_PATH="MyUnityProject"');
+    expect(script).toContain('export BUILD_TARGET="StandaloneWindows64"');
+    expect(script).toContain('export BUILD_NAME="MyBuild"');
+    expect(script).toContain('export BUILD_METHOD="MyNamespace.Builder.Build"');
+  });
+
+  it('still uses the log-stream/post-build-only stub for non-local, non-containerized providers (e.g. test)', () => {
+    Orchestrator.buildParameters = makeBuildParameters({ providerStrategy: 'test' });
+
+    const script = getBuildWorkflow();
+
+    expect(script).not.toContain('runsteps.sh');
+    expect(script).toContain('remote-cli-log-stream');
+    expect(script).toContain('remote-cli-post-build');
+  });
+
+  it('does not touch the local-docker containerized branch', () => {
+    Orchestrator.buildParameters = makeBuildParameters({ providerStrategy: 'local-docker' });
+
+    const script = getBuildWorkflow();
+
+    expect(script).toContain('/entrypoint.sh');
+    expect(script).not.toContain('STEPS_DIR');
+  });
+});

--- a/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.ts
+++ b/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.ts
@@ -101,6 +101,17 @@ export class BuildAutomationWorkflow implements WorkflowInterface {
       Orchestrator.buildParameters.providerStrategy === 'k8s' ||
       Orchestrator.buildParameters.providerStrategy === 'local-docker';
 
+    // The bare-host provider (game-ci/orchestrator's `local`/`local-system`
+    // provider strategy, both backed by LocalOrchestrator -- see
+    // plugins/orchestrator/src/cli-plugin/index.ts) is non-containerized like
+    // aws/k8s/local-docker's remote-dispatch cousins (test, gcp-cloud-run,
+    // github-actions, ...), but unlike those it actually needs to invoke
+    // Unity directly on this machine, so it gets its own branch below.
+    const isBareLocalProvider =
+      !isContainerized &&
+      (Orchestrator.buildParameters.providerStrategy === 'local' ||
+        Orchestrator.buildParameters.providerStrategy === 'local-system');
+
     const builderPath = isContainerized
       ? OrchestratorFolders.ToLinuxFolder(
           path.join(OrchestratorFolders.builderPathAbsolute, 'dist', `index.js`),
@@ -124,14 +135,17 @@ export class BuildAutomationWorkflow implements WorkflowInterface {
         Orchestrator.buildParameters.providerStrategy === 'local-docker'
           ? `export GITHUB_WORKSPACE="${Orchestrator.buildParameters.dockerWorkspacePath}"
       echo "Using docker workspace: $GITHUB_WORKSPACE"`
-          : `export GITHUB_WORKSPACE="${OrchestratorFolders.ToLinuxFolder(OrchestratorFolders.repoPathAbsolute)}"`
+          : isBareLocalProvider
+            ? `export GITHUB_WORKSPACE="${OrchestratorFolders.ToLinuxFolder(process.cwd())}"
+      echo "Using local workspace: $GITHUB_WORKSPACE"`
+            : `export GITHUB_WORKSPACE="${OrchestratorFolders.ToLinuxFolder(OrchestratorFolders.repoPathAbsolute)}"`
       }
       ${isContainerized ? 'df -H /data/' : '# skipping df on /data in non-container provider'}
       export LOG_FILE=${isContainerized ? '/home/job-log.txt' : '$(pwd)/temp/job-log.txt'}
       ${BuildAutomationWorkflow.setupCommands(builderPath, isContainerized)}
       ${setupHooks.filter((x) => x.hook.includes(`after`)).map((x) => x.commands) || ' '}
       ${buildHooks.filter((x) => x.hook.includes(`before`)).map((x) => x.commands) || ' '}
-      ${BuildAutomationWorkflow.BuildCommands(builderPath, isContainerized)}
+      ${BuildAutomationWorkflow.BuildCommands(builderPath, isContainerized, isBareLocalProvider)}
       ${buildHooks.filter((x) => x.hook.includes(`after`)).map((x) => x.commands) || ' '}`;
   }
 
@@ -172,7 +186,11 @@ export CACHE_KEY="${Orchestrator.buildParameters.cacheKey}"
 echo "CACHE_KEY=$CACHE_KEY"`;
   }
 
-  private static BuildCommands(builderPath: string, isContainerized: boolean) {
+  private static BuildCommands(
+    builderPath: string,
+    isContainerized: boolean,
+    isBareLocalProvider = false,
+  ) {
     const distFolder = path.join(OrchestratorFolders.builderPathAbsolute, 'dist');
     const ubuntuPlatformsFolder = path.join(
       OrchestratorFolders.builderPathAbsolute,
@@ -284,6 +302,51 @@ echo "CACHE_KEY=$CACHE_KEY"`;
     # Write end markers to both stdout and log file (builder might be cleaned up by post-build)
     echo "end of orchestrator job" | tee -a /home/job-log.txt
     echo "---${Orchestrator.buildParameters.logId}" | tee -a /home/job-log.txt`;
+    }
+
+    if (isBareLocalProvider) {
+      const bp = Orchestrator.buildParameters;
+      // Same step-script chain game-ci/cli's own HostRunner (src/model/host-runner.ts)
+      // drives for `game-ci build/test --local`: runsteps.sh -> activate.sh ->
+      // build.sh/test.sh -> return_license.sh, run directly against this host's
+      // Unity install. Deliberately skips entrypoint.sh (container-only setup:
+      // /etc/machine-id randomization, useradd/groupadd) for the same reason
+      // HostRunner does -- see the comment on HostRunner for why that would be
+      // dangerous to run against a real, persistent self-hosted machine.
+      //
+      // No repo clone / LFS pull here (unlike the aws/k8s/local-docker branches
+      // above): the `local` provider is for a self-hosted runner where the
+      // project is assumed already checked out and hydrated at GITHUB_WORKSPACE
+      // (set to process.cwd() above), so there is nothing to clone or hydrate.
+      const stepsDir = OrchestratorFolders.ToLinuxFolder(
+        path.join(process.cwd(), 'dist', 'platforms', 'ubuntu', 'steps'),
+      );
+
+      // prettier-ignore
+      return `
+    echo "game ci start"
+    echo "game ci start" >> "$LOG_FILE"
+    export STEPS_DIR="${stepsDir}"
+    export PROJECT_PATH="${bp.projectPath || ''}"
+    export BUILD_TARGET="${bp.targetPlatform || ''}"
+    export BUILD_NAME="${bp.buildName || ''}"
+    export BUILD_PATH="${bp.buildPath || ''}"
+    export BUILD_FILE="${bp.buildFile || ''}"
+    export BUILD_METHOD="${bp.buildMethod || ''}"
+    export VERSION="${bp.buildVersion || ''}"
+    export ANDROID_VERSION_CODE="${bp.androidVersionCode || ''}"
+    export CHOWN_FILES_TO="${bp.chownFilesTo || ''}"
+    export MANUAL_EXIT="${bp.manualExit ? 'true' : ''}"
+    export BUILD_PROFILE="${bp.buildProfile || ''}"
+    export SKIP_ACTIVATION="${bp.skipActivation ? 'true' : ''}"
+    # entrypoint.sh normally creates this before sourcing runsteps.sh; replicated
+    # here since we bypass entrypoint.sh entirely (see HostRunner.buildEnv).
+    export ACTIVATE_LICENSE_PATH="$GITHUB_WORKSPACE/_activate-license~"
+    mkdir -p "$ACTIVATE_LICENSE_PATH"
+    mkdir -p "$GITHUB_WORKSPACE/$BUILD_PATH"
+    # Pipe runsteps.sh output through log stream to capture Unity build/activation output
+    { bash "$STEPS_DIR/runsteps.sh"; echo "RUNSTEPS_EXIT_CODE:$?" >> "$LOG_FILE"; } | node ${builderPath} -m remote-cli-log-stream --logFile "$LOG_FILE"
+    node ${builderPath} -m remote-cli-post-build`;
     }
 
     // prettier-ignore


### PR DESCRIPTION
## Summary

\`game-ci orchestrate --providerStrategy local\`'s generated \`BuildWorkflow\` only did log-stream + post-build bookkeeping around nothing — it never actually invoked Unity. The \`isContainerized\` branch (which does invoke Unity, via a clone + entrypoint.sh) skips \`local\`/\`local-system\` entirely, and the non-containerized fallback had no Unity-invocation logic of its own to fall back on.

## What changed

- Adds a dedicated \`local\`/\`local-system\` branch to \`BuildAutomationWorkflow.BuildCommands()\` that shells directly into the same step-script chain \`game-ci/cli\`'s own \`HostRunner\` drives for \`build\`/\`test --local\` (\`runsteps.sh\` → \`activate.sh\` → \`build.sh\`/\`test.sh\` → \`return_license.sh\`), with env vars sourced from \`BuildParameters\` instead of CLI options directly.
- No repo clone / LFS pull in this branch, unlike aws/k8s/local-docker — \`local\` is for a self-hosted runner where the project is assumed already checked out and hydrated at \`GITHUB_WORKSPACE\` (set to \`process.cwd()\`). That's the point of the strategy: there's nothing to clone.
- Adds \`--skipActivation\` (threaded through \`build-parameters-adapter.ts\` → \`BuildParameters\` → the generated script's \`SKIP_ACTIVATION\` env var), for self-hosted runners with an already-licensed, long-lived Unity Hub session rather than per-run activation. \`runsteps.sh\` already supported \`SKIP_ACTIVATION\` for a different caller (\`game-ci activate\`) — this exposes it through the orchestrator too.
- Fixes \`LocalOrchestrator.garbageCollect()\`, which threw \`Method not implemented.\` — this would hard-fail \`Orchestrator.run()\`'s GC-timeout / \`constantGarbageCollection\` cleanup path for any \`local\` run that hit either condition. Now an honest no-op with a log line: \`local\` owns no cloud resources (no ECS tasks, no k8s pods, no S3/EBS volumes) to clean up, unlike aws/k8s.

\`BuildParameters\` intentionally does **not** export \`UNITY_LICENSE\`/\`UNITY_SERIAL\`/etc. into the generated script — those flow from the parent process environment the same way \`activate.sh\` already reads them, matching how host-mode invocation works elsewhere in this codebase (a comment in \`build-parameters-adapter.ts\` already notes these fields flow opaquely through the host).

## Verification

- \`bun test ./src\`: 159 pass / 3 skip / 0 fail
- \`plugins/orchestrator\`'s own vitest suite: 931 pass / 1 skip / 1 pre-existing flaky timeout in \`cli-integration.test.ts\` (confirmed pre-existing — passes clean every time when run standalone outside the full parallel suite)
- \`bun run build\` (root) and orchestrator's own \`tsc\` build both succeed
- **Live sanity check**: ran \`orchestrate --providerStrategy local --skipActivation\` against a synthetic git-initialized Unity-shaped project. Confirmed the generated script correctly sets \`GITHUB_WORKSPACE\`/\`STEPS_DIR\`/\`PROJECT_PATH\`/\`SKIP_ACTIVATION=\"true\"\` and invokes \`bash \"$STEPS_DIR/runsteps.sh\"\`. Isolating the exact env-var setup + \`runsteps.sh\` invocation (extracted verbatim from the real generated script) confirmed it runs the real step chain end to end, correctly skips \`activate.sh\` per \`SKIP_ACTIVATION\`, and fails exactly where expected in a sandbox with no real Unity install: \`build.sh: line 136: unity-editor: command not found\`, exit 127 — not silently doing nothing like the old stub.

## Known follow-up (not part of this PR, flagged for a separate fix)

The generated script pipes \`runsteps.sh\`'s output through \`node <builderPath> -m remote-cli-log-stream\` — the same pattern the existing aws/k8s/local-docker branches already use. In this sandbox, that log-stream subprocess crashed with \`Error: Cannot find module './src/cat'\` when invoked against the bundled \`dist/index.js\`, independently reproducible with zero orchestrator/local-provider involvement (\`node dist/index.js -m remote-cli-log-stream\` alone). This is a **pre-existing bug shared by every provider strategy that goes through this log-stream pattern**, not something this PR introduces or regresses — worth a dedicated fix, but out of scope here.

## Test plan

- [x] \`bun test ./src\` passes
- [x] orchestrator's own test suite passes (pre-existing flake aside)
- [x] \`bun run build\` succeeds for both packages
- [x] Live \`orchestrate --providerStrategy local --skipActivation\` reaches and executes the real step-script chain
- [ ] Follow-up: fix the pre-existing \`remote-cli-log-stream\` crash (separate PR)
- [ ] Follow-up: validate against a real self-hosted runner with Unity actually installed