### PR TITLE
feat: wire Library/LFS caching into the orchestrator's local provider

### DIFF
--- a/plugins/orchestrator/src/cli-plugin/build-parameters-adapter.ts
+++ b/plugins/orchestrator/src/cli-plugin/build-parameters-adapter.ts
@@ -111,6 +111,11 @@ export function createBuildParametersFromCliOptions(options: Record<string, any>
   bp.localCacheEnabled = options.localCacheEnabled === true || options.localCacheEnabled === 'true';
   bp.localCacheLibrary = options.localCacheLibrary === true || options.localCacheLibrary === 'true';
   bp.localCacheLfs = options.localCacheLfs === true || options.localCacheLfs === 'true';
+  bp.localCacheRoot = options.localCacheRoot || '';
+  bp.localCacheFallback =
+    options.localCacheFallback === true || options.localCacheFallback === 'true';
+  bp.localCacheFallbackKeys = options.localCacheFallbackKeys || '';
+  bp.localCacheMode = options.localCacheMode || 'tar';
   bp.childWorkspacesEnabled =
     options.childWorkspacesEnabled === true || options.childWorkspacesEnabled === 'true';
   bp.childWorkspaceName = options.childWorkspaceName || '';

--- a/plugins/orchestrator/src/cli-plugin/orchestrator-options-plugin.ts
+++ b/plugins/orchestrator/src/cli-plugin/orchestrator-options-plugin.ts
@@ -453,7 +453,8 @@ export function configureOrchestratorOptions(yargs: any): void {
   });
 
   yargs.option('localCacheRoot', {
-    description: 'Root directory for the local cache (default: RUNNER_TEMP/game-ci-cache or .game-ci/cache)',
+    description:
+      'Root directory for the local cache (default: RUNNER_TEMP/game-ci-cache or .game-ci/cache)',
     type: 'string',
     default: '',
   });

--- a/plugins/orchestrator/src/cli-plugin/orchestrator-options-plugin.ts
+++ b/plugins/orchestrator/src/cli-plugin/orchestrator-options-plugin.ts
@@ -433,6 +433,49 @@ export function configureOrchestratorOptions(yargs: any): void {
     default: 0,
   });
 
+  // --- Local cache (Library/LFS, bare-host `local`/`local-system` providers) ---
+  yargs.option('localCacheEnabled', {
+    description: 'Enable local filesystem Library/LFS caching (local/local-system providers)',
+    type: 'boolean',
+    default: false,
+  });
+
+  yargs.option('localCacheLibrary', {
+    description: 'Cache the engine Library folder locally (requires localCacheEnabled)',
+    type: 'boolean',
+    default: true,
+  });
+
+  yargs.option('localCacheLfs', {
+    description: 'Cache .git/lfs locally (requires localCacheEnabled)',
+    type: 'boolean',
+    default: false,
+  });
+
+  yargs.option('localCacheRoot', {
+    description: 'Root directory for the local cache (default: RUNNER_TEMP/game-ci-cache or .game-ci/cache)',
+    type: 'string',
+    default: '',
+  });
+
+  yargs.option('localCacheFallback', {
+    description: 'Allow restoring from a fallback cache key when the exact key misses',
+    type: 'boolean',
+    default: false,
+  });
+
+  yargs.option('localCacheFallbackKeys', {
+    description: 'Comma-separated explicit fallback cache keys to try, in order',
+    type: 'string',
+    default: '',
+  });
+
+  yargs.option('localCacheMode', {
+    description: 'Local cache save/restore mode: tar, move-directory, or copy-directory',
+    type: 'string',
+    default: 'tar',
+  });
+
   yargs.option('gcTimeoutMinutes', {
     description: 'Force garbage collection after this many minutes (0 = disabled)',
     type: 'number',

--- a/plugins/orchestrator/src/model/build-parameters.ts
+++ b/plugins/orchestrator/src/model/build-parameters.ts
@@ -117,6 +117,10 @@ class BuildParameters {
   localCacheEnabled!: boolean;
   localCacheLibrary!: boolean;
   localCacheLfs!: boolean;
+  localCacheRoot!: string;
+  localCacheFallback!: boolean;
+  localCacheFallbackKeys!: string;
+  localCacheMode!: string;
   childWorkspacesEnabled!: boolean;
   childWorkspaceName!: string;
   childWorkspaceCacheRoot!: string;

--- a/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.local-cache.test.ts
+++ b/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.local-cache.test.ts
@@ -1,0 +1,248 @@
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import BuildParameters from '../../build-parameters';
+import Orchestrator from '../orchestrator';
+import { ContainerHookService } from '../services/hooks/container-hook-service';
+import { OrchestratorStepParameters } from '../options/orchestrator-step-parameters';
+
+// The local-cache restore/save calls this workflow makes are dynamically
+// imported (`await import('../services/cache/local-cache-service')`), same
+// as plugin-lifecycle.ts does for its own beforeLocalBuild/afterLocalBuild
+// calls. Mock the module so we can assert call args/order without touching
+// the filesystem or shelling out to `tar`.
+vi.mock('../services/cache/local-cache-service', () => ({
+  LocalCacheService: {
+    resolveCacheRoot: vi.fn(() => '/fake/cache/root'),
+    generateCacheKey: vi.fn(() => 'fake-cache-key'),
+    generateCacheKeyCandidates: vi.fn(() => ['fake-cache-key', 'fallback-key']),
+    restoreLfsCache: vi.fn(async () => true),
+    restoreEngineCache: vi.fn(async () => true),
+    saveEngineCache: vi.fn(async () => undefined),
+    saveLfsCache: vi.fn(async () => undefined),
+  },
+}));
+
+// eslint-disable-next-line import/first -- must follow vi.mock (hoisted anyway, but keep them adjacent)
+import { BuildAutomationWorkflow } from './build-automation-workflow';
+// eslint-disable-next-line import/first
+import { LocalCacheService } from '../services/cache/local-cache-service';
+
+function makeBuildParameters(overrides: Partial<BuildParameters> = {}): BuildParameters {
+  const bp = new BuildParameters();
+  bp.providerStrategy = 'local';
+  bp.commandHooks = '';
+  bp.preBuildContainerHooks = '';
+  bp.postBuildContainerHooks = '';
+  bp.cacheKey = 'test-cache-key';
+  bp.projectPath = 'test-project';
+  bp.targetPlatform = 'StandaloneLinux64';
+  bp.editorVersion = '2021.3.0f1';
+  bp.branch = 'main';
+  bp.buildName = 'StandaloneLinux64';
+  bp.buildPath = 'build/StandaloneLinux64';
+  bp.buildFile = 'StandaloneLinux64';
+  bp.buildMethod = '';
+  bp.buildVersion = '0.0.1';
+  bp.androidVersionCode = '';
+  bp.chownFilesTo = '';
+  bp.manualExit = false;
+  bp.buildProfile = '';
+  bp.skipActivation = false;
+  bp.dockerWorkspacePath = '/github/workspace';
+  bp.orchestratorRepoName = 'game-ci/orchestrator';
+  bp.orchestratorBranch = 'main';
+  bp.gitAuthMode = 'header';
+  bp.logId = 'test-log-id';
+  bp.buildGuid = 'test-build-guid';
+  bp.maxRetainedWorkspaces = 0;
+  bp.repoPathOverride = '';
+  bp.preflightSuite = '';
+  bp.localCacheEnabled = false;
+  bp.localCacheLibrary = false;
+  bp.localCacheLfs = false;
+  bp.maxCacheEntries = 2;
+
+  return Object.assign(bp, overrides);
+}
+
+function makeStepState(): OrchestratorStepParameters {
+  return new OrchestratorStepParameters('test-image', [], []);
+}
+
+describe('BuildAutomationWorkflow local cache wiring (isBareLocalProvider only)', () => {
+  afterEach(() => {
+    Orchestrator.buildParameters = undefined as any;
+    Orchestrator.Provider = undefined as any;
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  function stubProviderAndHooks(): string[] {
+    const callOrder: string[] = [];
+
+    Orchestrator.Provider = {
+      runTaskInWorkflow: vi.fn(async () => {
+        callOrder.push('runTaskInWorkflow');
+
+        return 'build output';
+      }),
+    } as any;
+
+    vi.spyOn(ContainerHookService, 'RunPreBuildSteps').mockResolvedValue('');
+    vi.spyOn(ContainerHookService, 'RunPostBuildSteps').mockResolvedValue('');
+
+    return callOrder;
+  }
+
+  it('does not touch LocalCacheService when localCacheEnabled is unset/false (no behavior change from baseline)', async () => {
+    Orchestrator.buildParameters = makeBuildParameters({
+      providerStrategy: 'local',
+      localCacheEnabled: false,
+      localCacheLibrary: true,
+      localCacheLfs: true,
+    });
+    stubProviderAndHooks();
+
+    await new BuildAutomationWorkflow().run(makeStepState());
+
+    expect(LocalCacheService.restoreEngineCache).not.toHaveBeenCalled();
+    expect(LocalCacheService.restoreLfsCache).not.toHaveBeenCalled();
+    expect(LocalCacheService.saveEngineCache).not.toHaveBeenCalled();
+    expect(LocalCacheService.saveLfsCache).not.toHaveBeenCalled();
+  });
+
+  it('restores and saves the engine (Library) cache when localCacheEnabled + localCacheLibrary are set, around the Unity invocation', async () => {
+    Orchestrator.buildParameters = makeBuildParameters({
+      providerStrategy: 'local',
+      localCacheEnabled: true,
+      localCacheLibrary: true,
+      localCacheLfs: false,
+    });
+    const callOrder = stubProviderAndHooks();
+    (LocalCacheService.restoreEngineCache as any).mockImplementation(async () => {
+      callOrder.push('restoreEngineCache');
+
+      return true;
+    });
+    (LocalCacheService.saveEngineCache as any).mockImplementation(async () => {
+      callOrder.push('saveEngineCache');
+    });
+
+    await new BuildAutomationWorkflow().run(makeStepState());
+
+    expect(LocalCacheService.resolveCacheRoot).toHaveBeenCalledWith(Orchestrator.buildParameters);
+    expect(LocalCacheService.generateCacheKey).toHaveBeenCalledWith(
+      'StandaloneLinux64',
+      '2021.3.0f1',
+      'main',
+    );
+
+    const expectedProjectPath = path.join(process.cwd(), 'test-project');
+    expect(LocalCacheService.restoreEngineCache).toHaveBeenCalledWith(
+      expectedProjectPath,
+      '/fake/cache/root',
+      'fake-cache-key',
+      expect.objectContaining({ fallbackKeys: [] }),
+    );
+    expect(LocalCacheService.saveEngineCache).toHaveBeenCalledWith(
+      expectedProjectPath,
+      '/fake/cache/root',
+      'fake-cache-key',
+      expect.objectContaining({ maxCacheEntries: 2 }),
+    );
+
+    expect(LocalCacheService.restoreLfsCache).not.toHaveBeenCalled();
+    expect(LocalCacheService.saveLfsCache).not.toHaveBeenCalled();
+
+    expect(callOrder).toEqual(['restoreEngineCache', 'runTaskInWorkflow', 'saveEngineCache']);
+  });
+
+  it('restores and saves the LFS cache when localCacheEnabled + localCacheLfs are set, around the Unity invocation', async () => {
+    Orchestrator.buildParameters = makeBuildParameters({
+      providerStrategy: 'local-system',
+      localCacheEnabled: true,
+      localCacheLibrary: false,
+      localCacheLfs: true,
+    });
+    const callOrder = stubProviderAndHooks();
+    (LocalCacheService.restoreLfsCache as any).mockImplementation(async () => {
+      callOrder.push('restoreLfsCache');
+
+      return true;
+    });
+    (LocalCacheService.saveLfsCache as any).mockImplementation(async () => {
+      callOrder.push('saveLfsCache');
+    });
+
+    await new BuildAutomationWorkflow().run(makeStepState());
+
+    expect(LocalCacheService.restoreLfsCache).toHaveBeenCalledWith(
+      process.cwd(),
+      '/fake/cache/root',
+      'fake-cache-key',
+    );
+    expect(LocalCacheService.saveLfsCache).toHaveBeenCalledWith(
+      process.cwd(),
+      '/fake/cache/root',
+      'fake-cache-key',
+      2,
+    );
+
+    expect(LocalCacheService.restoreEngineCache).not.toHaveBeenCalled();
+    expect(LocalCacheService.saveEngineCache).not.toHaveBeenCalled();
+
+    expect(callOrder).toEqual(['restoreLfsCache', 'runTaskInWorkflow', 'saveLfsCache']);
+  });
+
+  it.each(['aws', 'k8s', 'local-docker', 'test'])(
+    'never touches LocalCacheService for providerStrategy=%s even when localCacheEnabled is set (scoped to isBareLocalProvider only)',
+    async (providerStrategy) => {
+      Orchestrator.buildParameters = makeBuildParameters({
+        providerStrategy,
+        localCacheEnabled: true,
+        localCacheLibrary: true,
+        localCacheLfs: true,
+      });
+      stubProviderAndHooks();
+
+      await new BuildAutomationWorkflow().run(makeStepState());
+
+      expect(LocalCacheService.restoreEngineCache).not.toHaveBeenCalled();
+      expect(LocalCacheService.restoreLfsCache).not.toHaveBeenCalled();
+      expect(LocalCacheService.saveEngineCache).not.toHaveBeenCalled();
+      expect(LocalCacheService.saveLfsCache).not.toHaveBeenCalled();
+    },
+  );
+
+  it('a cache restore failure is logged and does not abort the build (Unity still runs)', async () => {
+    Orchestrator.buildParameters = makeBuildParameters({
+      providerStrategy: 'local',
+      localCacheEnabled: true,
+      localCacheLibrary: true,
+      localCacheLfs: false,
+    });
+    const callOrder = stubProviderAndHooks();
+    (LocalCacheService.restoreEngineCache as any).mockRejectedValue(
+      new Error('simulated restore failure'),
+    );
+
+    await expect(new BuildAutomationWorkflow().run(makeStepState())).resolves.toBeTypeOf('string');
+
+    expect(callOrder).toContain('runTaskInWorkflow');
+  });
+
+  it('a cache save failure after a successful build is logged and does not throw', async () => {
+    Orchestrator.buildParameters = makeBuildParameters({
+      providerStrategy: 'local',
+      localCacheEnabled: true,
+      localCacheLibrary: true,
+      localCacheLfs: false,
+    });
+    stubProviderAndHooks();
+    (LocalCacheService.saveEngineCache as any).mockRejectedValue(
+      new Error('simulated save failure'),
+    );
+
+    await expect(new BuildAutomationWorkflow().run(makeStepState())).resolves.toBeTypeOf('string');
+  });
+});

--- a/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.ts
+++ b/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.ts
@@ -224,7 +224,12 @@ export class BuildAutomationWorkflow implements WorkflowInterface {
       }
 
       if (bp.localCacheLfs) {
-        await LocalCacheService.saveLfsCache(workspacePath, cacheRoot, cacheKey, bp.maxCacheEntries);
+        await LocalCacheService.saveLfsCache(
+          workspacePath,
+          cacheRoot,
+          cacheKey,
+          bp.maxCacheEntries,
+        );
       }
     } catch (error: any) {
       OrchestratorLogger.logWarning(

--- a/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.ts
+++ b/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.ts
@@ -39,6 +39,13 @@ export class BuildAutomationWorkflow implements WorkflowInterface {
     OrchestratorLogger.logLine(` `);
     OrchestratorLogger.logLine('Starting build automation job');
 
+    // Local Library/LFS caching for the bare-host `local`/`local-system`
+    // provider strategy -- mirrors the restore step plugin-lifecycle.ts runs
+    // in beforeLocalBuild() for the unity-builder integration surface, but
+    // calls LocalCacheService directly instead of going through that surface
+    // (this code path is the standalone `game-ci orchestrate` CLI command).
+    const localCacheState = await BuildAutomationWorkflow.restoreLocalCacheIfEnabled();
+
     output += await Orchestrator.Provider.runTaskInWorkflow(
       Orchestrator.buildParameters.buildGuid,
       baseImage.toString(),
@@ -49,6 +56,11 @@ export class BuildAutomationWorkflow implements WorkflowInterface {
       orchestratorStepState.secrets,
     );
     OrchestratorLogger.logWithTime('Build time');
+
+    // Save step mirrors plugin-lifecycle.ts's afterLocalBuild() handling.
+    // Only reached if runTaskInWorkflow above resolved rather than throwing,
+    // i.e. Unity actually ran to completion.
+    await BuildAutomationWorkflow.saveLocalCacheIfEnabled(localCacheState);
 
     output += await ContainerHookService.RunPostBuildSteps(orchestratorStepState);
     OrchestratorLogger.logWithTime('Configurable post build step(s) time');
@@ -89,6 +101,138 @@ export class BuildAutomationWorkflow implements WorkflowInterface {
     }
   }
 
+  /**
+   * True for game-ci/orchestrator's bare-host `local`/`local-system` provider
+   * strategy (both backed by LocalOrchestrator -- see
+   * plugins/orchestrator/src/cli-plugin/index.ts). Non-containerized like
+   * aws/k8s/local-docker's remote-dispatch cousins (test, gcp-cloud-run,
+   * github-actions, ...), but unlike those it actually needs to invoke Unity
+   * directly on this machine.
+   */
+  private static get isBareLocalProvider(): boolean {
+    const isContainerized =
+      Orchestrator.buildParameters.providerStrategy === 'aws' ||
+      Orchestrator.buildParameters.providerStrategy === 'k8s' ||
+      Orchestrator.buildParameters.providerStrategy === 'local-docker';
+
+    return (
+      !isContainerized &&
+      (Orchestrator.buildParameters.providerStrategy === 'local' ||
+        Orchestrator.buildParameters.providerStrategy === 'local-system')
+    );
+  }
+
+  /**
+   * Restore Library/LFS caches via LocalCacheService before Unity runs, for
+   * the bare-host `local`/`local-system` provider strategy only. Mirrors
+   * plugin-lifecycle.ts's beforeLocalBuild() local-cache-restore block.
+   *
+   * LocalCacheService's restore methods already catch and log their own
+   * errors internally (a cache miss or restore failure returns
+   * false/void rather than throwing), so a first run with no cache yet is
+   * expected to log a miss and fall through -- not fail the build. The
+   * try/catch here is an extra safety net around resolveCacheRoot /
+   * generateCacheKey / generateCacheKeyCandidates, which are cheap sync
+   * calls but are still wrapped so that any unexpected error here can never
+   * abort the build.
+   */
+  private static async restoreLocalCacheIfEnabled(): Promise<
+    { cacheRoot: string; cacheKey: string } | undefined
+  > {
+    const bp = Orchestrator.buildParameters;
+    if (!BuildAutomationWorkflow.isBareLocalProvider || !bp.localCacheEnabled) {
+      return undefined;
+    }
+
+    try {
+      const { LocalCacheService } = await import('../services/cache/local-cache-service');
+      const cacheRoot = LocalCacheService.resolveCacheRoot(bp as any) || '';
+      const cacheKey =
+        LocalCacheService.generateCacheKey(bp.targetPlatform, bp.editorVersion, bp.branch || '') ||
+        '';
+
+      // GITHUB_WORKSPACE for the bare-local provider is process.cwd() (see
+      // the isBareLocalProvider branch of BuildWorkflow below); the project
+      // itself lives at process.cwd()/<projectPath> underneath that.
+      const workspacePath = process.cwd();
+      const projectFullPath = path.join(workspacePath, bp.projectPath);
+
+      if (bp.localCacheLfs) {
+        await LocalCacheService.restoreLfsCache(workspacePath, cacheRoot, cacheKey);
+      }
+
+      if (bp.localCacheLibrary) {
+        const fallbackKeys = bp.localCacheFallback
+          ? LocalCacheService.generateCacheKeyCandidates(
+              cacheRoot,
+              bp.targetPlatform,
+              bp.editorVersion,
+              bp.branch || '',
+              String(bp.localCacheFallbackKeys || '')
+                .split(',')
+                .map((key: string) => key.trim())
+                .filter(Boolean),
+            ).filter((key) => key !== cacheKey)
+          : [];
+
+        await LocalCacheService.restoreEngineCache(projectFullPath, cacheRoot, cacheKey, {
+          fallbackKeys,
+          restoreMode: bp.localCacheMode as any,
+        });
+      }
+
+      return { cacheRoot, cacheKey };
+    } catch (error: any) {
+      OrchestratorLogger.logWarning(
+        `[LocalCache] Restore step failed, continuing without cache: ${error.message}`,
+      );
+
+      return undefined;
+    }
+  }
+
+  /**
+   * Save Library/LFS caches via LocalCacheService after Unity finishes, for
+   * the bare-host `local`/`local-system` provider strategy only. Mirrors
+   * plugin-lifecycle.ts's afterLocalBuild() local-cache-save block.
+   *
+   * LocalCacheService's save methods already catch and log their own errors
+   * internally and never throw, so this can never mask a build that
+   * otherwise completed successfully. The try/catch is an extra safety net,
+   * matching restoreLocalCacheIfEnabled() above.
+   */
+  private static async saveLocalCacheIfEnabled(
+    cacheState: { cacheRoot: string; cacheKey: string } | undefined,
+  ): Promise<void> {
+    const bp = Orchestrator.buildParameters;
+    if (!BuildAutomationWorkflow.isBareLocalProvider || !bp.localCacheEnabled || !cacheState) {
+      return;
+    }
+
+    try {
+      const { LocalCacheService } = await import('../services/cache/local-cache-service');
+      const { cacheRoot, cacheKey } = cacheState;
+      const workspacePath = process.cwd();
+      const projectFullPath = path.join(workspacePath, bp.projectPath);
+
+      if (bp.localCacheLibrary) {
+        await LocalCacheService.saveEngineCache(projectFullPath, cacheRoot, cacheKey, {
+          saveMode: bp.localCacheMode as any,
+          skipOnLfsPointerPoisoning: true,
+          maxCacheEntries: bp.maxCacheEntries,
+        });
+      }
+
+      if (bp.localCacheLfs) {
+        await LocalCacheService.saveLfsCache(workspacePath, cacheRoot, cacheKey, bp.maxCacheEntries);
+      }
+    } catch (error: any) {
+      OrchestratorLogger.logWarning(
+        `[LocalCache] Save step failed after a successful build: ${error.message}`,
+      );
+    }
+  }
+
   private static get BuildWorkflow() {
     const setupHooks = CommandHookService.getHooks(
       Orchestrator.buildParameters.commandHooks,
@@ -101,16 +245,7 @@ export class BuildAutomationWorkflow implements WorkflowInterface {
       Orchestrator.buildParameters.providerStrategy === 'k8s' ||
       Orchestrator.buildParameters.providerStrategy === 'local-docker';
 
-    // The bare-host provider (game-ci/orchestrator's `local`/`local-system`
-    // provider strategy, both backed by LocalOrchestrator -- see
-    // plugins/orchestrator/src/cli-plugin/index.ts) is non-containerized like
-    // aws/k8s/local-docker's remote-dispatch cousins (test, gcp-cloud-run,
-    // github-actions, ...), but unlike those it actually needs to invoke
-    // Unity directly on this machine, so it gets its own branch below.
-    const isBareLocalProvider =
-      !isContainerized &&
-      (Orchestrator.buildParameters.providerStrategy === 'local' ||
-        Orchestrator.buildParameters.providerStrategy === 'local-system');
+    const isBareLocalProvider = BuildAutomationWorkflow.isBareLocalProvider;
 
     const builderPath = isContainerized
       ? OrchestratorFolders.ToLinuxFolder(


### PR DESCRIPTION
## Summary

\`game-ci orchestrate --providerStrategy local\` (given a real Unity-invocation path by #109) had no caching or LFS handling. \`LocalCacheService\` (~1240 lines, real restore/save logic for Library folders and LFS objects) already exists and works, but was only reachable via \`plugin-lifecycle.ts\` — the integration surface used when \`unity-builder\` imports \`@game-ci/orchestrator\` as a library — not the \`orchestrate\` CLI command's own code path.

## What changed

- \`BuildAutomationWorkflow\` now calls \`LocalCacheService\` directly around \`Provider.runTaskInWorkflow()\`, gated on the \`local\`/\`local-system\` provider strategy only:
  - **Before** Unity runs: restore LFS cache (\`--localCacheLfs\`) and/or Library cache (\`--localCacheLibrary\`), with fallback-key candidate resolution mirroring \`plugin-lifecycle.ts\`'s existing handling.
  - **After** Unity finishes successfully: save both back.
- A cache miss or restore/save failure logs and continues rather than failing the build — \`LocalCacheService\`'s own methods already swallow their internal errors; the try/catch added here is an extra safety net around the surrounding cache-key resolution calls, not a change to \`LocalCacheService\` itself (untouched).
- Registers \`localCacheRoot\`/\`localCacheFallback\`/\`localCacheFallbackKeys\`/\`localCacheMode\` as CLI options. These were readable on \`BuildParameters\` already but never registered with yargs — under \`orchestrate\`'s strict-mode parsing this meant even the already-registered \`localCacheEnabled\`/\`Library\`/\`Lfs\` flags were effectively unreachable end-to-end (verified: passing them failed with \"Unknown arguments\" before ever reaching this code).

Scoped tightly: no changes to \`LocalCacheService\`, \`plugin-lifecycle.ts\`, or any other provider strategy (aws/k8s/local-docker/etc. untouched).

## Verification

- \`bun test ./src\`: 168 pass / 3 skip / 0 fail
- \`plugins/orchestrator\`'s own vitest suite: 939 pass / 1 skip / 2 pre-existing failures unrelated to this change — \`cli-integration.test.ts\` (subprocess-spawn timeout flake under parallel load, confirmed passes 9/9 standalone) and \`orchestrator-rclone-steps.test.ts\` (fails because \`plugins/orchestrator/dist/\` doesn't exist in a fresh worktree with no prior \`tsc\` build — confirmed identical failure against the pre-change baseline via \`git stash\`)
- \`tsc --noEmit\` (orchestrator) and root \`bun run build\`: both clean
- **Live sanity check**: \`orchestrate --providerStrategy local --skipActivation --localCacheEnabled --localCacheLibrary --projectPath .\` against a synthetic project — log showed \`[LocalCache] Library cache miss: .../.game-ci/cache/StandaloneLinux64-.../Library\` **before** the Unity-invocation step, confirming the restore call fires pre-build with the expected first-run miss.

## Test plan

- [x] \`bun test ./src\` passes
- [x] orchestrator's own test suite passes (2 pre-existing, unrelated failures aside)
- [x] \`bun run build\` succeeds for both packages
- [x] Live run confirms restore fires before the build step with correct cache-key resolution
- [ ] Follow-up: validate a real cache hit/miss round-trip against an actual Unity project with a populated \`Library/\` folder