### PR TITLE
feat: warn about Windows-only-Editor native plugins on Docker builds

### DIFF
--- a/src/command-options/build-options.ts
+++ b/src/command-options/build-options.ts
@@ -178,6 +178,14 @@ export class BuildOptions implements IOptions {
         type: 'string',
         demandOption: false,
         default: '',
+      })
+      .option('skipNativePluginCheck', {
+        description: String.dedent`Skip the preflight scan for native plugins (.dll.meta) whose PluginImporter
+        restricts them to Windows-hosted Editors only. That scan only warns (it never fails the build), but some
+        projects may want to skip it entirely - e.g. too much noise, or the setup is already well understood.`,
+        type: 'boolean',
+        demandOption: false,
+        default: false,
       });
   }
 }

--- a/src/command/build/unity-build-command.test.ts
+++ b/src/command/build/unity-build-command.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, mock, afterEach, beforeAll, afterAll } from 'bun:test';
+import { Docker } from '../../model/index.ts';
+import { MacBuilder } from '../../model/mac-builder.ts';
+import { PlatformSetup } from '../../logic/unity/platform-setup/index.ts';
+import { PlatformValidation } from '../../logic/unity/platform-validation/platform-validation.ts';
+import { CacheValidation } from '../../model/index.ts';
+
+const NATIVE_PLUGIN_COMPAT_MODULE_PATH = '../../logic/unity/native-plugin-compatibility.ts';
+
+// Named-export bindings imported directly (as UnityBuildCommand.ts does:
+// `import { scanForWindowsOnlyEditorPlugins } from '...'`) are read-only at
+// the call site - reassigning them from a test throws "Attempted to assign
+// to readonly property." bun:test's mock.module replaces the whole module
+// in the module registry instead, which UnityBuildCommand.ts's own import
+// then resolves through - as long as the mock is installed before
+// UnityBuildCommand.ts is first imported anywhere in this test run.
+//
+// mock.module patches the module registry process-wide (bun runs all test
+// files in one process), so it would otherwise leak into
+// native-plugin-compatibility.test.ts, which exercises the real
+// implementation - capture that real implementation first and restore it
+// in afterAll so this file's mock doesn't outlive its own tests.
+const realNativePluginCompatibility = await import(NATIVE_PLUGIN_COMPAT_MODULE_PATH);
+const realScan = realNativePluginCompatibility.scanForWindowsOnlyEditorPlugins;
+
+const scanMock = mock((..._args: unknown[]) => [] as { path: string; guid?: string }[]);
+mock.module(NATIVE_PLUGIN_COMPAT_MODULE_PATH, () => ({
+  scanForWindowsOnlyEditorPlugins: scanMock,
+}));
+
+const originalDockerRun = Docker.run;
+const originalMacBuilderRun = MacBuilder.run;
+const originalPlatformSetup = PlatformSetup.setup;
+const originalCheckCompatibility = PlatformValidation.checkCompatibility;
+const originalCacheVerify = CacheValidation.verify;
+let originalLogWarning: ((msg: any, ...args: any[]) => void) | undefined;
+let warningMock: ReturnType<typeof mock>;
+
+beforeAll(() => {
+  originalLogWarning = (globalThis as any).log?.warning;
+});
+
+afterEach(() => {
+  Docker.run = originalDockerRun;
+  MacBuilder.run = originalMacBuilderRun;
+  PlatformSetup.setup = originalPlatformSetup;
+  PlatformValidation.checkCompatibility = originalCheckCompatibility;
+  CacheValidation.verify = originalCacheVerify;
+  scanMock.mockClear();
+  scanMock.mockReset();
+  scanMock.mockImplementation(() => []);
+  if (originalLogWarning) (globalThis as any).log.warning = originalLogWarning;
+});
+
+afterAll(() => {
+  if (originalLogWarning) (globalThis as any).log.warning = originalLogWarning;
+  mock.module(NATIVE_PLUGIN_COMPAT_MODULE_PATH, () => ({
+    scanForWindowsOnlyEditorPlugins: realScan,
+  }));
+});
+
+const baseOptions = {
+  hostPlatform: 'linux',
+  hostOS: 'linux',
+  engine: 'unity',
+  engineVersion: '2022.3.20f1',
+  targetPlatform: 'StandaloneLinux64',
+  projectPath: '/tmp/some-project',
+} as any;
+
+function stubCollaborators() {
+  PlatformValidation.checkCompatibility = mock(() => {});
+  CacheValidation.verify = mock(() => {});
+  PlatformSetup.setup = mock(() => Promise.resolve());
+  Docker.run = mock(() => Promise.resolve());
+  MacBuilder.run = mock(() => Promise.resolve());
+  warningMock = mock(() => {});
+  (globalThis as any).log.warning = warningMock;
+}
+
+describe('UnityBuildCommand native plugin compatibility warning', () => {
+  it('warns when the scan finds Windows-only Editor plugins, on the Linux Docker path', async () => {
+    stubCollaborators();
+    scanMock.mockImplementation(() => [{ path: 'Assets/Plugins/Windows/NativeThing.dll', guid: 'abc123' }]);
+
+    const { UnityBuildCommand } = await import('./unity-build-command.ts');
+    const command = new UnityBuildCommand('build');
+    await command.execute({ ...baseOptions });
+
+    expect(scanMock).toHaveBeenCalledWith('/tmp/some-project');
+    expect(warningMock).toHaveBeenCalled();
+    const warned = warningMock.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(warned).toContain('native-plugin-compatibility');
+    expect(warned).toContain('Assets/Plugins/Windows/NativeThing.dll');
+  });
+
+  it('does not warn when the scan finds nothing', async () => {
+    stubCollaborators();
+    scanMock.mockImplementation(() => []);
+
+    const { UnityBuildCommand } = await import('./unity-build-command.ts');
+    const command = new UnityBuildCommand('build');
+    await command.execute({ ...baseOptions });
+
+    expect(scanMock).toHaveBeenCalled();
+    expect(warningMock).not.toHaveBeenCalled();
+  });
+
+  it('does not run the scan at all when --skipNativePluginCheck is set', async () => {
+    stubCollaborators();
+    scanMock.mockImplementation(() => [{ path: 'Assets/Plugins/Windows/NativeThing.dll' }]);
+
+    const { UnityBuildCommand } = await import('./unity-build-command.ts');
+    const command = new UnityBuildCommand('build');
+    await command.execute({ ...baseOptions, skipNativePluginCheck: true });
+
+    expect(scanMock).not.toHaveBeenCalled();
+    expect(warningMock).not.toHaveBeenCalled();
+  });
+
+  it('does not run the scan on the Windows Docker container path', async () => {
+    stubCollaborators();
+    scanMock.mockImplementation(() => [{ path: 'Assets/Plugins/Windows/NativeThing.dll' }]);
+
+    const { UnityBuildCommand } = await import('./unity-build-command.ts');
+    const command = new UnityBuildCommand('build');
+    await command.execute({ ...baseOptions, hostPlatform: 'win32', hostOS: 'windows' });
+
+    expect(scanMock).not.toHaveBeenCalled();
+  });
+
+  it('does not run the scan on the macOS (MacBuilder) path', async () => {
+    stubCollaborators();
+    scanMock.mockImplementation(() => [{ path: 'Assets/Plugins/Windows/NativeThing.dll' }]);
+
+    const { UnityBuildCommand } = await import('./unity-build-command.ts');
+    const command = new UnityBuildCommand('build');
+    await command.execute({ ...baseOptions, hostPlatform: 'darwin', hostOS: 'darwin' });
+
+    expect(scanMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/command/build/unity-build-command.ts
+++ b/src/command/build/unity-build-command.ts
@@ -13,13 +13,25 @@ import { AndroidOptions } from '../../command-options/android-options.ts';
 import { UnityLogsOptions } from '../../command-options/unity-logs-options.ts';
 import { PlatformValidation } from '../../logic/unity/platform-validation/platform-validation.ts';
 import { ProjectOptions } from '../../command-options/project-options.ts';
+import { scanForWindowsOnlyEditorPlugins } from '../../logic/unity/native-plugin-compatibility.ts';
 
 export class UnityBuildCommand extends CommandBase implements CommandInterface {
   public async execute(options: Options): Promise<boolean> {
-    const { hostPlatform } = options;
+    const { hostPlatform, hostOS, engine } = options;
 
     PlatformValidation.checkCompatibility(options);
     CacheValidation.verify(options);
+
+    // The Windows-only-Editor-plugin visibility gate (see
+    // native-plugin-compatibility.ts) is specific to a Linux-hosted Editor -
+    // it's exactly the container Docker.run's getLinuxCommand path spins up
+    // (unityci/editor images on hostOS 'linux'), regardless of what
+    // targetPlatform is being cross-compiled for. Skip it for the Windows
+    // container path (getWindowsCommand) and for macOS, which never goes
+    // through Docker.run at all here (see MacBuilder branch below).
+    if (engine === 'unity' && hostOS === 'linux' && !options.skipNativePluginCheck) {
+      UnityBuildCommand.warnAboutWindowsOnlyEditorPlugins(options);
+    }
 
     const image = new RunnerImageTag(options);
     if (log.isVerbose) log.debug('Using image:', image);
@@ -88,6 +100,36 @@ export class UnityBuildCommand extends CommandBase implements CommandInterface {
     await Output.setAndroidVersionCode(options.androidVersionCode);
 
     return true;
+  }
+
+  /**
+   * Warning-only preflight (see native-plugin-compatibility.ts) - never
+   * throws, since a false positive here (e.g. a plugin that's actually
+   * guarded behind a #if UNITY_STANDALONE_WIN and never referenced in a
+   * Linux-container build) must never fail-close a build that would
+   * otherwise have succeeded.
+   */
+  private static warnAboutWindowsOnlyEditorPlugins(options: Options): void {
+    try {
+      const projectDir: string =
+        (options as any).projectPath || (options as any).workspace || process.cwd();
+      const flagged = scanForWindowsOnlyEditorPlugins(projectDir);
+      if (flagged.length === 0) return;
+
+      const list = flagged.map((plugin) => `  - ${plugin.path}`).join('\n');
+      log.warning(String.dedent`
+        [native-plugin-compatibility] ${flagged.length} native plugin(s) are Editor-visible on Windows hosts only,
+        but this build is running inside a Linux container - they may be invisible to the Editor here and could
+        cause confusing compile errors if referenced unconditionally:
+        ${list}
+        If this looks wrong, check the plugin's Inspector > Platform Settings > Editor > OS setting. If the plugin
+        is meant to be Windows-only and is only ever referenced behind a preprocessor guard (e.g. #if
+        UNITY_STANDALONE_WIN), this warning can be safely ignored.
+      `);
+    } catch (error: any) {
+      // Best-effort scan - never let a scan failure interrupt the build.
+      if (log.isVerbose) log.debug(`[native-plugin-compatibility] scan failed: ${error?.message}`);
+    }
   }
 
   public async configureOptions(yargs: YargsInstance): Promise<void> {

--- a/src/logic/unity/native-plugin-compatibility.test.ts
+++ b/src/logic/unity/native-plugin-compatibility.test.ts
@@ -1,0 +1,214 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { scanForWindowsOnlyEditorPlugins } from './native-plugin-compatibility.ts';
+
+// Real Unity PluginImporter serialization for a native plugin gated to
+// Windows-hosted Editors only: platformData is an array of
+// { first, second } pairs (Unity's own convention for a
+// Dictionary<BuildTarget, PluginImporterPlatformData>), and the pair with
+// first.Editor: Editor / second.settings.OS: Windows / second.enabled: 1 is
+// exactly the one that makes the plugin invisible to a Linux-hosted Editor.
+const WINDOWS_ONLY_EDITOR_META = `fileFormatVersion: 2
+guid: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any:
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+      Windows: Windows
+    second:
+      enabled: 1
+      settings:
+        DefaultValueInitialized: true
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 0
+        Exclude Win64: 0
+        OS: Windows
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+`;
+
+// A plugin available on AnyOS / not gated to Windows-only Editor - should
+// NOT be flagged.
+const ANY_OS_META = `fileFormatVersion: 2
+guid: b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Editor: Editor
+      Windows: Windows
+    second:
+      enabled: 1
+      settings:
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+`;
+
+// A plugin gated to Editor, but not enabled - should NOT be flagged.
+const DISABLED_WINDOWS_EDITOR_META = `fileFormatVersion: 2
+guid: c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6
+PluginImporter:
+  serializedVersion: 2
+  platformData:
+  - first:
+      Editor: Editor
+      Windows: Windows
+    second:
+      enabled: 0
+      settings:
+        OS: Windows
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+`;
+
+// A non-plugin .meta file (e.g. a .cs.meta) - no PluginImporter key at all.
+const SCRIPT_META = `fileFormatVersion: 2
+guid: d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+`;
+
+function makeTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'native-plugin-compat-'));
+}
+
+function writeFile(root: string, relativePath: string, contents: string): void {
+  const fullPath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, contents);
+}
+
+describe('scanForWindowsOnlyEditorPlugins', () => {
+  let projectPath: string;
+
+  afterEach(() => {
+    if (projectPath) fs.rmSync(projectPath, { recursive: true, force: true });
+  });
+
+  it('flags a .dll.meta with a Windows-only Editor platformData entry', () => {
+    projectPath = makeTempProject();
+    writeFile(projectPath, 'Assets/Plugins/Windows/NativeThing.dll', 'binary-stand-in');
+    writeFile(projectPath, 'Assets/Plugins/Windows/NativeThing.dll.meta', WINDOWS_ONLY_EDITOR_META);
+
+    const result = scanForWindowsOnlyEditorPlugins(projectPath);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe('Assets/Plugins/Windows/NativeThing.dll');
+    expect(result[0].guid).toBe('a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4');
+  });
+
+  it('does not flag a plugin available on AnyOS', () => {
+    projectPath = makeTempProject();
+    writeFile(projectPath, 'Assets/Plugins/CrossPlatform.dll', 'binary-stand-in');
+    writeFile(projectPath, 'Assets/Plugins/CrossPlatform.dll.meta', ANY_OS_META);
+
+    const result = scanForWindowsOnlyEditorPlugins(projectPath);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('does not flag a Windows-gated Editor entry that is disabled', () => {
+    projectPath = makeTempProject();
+    writeFile(projectPath, 'Assets/Plugins/Disabled.dll', 'binary-stand-in');
+    writeFile(projectPath, 'Assets/Plugins/Disabled.dll.meta', DISABLED_WINDOWS_EDITOR_META);
+
+    const result = scanForWindowsOnlyEditorPlugins(projectPath);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('ignores non-.dll.meta files entirely (e.g. .cs.meta, .png.meta)', () => {
+    projectPath = makeTempProject();
+    writeFile(projectPath, 'Assets/Scripts/Foo.cs', 'public class Foo {}');
+    writeFile(projectPath, 'Assets/Scripts/Foo.cs.meta', SCRIPT_META);
+    writeFile(projectPath, 'Assets/Textures/Icon.png', 'binary-stand-in');
+    writeFile(projectPath, 'Assets/Textures/Icon.png.meta', SCRIPT_META);
+
+    const result = scanForWindowsOnlyEditorPlugins(projectPath);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('does not throw on a malformed or empty .meta file, and skips it', () => {
+    projectPath = makeTempProject();
+    writeFile(projectPath, 'Assets/Plugins/Broken.dll', 'binary-stand-in');
+    writeFile(projectPath, 'Assets/Plugins/Broken.dll.meta', '{this is not: valid: yaml: [');
+    writeFile(projectPath, 'Assets/Plugins/Empty.dll', 'binary-stand-in');
+    writeFile(projectPath, 'Assets/Plugins/Empty.dll.meta', '');
+
+    expect(() => scanForWindowsOnlyEditorPlugins(projectPath)).not.toThrow();
+    expect(scanForWindowsOnlyEditorPlugins(projectPath)).toHaveLength(0);
+  });
+
+  it('returns an empty array when Assets does not exist', () => {
+    projectPath = makeTempProject();
+
+    expect(scanForWindowsOnlyEditorPlugins(projectPath)).toHaveLength(0);
+  });
+
+  it('scans recursively and can flag multiple plugins while skipping others', () => {
+    projectPath = makeTempProject();
+    writeFile(projectPath, 'Assets/Plugins/Windows/A.dll', 'a');
+    writeFile(projectPath, 'Assets/Plugins/Windows/A.dll.meta', WINDOWS_ONLY_EDITOR_META);
+    writeFile(projectPath, 'Assets/Plugins/Deep/Nested/Dir/B.dll', 'b');
+    writeFile(projectPath, 'Assets/Plugins/Deep/Nested/Dir/B.dll.meta', WINDOWS_ONLY_EDITOR_META);
+    writeFile(projectPath, 'Assets/Plugins/CrossPlatform.dll', 'c');
+    writeFile(projectPath, 'Assets/Plugins/CrossPlatform.dll.meta', ANY_OS_META);
+    writeFile(projectPath, 'Assets/Scripts/Foo.cs', 'public class Foo {}');
+    writeFile(projectPath, 'Assets/Scripts/Foo.cs.meta', SCRIPT_META);
+
+    const result = scanForWindowsOnlyEditorPlugins(projectPath);
+    const paths = result.map((r) => r.path).sort();
+
+    expect(paths).toEqual(['Assets/Plugins/Deep/Nested/Dir/B.dll', 'Assets/Plugins/Windows/A.dll']);
+  });
+});

--- a/src/logic/unity/native-plugin-compatibility.ts
+++ b/src/logic/unity/native-plugin-compatibility.ts
@@ -1,0 +1,134 @@
+import { fsSync as fs, path, yaml } from '../../dependencies.ts';
+
+export interface WindowsOnlyEditorPlugin {
+  /** Path to the .dll (not the .meta), relative to projectPath, for a readable warning message. */
+  path: string;
+  guid?: string;
+}
+
+/**
+ * Unity serializes a PluginImporter's platformData as a YAML array of
+ * `{ first: {...}, second: {...} }` pairs - its own convention for what's
+ * conceptually a Dictionary<BuildTarget, PluginImporterPlatformData>, not a
+ * plain YAML mapping. A real Windows-only-Editor entry looks like:
+ *
+ *   PluginImporter:
+ *     ...
+ *     platformData:
+ *     - first:
+ *         Editor: Editor
+ *         Windows: Windows
+ *       second:
+ *         enabled: 1
+ *         settings:
+ *           DefaultValueInitialized: true
+ *           Exclude Editor: 0
+ *           Exclude Linux64: 1
+ *           Exclude OSXUniversal: 1
+ *           Exclude Win: 0
+ *           Exclude Win64: 0
+ *           OS: Windows
+ */
+interface PlatformDataEntry {
+  first?: { Editor?: string; [key: string]: unknown };
+  second?: { enabled?: unknown; settings?: { OS?: string; [key: string]: unknown } };
+}
+
+function isWindowsOnlyEditorEntry(entry: unknown): boolean {
+  if (!entry || typeof entry !== 'object') return false;
+
+  const { first, second } = entry as PlatformDataEntry;
+  if (!first || first.Editor !== 'Editor') return false;
+  if (!second) return false;
+
+  const enabled = second.enabled;
+  const isEnabled = enabled === 1 || enabled === '1' || enabled === true;
+  if (!isEnabled) return false;
+
+  return second.settings?.OS === 'Windows';
+}
+
+/**
+ * Best-effort heuristic scan, not strict validation - .meta files can have
+ * all kinds of importer types, and this only cares about the one specific
+ * PluginImporter shape described above. Anything that doesn't parse or
+ * doesn't match is silently skipped rather than thrown from.
+ */
+function parseMetaFile(metaFilePath: string): { guid?: string } | null {
+  let content: string;
+  try {
+    content = fs.readFileSync(metaFilePath, 'utf-8');
+  } catch {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = yaml.parse(content);
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== 'object') return null;
+
+  const pluginImporter = (parsed as Record<string, unknown>).PluginImporter;
+  if (!pluginImporter || typeof pluginImporter !== 'object') return null;
+
+  const platformData = (pluginImporter as Record<string, unknown>).platformData;
+  if (!Array.isArray(platformData)) return null;
+
+  const isWindowsOnlyEditor = platformData.some(isWindowsOnlyEditorEntry);
+  if (!isWindowsOnlyEditor) return null;
+
+  const guid = (parsed as Record<string, unknown>).guid;
+  return { guid: typeof guid === 'string' ? guid : undefined };
+}
+
+function findDllMetaFiles(dir: string): string[] {
+  let entries: import('node:fs').Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const results: string[] = [];
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...findDllMetaFiles(entryPath));
+    } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.dll.meta')) {
+      results.push(entryPath);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Scans <projectPath>/Assets for .dll.meta files whose PluginImporter
+ * restricts Editor availability to Windows-hosted editors only (see
+ * WindowsOnlyEditorPlugin doc). Used to warn (never fail) before a build
+ * that will run inside a Linux Docker container, where such a plugin is
+ * invisible to the Editor entirely - not just excluded from the built
+ * player - which can silently break compilation of any code that
+ * references it unconditionally.
+ */
+export function scanForWindowsOnlyEditorPlugins(projectPath: string): WindowsOnlyEditorPlugin[] {
+  const assetsDir = path.join(projectPath, 'Assets');
+  const metaFiles = findDllMetaFiles(assetsDir);
+
+  const flagged: WindowsOnlyEditorPlugin[] = [];
+  for (const metaFilePath of metaFiles) {
+    const result = parseMetaFile(metaFilePath);
+    if (!result) continue;
+
+    // Strip the trailing .meta to report the plugin's own (non-meta) path.
+    const dllPath = metaFilePath.slice(0, -'.meta'.length);
+    const relativePath = path.relative(projectPath, dllPath).split(path.sep).join('/');
+
+    flagged.push({ path: relativePath, guid: result.guid });
+  }
+
+  return flagged;
+}


### PR DESCRIPTION
## Summary

\`game-ci build\`'s Docker path runs Unity inside a **Linux-hosted** \`unityci/editor\` container, regardless of what platform is actually being cross-compiled for. There's a real, documented Unity behavior this creates a blind spot for: a native plugin's \`.dll.meta\` can restrict its \`PluginImporter\` platform data so it's Editor-available on Windows-hosted editors only. When that plugin is loaded by a Linux-hosted Editor (every \`unityci/editor\` container), it isn't just excluded from the built player — it becomes **invisible to the Editor entirely**, which can silently break compilation of anything that references it unconditionally.

This isn't a game-ci bug or anything project-specific — it's genuine Unity platform behavior. But today it's completely undetected: the failure mode is a confusing, seemingly-unrelated compile error buried in a Docker build log, with nothing pointing at the actual cause.

## What changed

- New \`src/logic/unity/native-plugin-compatibility.ts\`: \`scanForWindowsOnlyEditorPlugins(projectPath)\` walks \`Assets/\` for \`*.dll.meta\` files, parses Unity's own YAML serialization of \`PluginImporter.platformData\` (an array of \`{first, second}\` pairs — Unity's convention for what's conceptually a \`Dictionary<BuildTarget, PluginImporterPlatformData>\`), and flags any entry where \`first.Editor === 'Editor'\`, \`second.enabled\` is truthy, and \`second.settings.OS === 'Windows'\`. Anything that doesn't parse as expected is silently skipped — this is a best-effort heuristic, not strict \`.meta\` validation.
- Wired into \`UnityBuildCommand\`, gated to \`hostOS === 'linux'\` only (the Windows container path and macOS's native \`MacBuilder\` path never hit this risk, since it's specific to a Linux-hosted Editor). Logs a clear \`log.warning(...)\` listing flagged plugins before the build starts.
- **Warning-only, never fails the build.** A plugin might be legitimately guarded behind a \`#if UNITY_STANDALONE_WIN\` block and never actually referenced in a Linux-container build — this heuristic has no way to know that, so false positives are expected and acceptable for a warning, not for a hard failure. Real preprocessor-guard-aware detection (avoiding those false positives) is a separate, much bigger problem — deliberately out of scope here.
- New \`--skipNativePluginCheck\` boolean option (default \`false\`) to opt out entirely.

## Verification

- \`bun test ./src\`: 180 pass / 3 skip / 0 fail (12 new tests: 7 for the scanner covering flagged/AnyOS/disabled/non-plugin-meta/malformed-meta/missing-Assets-dir/recursive-scan cases, 5 for the command wiring covering warn-fires/no-warn/opt-out/Windows-container-skip/macOS-skip)
- \`bun run build\`: succeeds
- **Live sanity check**: constructed a real synthetic project directory on disk with a Windows-only-Editor \`.dll.meta\`, an AnyOS \`.dll.meta\`, and an unrelated \`.cs.meta\`, ran the scanner against real filesystem content — correctly flagged exactly the one Windows-only plugin and excluded the other two.

## Test plan

- [x] \`bun test ./src\` passes
- [x] \`bun run build\` succeeds
- [x] Live scan against real filesystem fixtures returns exactly the expected match
- [ ] Follow-up (optional, separate scope): preprocessor-guard-aware detection to reduce false positives, if this proves noisy in practice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a build option to skip native-plugin compatibility checks.
  * Linux Docker Unity builds now warn about detected Windows-only Editor plugins before building.
  * Plugin scanning checks nested project assets and reports matching plugin paths and identifiers.

* **Bug Fixes**
  * Scan errors no longer interrupt builds.
  * Checks are automatically skipped for supported platforms and when explicitly disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->