### PR TITLE
feat: wire the Middleware hook system into the live build pipeline

### DIFF
--- a/plugins/orchestrator/src/cli-plugin/cli-plugin.test.ts
+++ b/plugins/orchestrator/src/cli-plugin/cli-plugin.test.ts
@@ -204,9 +204,8 @@ describe('CLI Plugin Adapter', () => {
 
     it('reads a comma-separated middlewareFiles CLI option through to OrchestratorOptions', async () => {
       const { Cli } = await import('../model/cli/cli');
-      const { default: OrchestratorOptions } = await import(
-        '../model/orchestrator/options/orchestrator-options'
-      );
+      const { default: OrchestratorOptions } =
+        await import('../model/orchestrator/options/orchestrator-options');
 
       Cli.options = { mode: 'cli', middlewareFiles: 'code-signing,cache-optimizer' } as any;
 
@@ -215,9 +214,8 @@ describe('CLI Plugin Adapter', () => {
 
     it('defaults middlewareFiles to an empty array when unset', async () => {
       const { Cli } = await import('../model/cli/cli');
-      const { default: OrchestratorOptions } = await import(
-        '../model/orchestrator/options/orchestrator-options'
-      );
+      const { default: OrchestratorOptions } =
+        await import('../model/orchestrator/options/orchestrator-options');
 
       Cli.options = { mode: 'cli' } as any;
 

--- a/plugins/orchestrator/src/cli-plugin/cli-plugin.test.ts
+++ b/plugins/orchestrator/src/cli-plugin/cli-plugin.test.ts
@@ -72,6 +72,8 @@ describe('CLI Plugin Adapter', () => {
       expect(registered).toHaveProperty('ansibleInventory');
       expect(registered).toHaveProperty('skipActivation');
       expect(registered.skipActivation.default).toBe(false);
+      expect(registered).toHaveProperty('middlewarePipeline');
+      expect(registered).toHaveProperty('middlewareFiles');
     });
   });
 
@@ -176,6 +178,50 @@ describe('CLI Plugin Adapter', () => {
 
       const stringFalse = createBuildParametersFromCliOptions({ skipActivation: 'false' });
       expect(stringFalse.skipActivation).toBe(false);
+    });
+
+    it('maps middlewarePipeline from CLI options to BuildParameters', () => {
+      const yaml = 'name: mw\ntype: command\ntrigger:\n  phase: [build]\nbefore: echo "hi"';
+      const bp = createBuildParametersFromCliOptions({ middlewarePipeline: yaml });
+      expect(bp.middlewarePipeline).toBe(yaml);
+    });
+
+    it('defaults middlewarePipeline to empty string when unset', () => {
+      const bp = createBuildParametersFromCliOptions({});
+      expect(bp.middlewarePipeline).toBe('');
+    });
+  });
+
+  describe('middlewareFiles CLI reachability', () => {
+    // middlewareFiles is read directly via OrchestratorOptions.getInput (the
+    // same mechanism as commandHookFiles/containerHookFiles), not routed
+    // through BuildParameters. Confirm it is actually wired end-to-end from
+    // Cli.options through to OrchestratorOptions.middlewareFiles.
+    afterEach(async () => {
+      const { Cli } = await import('../model/cli/cli');
+      Cli.options = undefined;
+    });
+
+    it('reads a comma-separated middlewareFiles CLI option through to OrchestratorOptions', async () => {
+      const { Cli } = await import('../model/cli/cli');
+      const { default: OrchestratorOptions } = await import(
+        '../model/orchestrator/options/orchestrator-options'
+      );
+
+      Cli.options = { mode: 'cli', middlewareFiles: 'code-signing,cache-optimizer' } as any;
+
+      expect(OrchestratorOptions.middlewareFiles).toEqual(['code-signing', 'cache-optimizer']);
+    });
+
+    it('defaults middlewareFiles to an empty array when unset', async () => {
+      const { Cli } = await import('../model/cli/cli');
+      const { default: OrchestratorOptions } = await import(
+        '../model/orchestrator/options/orchestrator-options'
+      );
+
+      Cli.options = { mode: 'cli' } as any;
+
+      expect(OrchestratorOptions.middlewareFiles).toEqual([]);
     });
   });
 });

--- a/plugins/orchestrator/src/model/orchestrator/services/hooks/container-hook-service.test.ts
+++ b/plugins/orchestrator/src/model/orchestrator/services/hooks/container-hook-service.test.ts
@@ -21,7 +21,16 @@ vi.mock('../../orchestrator', () => ({
   },
 }));
 
+vi.mock('../../workflows/custom-workflow', () => ({
+  __esModule: true,
+  CustomWorkflow: {
+    runContainerJob: vi.fn().mockResolvedValue(''),
+  },
+}));
+
 import { ContainerHookService } from './container-hook-service';
+import Orchestrator from '../../orchestrator';
+import { CustomWorkflow } from '../../workflows/custom-workflow';
 
 describe('ContainerHookService.GetContainerHooksFromFiles', () => {
   let scratch: string;
@@ -83,5 +92,176 @@ describe('ContainerHookService.GetContainerHooksFromFiles', () => {
 
     logSpy.mockRestore();
     errSpy.mockRestore();
+  });
+});
+
+describe('ContainerHookService.RunPreBuildSteps / RunPostBuildSteps -- middleware container-hook wiring', () => {
+  let scratch: string;
+  let originalCwd: string;
+  const runContainerJobMock = CustomWorkflow.runContainerJob as unknown as ReturnType<typeof vi.fn>;
+
+  beforeAll(() => {
+    originalCwd = process.cwd();
+  });
+
+  afterAll(() => {
+    process.chdir(originalCwd);
+  });
+
+  beforeEach(() => {
+    scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'container-hook-service-mw-test-'));
+    process.chdir(scratch);
+    runContainerJobMock.mockClear();
+    runContainerJobMock.mockResolvedValue('');
+
+    (Orchestrator as any).buildParameters = {
+      buildGuid: 'test-guid',
+      awsStackName: 'test-stack',
+      useCompressionStrategy: false,
+      providerStrategy: 'local',
+      targetPlatform: 'StandaloneLinux64',
+      middlewarePipeline: '',
+      preBuildContainerHooks: '',
+      postBuildContainerHooks: '',
+    };
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(scratch, { recursive: true, force: true });
+  });
+
+  const stepState = { environment: [], secrets: [] } as any;
+
+  it('produces no container job call with no middleware and no legacy hooks configured (regression guard)', async () => {
+    await ContainerHookService.RunPreBuildSteps(stepState);
+    await ContainerHookService.RunPostBuildSteps(stepState);
+
+    expect(runContainerJobMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves a container-type middleware before/after command at the pre-build phase', async () => {
+    (Orchestrator as any).buildParameters.middlewarePipeline = `
+name: prebuild-mw
+type: container
+image: node:20
+trigger:
+  phase: [pre-build]
+before:
+  commands: echo "prebuild-before"
+after:
+  commands: echo "prebuild-after"
+`;
+
+    await ContainerHookService.RunPreBuildSteps(stepState);
+
+    expect(runContainerJobMock).toHaveBeenCalledTimes(1);
+    const steps = runContainerJobMock.mock.calls[0][0];
+    const names = steps.map((s: any) => s.name);
+    expect(names).toContain('middleware:prebuild-mw:before');
+    expect(names).toContain('middleware:prebuild-mw:after');
+  });
+
+  it('resolves a container-type middleware before/after command at the post-build phase', async () => {
+    (Orchestrator as any).buildParameters.middlewarePipeline = `
+name: postbuild-mw
+type: container
+trigger:
+  phase: [post-build]
+before:
+  commands: echo "postbuild-before"
+after:
+  commands: echo "postbuild-after"
+`;
+
+    await ContainerHookService.RunPostBuildSteps(stepState);
+
+    expect(runContainerJobMock).toHaveBeenCalledTimes(1);
+    const steps = runContainerJobMock.mock.calls[0][0];
+    const names = steps.map((s: any) => s.name);
+    expect(names).toContain('middleware:postbuild-mw:before');
+    expect(names).toContain('middleware:postbuild-mw:after');
+  });
+
+  it('does not leak pre-build middleware into the post-build phase or vice versa', async () => {
+    (Orchestrator as any).buildParameters.middlewarePipeline = `
+name: prebuild-only-mw
+type: container
+trigger:
+  phase: [pre-build]
+before:
+  commands: echo "prebuild-only"
+`;
+
+    await ContainerHookService.RunPostBuildSteps(stepState);
+
+    expect(runContainerJobMock).not.toHaveBeenCalled();
+  });
+
+  it('propagates allowFailure onto the resolved ContainerHook', async () => {
+    (Orchestrator as any).buildParameters.middlewarePipeline = `
+name: allow-failure-mw
+type: container
+allowFailure: true
+trigger:
+  phase: [pre-build]
+before:
+  commands: echo "may-fail"
+`;
+
+    await ContainerHookService.RunPreBuildSteps(stepState);
+
+    const steps = runContainerJobMock.mock.calls[0][0];
+    const hook = steps.find((s: any) => s.name === 'middleware:allow-failure-mw:before');
+    expect(hook.allowFailure).toBe(true);
+  });
+
+  it('filters out middleware whose trigger provider does not match providerStrategy', async () => {
+    (Orchestrator as any).buildParameters.providerStrategy = 'local';
+    (Orchestrator as any).buildParameters.middlewarePipeline = `
+name: aws-only-container-mw
+type: container
+trigger:
+  phase: [pre-build]
+  provider: [aws]
+before:
+  commands: echo "aws-only"
+`;
+
+    await ContainerHookService.RunPreBuildSteps(stepState);
+
+    expect(runContainerJobMock).not.toHaveBeenCalled();
+  });
+
+  it('merges legacy inline container hooks and middleware, legacy first', async () => {
+    (Orchestrator as any).buildParameters.preBuildContainerHooks = `
+- name: legacy-pre-hook
+  hook: before
+  commands: echo "legacy-pre-command"
+`;
+    (Orchestrator as any).buildParameters.middlewarePipeline = `
+name: merge-container-mw
+type: container
+trigger:
+  phase: [pre-build]
+before:
+  commands: echo "middleware-pre-command"
+`;
+
+    await ContainerHookService.RunPreBuildSteps(stepState);
+
+    const steps = runContainerJobMock.mock.calls[0][0];
+    const names = steps.map((s: any) => s.name);
+    const legacyIndex = names.indexOf('legacy-pre-hook');
+    const middlewareIndex = names.indexOf('middleware:merge-container-mw:before');
+    expect(legacyIndex).toBeGreaterThanOrEqual(0);
+    expect(middlewareIndex).toBeGreaterThan(legacyIndex);
+  });
+
+  it('does not crash and skips malformed inline middleware YAML', async () => {
+    (Orchestrator as any).buildParameters.middlewarePipeline = `not: [valid, yaml, : : broken`;
+
+    await expect(ContainerHookService.RunPreBuildSteps(stepState)).resolves.not.toThrow();
+    expect(runContainerJobMock).not.toHaveBeenCalled();
   });
 });

--- a/plugins/orchestrator/src/model/orchestrator/services/hooks/container-hook-service.ts
+++ b/plugins/orchestrator/src/model/orchestrator/services/hooks/container-hook-service.ts
@@ -10,6 +10,7 @@ import Input from '../../../input';
 import OrchestratorOptions from '../../options/orchestrator-options';
 import { ContainerHook } from './container-hook';
 import { OrchestratorStepParameters } from '../../options/orchestrator-step-parameters';
+import { MiddlewareService } from './middleware-service';
 
 export class ContainerHookService {
   static GetContainerHooksFromFiles(hookLifecycle: string): ContainerHook[] {
@@ -426,11 +427,24 @@ export class ContainerHookService {
 
   static async RunPostBuildSteps(orchestratorStepState: OrchestratorStepParameters) {
     let output = ``;
+    // Load middleware once for this phase and merge its resolved container
+    // hooks in with the legacy container-hook list (inline YAML + files).
+    // Merge order is legacy-first so a project not using middleware gets a
+    // byte-identical hook list to before this change (resolveContainerHooks
+    // returns [] when no middleware matches). Both timings ('before' and
+    // 'after') are included here since RunPostBuildSteps is itself a single
+    // container job run after the main build -- there is no separate legacy
+    // slot to distinguish "before the post-build job" from "after" it.
+    const middlewareDefinitions = MiddlewareService.getMiddleware(
+      Orchestrator.buildParameters.middlewarePipeline || '',
+    );
     const steps: ContainerHook[] = [
       ...ContainerHookService.ParseContainerHooks(
         Orchestrator.buildParameters.postBuildContainerHooks,
       ),
       ...ContainerHookService.GetContainerHooksFromFiles(`after`),
+      ...MiddlewareService.resolveContainerHooks(middlewareDefinitions, 'post-build', 'before'),
+      ...MiddlewareService.resolveContainerHooks(middlewareDefinitions, 'post-build', 'after'),
     ];
 
     if (steps.length > 0) {
@@ -445,11 +459,17 @@ export class ContainerHookService {
   }
   static async RunPreBuildSteps(orchestratorStepState: OrchestratorStepParameters) {
     let output = ``;
+    // See RunPostBuildSteps for the merge-strategy rationale.
+    const middlewareDefinitions = MiddlewareService.getMiddleware(
+      Orchestrator.buildParameters.middlewarePipeline || '',
+    );
     const steps: ContainerHook[] = [
       ...ContainerHookService.ParseContainerHooks(
         Orchestrator.buildParameters.preBuildContainerHooks,
       ),
       ...ContainerHookService.GetContainerHooksFromFiles(`before`),
+      ...MiddlewareService.resolveContainerHooks(middlewareDefinitions, 'pre-build', 'before'),
+      ...MiddlewareService.resolveContainerHooks(middlewareDefinitions, 'pre-build', 'after'),
     ];
 
     if (steps.length > 0) {

--- a/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.test.ts
+++ b/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.test.ts
@@ -134,3 +134,273 @@ describe('BuildAutomationWorkflow.BuildWorkflow (local/local-system branch)', ()
     expect(script).not.toContain('STEPS_DIR');
   });
 });
+
+describe('BuildAutomationWorkflow.BuildWorkflow -- middleware command-hook wiring', () => {
+  afterEach(() => {
+    Orchestrator.buildParameters = undefined as any;
+  });
+
+  it('produces byte-identical output with no middleware configured (regression guard)', () => {
+    const withoutMiddleware = makeBuildParameters({ commandHooks: '' });
+    Orchestrator.buildParameters = withoutMiddleware;
+    const scriptWithoutField = getBuildWorkflow();
+
+    const withEmptyMiddleware = makeBuildParameters({
+      commandHooks: '',
+      middlewarePipeline: '',
+    });
+    Orchestrator.buildParameters = withEmptyMiddleware;
+    const scriptWithEmptyMiddleware = getBuildWorkflow();
+
+    expect(scriptWithEmptyMiddleware).toBe(scriptWithoutField);
+  });
+
+  it('inserts a command-type middleware before/after command at the setup phase', () => {
+    Orchestrator.buildParameters = makeBuildParameters({
+      middlewarePipeline: `
+name: setup-mw
+type: command
+trigger:
+  phase: [setup]
+before:
+  commands: echo "setup-mw-before"
+after:
+  commands: echo "setup-mw-after"
+`,
+    });
+
+    const script = getBuildWorkflow();
+
+    expect(script).toContain('echo "setup-mw-before"');
+    expect(script).toContain('echo "setup-mw-after"');
+    // Should appear before the toolchain-setup marker's "after" position and
+    // around the setup commands, not inside the build-phase section.
+    const beforeIndex = script.indexOf('echo "setup-mw-before"');
+    const setupCommandsIndex = script.indexOf('export CACHE_KEY=');
+    expect(beforeIndex).toBeLessThan(setupCommandsIndex);
+  });
+
+  it('inserts a command-type middleware before/after command at the build phase', () => {
+    Orchestrator.buildParameters = makeBuildParameters({
+      middlewarePipeline: `
+name: build-mw
+type: command
+trigger:
+  phase: [build]
+before:
+  commands: echo "build-mw-before"
+after:
+  commands: echo "build-mw-after"
+`,
+    });
+
+    const script = getBuildWorkflow();
+
+    expect(script).toContain('echo "build-mw-before"');
+    expect(script).toContain('echo "build-mw-after"');
+    const buildBeforeIndex = script.indexOf('echo "build-mw-before"');
+    const buildRunIndex = script.indexOf('remote-cli-log-stream');
+    const buildAfterIndex = script.indexOf('echo "build-mw-after"');
+    expect(buildBeforeIndex).toBeLessThan(buildRunIndex);
+    expect(buildAfterIndex).toBeGreaterThan(buildRunIndex);
+  });
+
+  it('filters out middleware whose trigger phase does not match either slot', () => {
+    Orchestrator.buildParameters = makeBuildParameters({
+      middlewarePipeline: `
+name: prebuild-only-mw
+type: command
+trigger:
+  phase: [pre-build]
+before:
+  commands: echo "should-not-appear"
+`,
+    });
+
+    const script = getBuildWorkflow();
+
+    expect(script).not.toContain('should-not-appear');
+  });
+
+  it('filters out middleware whose trigger provider does not match providerStrategy', () => {
+    Orchestrator.buildParameters = makeBuildParameters({
+      providerStrategy: 'local',
+      middlewarePipeline: `
+name: aws-only-mw
+type: command
+trigger:
+  phase: [build]
+  provider: [aws]
+before:
+  commands: echo "aws-only-command"
+`,
+    });
+
+    const script = getBuildWorkflow();
+
+    expect(script).not.toContain('aws-only-command');
+  });
+
+  it('includes middleware whose trigger provider matches providerStrategy', () => {
+    Orchestrator.buildParameters = makeBuildParameters({
+      providerStrategy: 'local',
+      middlewarePipeline: `
+name: local-only-mw
+type: command
+trigger:
+  phase: [build]
+  provider: [local]
+before:
+  commands: echo "local-only-command"
+`,
+    });
+
+    const script = getBuildWorkflow();
+
+    expect(script).toContain('echo "local-only-command"');
+  });
+
+  it('filters out middleware whose trigger platform does not match targetPlatform', () => {
+    Orchestrator.buildParameters = makeBuildParameters({
+      targetPlatform: 'StandaloneLinux64',
+      middlewarePipeline: `
+name: windows-only-mw
+type: command
+trigger:
+  phase: [build]
+  platform: [StandaloneWindows64]
+before:
+  commands: echo "windows-only-command"
+`,
+    });
+
+    const script = getBuildWorkflow();
+
+    expect(script).not.toContain('windows-only-command');
+  });
+
+  it('evaluates a truthy env.VAR trigger expression', () => {
+    process.env.MW_FEATURE_FLAG = 'true';
+    Orchestrator.buildParameters = makeBuildParameters({
+      middlewarePipeline: `
+name: flagged-mw
+type: command
+trigger:
+  phase: [build]
+  when: "env.MW_FEATURE_FLAG == 'true'"
+before:
+  commands: echo "flag-on-command"
+`,
+    });
+
+    const script = getBuildWorkflow();
+
+    expect(script).toContain('echo "flag-on-command"');
+    delete process.env.MW_FEATURE_FLAG;
+  });
+
+  it('excludes middleware when the when-expression evaluates falsy', () => {
+    process.env.MW_FEATURE_FLAG = 'false';
+    Orchestrator.buildParameters = makeBuildParameters({
+      middlewarePipeline: `
+name: flagged-mw
+type: command
+trigger:
+  phase: [build]
+  when: "env.MW_FEATURE_FLAG == 'true'"
+before:
+  commands: echo "flag-off-command"
+`,
+    });
+
+    const script = getBuildWorkflow();
+
+    expect(script).not.toContain('flag-off-command');
+    delete process.env.MW_FEATURE_FLAG;
+  });
+
+  it('merges legacy command hooks and middleware, legacy first, at the same slot', () => {
+    Orchestrator.buildParameters = makeBuildParameters({
+      commandHooks: `
+- name: legacy-build-hook
+  hook: [before]
+  step: [build]
+  commands: echo "legacy-command"
+`,
+      middlewarePipeline: `
+name: merge-mw
+type: command
+trigger:
+  phase: [build]
+before:
+  commands: echo "middleware-command"
+`,
+    });
+
+    const script = getBuildWorkflow();
+
+    expect(script).toContain('echo "legacy-command"');
+    expect(script).toContain('echo "middleware-command"');
+    const legacyIndex = script.indexOf('echo "legacy-command"');
+    const middlewareIndex = script.indexOf('echo "middleware-command"');
+    expect(legacyIndex).toBeLessThan(middlewareIndex);
+  });
+
+  it('orders multiple before-phase middleware by ascending priority (wrapping order)', () => {
+    Orchestrator.buildParameters = makeBuildParameters({
+      middlewarePipeline: `
+- name: low-priority-mw
+  type: command
+  priority: 10
+  trigger:
+    phase: [build]
+  before:
+    commands: echo "low-priority-command"
+- name: high-priority-mw
+  type: command
+  priority: 90
+  trigger:
+    phase: [build]
+  before:
+    commands: echo "high-priority-command"
+`,
+    });
+
+    const script = getBuildWorkflow();
+
+    const lowIndex = script.indexOf('echo "low-priority-command"');
+    const highIndex = script.indexOf('echo "high-priority-command"');
+    expect(lowIndex).toBeGreaterThan(-1);
+    expect(highIndex).toBeGreaterThan(-1);
+    expect(lowIndex).toBeLessThan(highIndex);
+  });
+
+  it('does not crash and skips malformed inline middleware YAML', () => {
+    Orchestrator.buildParameters = makeBuildParameters({
+      middlewarePipeline: `not: [valid, yaml, : : broken`,
+    });
+
+    expect(() => getBuildWorkflow()).not.toThrow();
+  });
+
+  it('calls MiddlewareService.getMiddleware once per BuildWorkflow evaluation, not once per slot', async () => {
+    const { MiddlewareService } = await import('../services/hooks/middleware-service');
+    const spy = vi.spyOn(MiddlewareService, 'getMiddleware');
+
+    Orchestrator.buildParameters = makeBuildParameters({
+      middlewarePipeline: `
+name: spy-mw
+type: command
+trigger:
+  phase: [build]
+before:
+  commands: echo "spy-command"
+`,
+    });
+
+    getBuildWorkflow();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+});

--- a/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.ts
+++ b/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.ts
@@ -6,6 +6,7 @@ import { CommandHookService } from '../services/hooks/command-hook-service';
 import path from 'node:path';
 import Orchestrator from '../orchestrator';
 import { ContainerHookService } from '../services/hooks/container-hook-service';
+import { MiddlewareService } from '../services/hooks/middleware-service';
 import { CacheCheckpointService } from '../services/cache/cache-checkpoint-service';
 import { PreflightService } from '../services/preflight';
 import { getEngine } from '../../engine';
@@ -239,12 +240,25 @@ export class BuildAutomationWorkflow implements WorkflowInterface {
   }
 
   private static get BuildWorkflow() {
-    const setupHooks = CommandHookService.getHooks(
-      Orchestrator.buildParameters.commandHooks,
-    ).filter((x) => x.step?.includes(`setup`));
-    const buildHooks = CommandHookService.getHooks(
-      Orchestrator.buildParameters.commandHooks,
-    ).filter((x) => x.step?.includes(`build`));
+    // Load middleware once per build (not once per phase/timing slot) and
+    // merge its resolved command hooks in with the legacy command-hook list.
+    // Merge order is legacy-first so a project not using middleware gets a
+    // byte-identical hook list to before this change (resolveCommandHooks
+    // returns [] when no middleware matches).
+    const middlewareDefinitions = MiddlewareService.getMiddleware(
+      Orchestrator.buildParameters.middlewarePipeline || '',
+    );
+    const legacyCommandHooks = CommandHookService.getHooks(Orchestrator.buildParameters.commandHooks);
+    const setupHooks = [
+      ...legacyCommandHooks.filter((x) => x.step?.includes(`setup`)),
+      ...MiddlewareService.resolveCommandHooks(middlewareDefinitions, 'setup', 'before'),
+      ...MiddlewareService.resolveCommandHooks(middlewareDefinitions, 'setup', 'after'),
+    ];
+    const buildHooks = [
+      ...legacyCommandHooks.filter((x) => x.step?.includes(`build`)),
+      ...MiddlewareService.resolveCommandHooks(middlewareDefinitions, 'build', 'before'),
+      ...MiddlewareService.resolveCommandHooks(middlewareDefinitions, 'build', 'after'),
+    ];
     const isContainerized =
       Orchestrator.buildParameters.providerStrategy === 'aws' ||
       Orchestrator.buildParameters.providerStrategy === 'k8s' ||

--- a/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.ts
+++ b/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.ts
@@ -248,7 +248,9 @@ export class BuildAutomationWorkflow implements WorkflowInterface {
     const middlewareDefinitions = MiddlewareService.getMiddleware(
       Orchestrator.buildParameters.middlewarePipeline || '',
     );
-    const legacyCommandHooks = CommandHookService.getHooks(Orchestrator.buildParameters.commandHooks);
+    const legacyCommandHooks = CommandHookService.getHooks(
+      Orchestrator.buildParameters.commandHooks,
+    );
     const setupHooks = [
       ...legacyCommandHooks.filter((x) => x.step?.includes(`setup`)),
       ...MiddlewareService.resolveCommandHooks(middlewareDefinitions, 'setup', 'before'),


### PR DESCRIPTION
## Summary

\`MiddlewareService\`/\`Middleware\` (\`plugins/orchestrator/src/model/orchestrator/services/hooks/middleware-service.ts\`, \`middleware.ts\`) is a complete, well-designed hook abstraction — named definitions with trigger conditions (\`phase\`/\`provider\`/\`platform\`/an \`env.VAR\`-based \`when\` expression), \`before\`/\`after\` command or container blocks, priority ordering (ascending for \`before\`, descending for \`after\` — a "wrapping" pattern), and \`allowFailure\`. It already resolves to the exact \`CommandHook\`/\`ContainerHook\` shapes the live pipeline consumes via \`resolveCommandHooks\`/\`resolveContainerHooks\`. It was never connected to anything: every non-test call site of \`MiddlewareService\`/\`Middleware\` was inside its own test file.

## What changed

Wires it into the 6 real hook slots:
- \`BuildAutomationWorkflow.BuildWorkflow\`'s \`setup\`/\`build\` × \`before\`/\`after\` command-hook splice points (around toolchain setup and the actual Unity invocation)
- \`ContainerHookService.RunPreBuildSteps\`/\`RunPostBuildSteps\`'s container-hook lists

Merge order is **legacy-first** in every slot, so a project not using middleware gets a byte-identical hook list to before this change (\`resolveCommandHooks\`/\`resolveContainerHooks\` return \`[]\` when no middleware matches its trigger — confirmed by a dedicated regression test). Middleware is loaded once per call site (3× per build total — \`BuildWorkflow\`, \`RunPreBuildSteps\`, \`RunPostBuildSteps\` — not once per phase/timing slot within each).

\`--middlewarePipeline\`/\`--middlewareFiles\` were already fully registered as CLI options and threaded through \`BuildParameters\` — confirmed via test, no fix needed there (unlike \`--skipActivation\`/\`--local-cache-*\` in earlier PRs on this codebase, which did have that exact gap).

## Also found, not fixed — flagged for a follow-up decision

\`UnityRetryService\` (\`services/reliability/unity-retry-service.ts\`) is a complete, documented multi-phase retry orchestrator (Library backups, budget-limited retries, CRASH/COMPILE/LICENSE recovery chains) with **zero call sites anywhere**, not even its own test file. \`UnityRecoveryService.decide()\`'s \`'retry-licensing'\` branch returns a decision object but never actually invokes \`UnityRetryService\` to execute it — looks like an unfinished decide/execute split where the execute half never got wired in. This may be directly relevant to a previously-identified gap: no lifecycle point currently exists between a build's exit code and orchestrator's success/failure decision. Worth investigating as a dedicated follow-up rather than folding into this PR.

## Verification

- \`tsc --noEmit\` (orchestrator): clean
- \`bun run test:ci\` (orchestrator, vitest): 965 passed / 1 skipped / 2 pre-existing failures unrelated to this change (\`cli-integration.test.ts\` subprocess-timeout flake, confirmed passing 9/9 standalone; \`orchestrator-rclone-steps.test.ts\`, which needs a prior \`tsc\` build producing \`dist/\` that doesn't exist in a fresh worktree) — up from a 940-passing baseline, all 25 new tests green
- \`bun test ./src\` (root cli): 180 pass / 3 skip / 0 fail
- \`bun run build\`: succeeds for both packages
- **Live sanity check**: the full CLI path hits the same pre-existing, unrelated \`remote-cli-log-stream\`/\`Cannot find module\` bug noted in earlier PRs on this codebase (reproduced independently by the \`orchestrator-rclone-steps.test.ts\` failure above), so verification was done at the \`BuildAutomationWorkflow\`/\`ContainerHookService\` level directly: new tests assert inline-YAML middleware \`before\`/\`after\` commands literally appear in the correct position of the generated shell script (command hooks) and in the correct position/order of the resolved \`ContainerHook[]\` array (container hooks).

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`bun run test:ci\` passes (965/966 real tests, 2 pre-existing unrelated failures)
- [x] \`bun run build\` succeeds for both packages
- [x] No-middleware regression test confirms byte-identical behavior for existing projects
- [ ] Follow-up: investigate wiring \`UnityRetryService\` (see above)
- [ ] Follow-up: real end-to-end validation against a project actually using \`game-ci/middleware/*.yaml\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added middleware pipeline support for build setup and build phases.
  * Middleware commands can run before or after build steps based on configured triggers.
  * Middleware is filtered by phase, provider, platform, and conditional expressions.
  * Middleware commands integrate with existing hooks while preserving priority and execution order.

* **Bug Fixes**
  * Invalid middleware configuration is safely skipped without interrupting workflow generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->