### PR TITLE
feat: named build profiles in .game-ci.yml via --profile

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -100,12 +100,18 @@ describe('Cli env var option mapping', () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'game-ci-cli-'));
     try {
       await fs.mkdir(path.join(tempDir, 'ProjectSettings'), { recursive: true });
-      await fs.writeFile(path.join(tempDir, 'ProjectSettings', 'ProjectVersion.txt'), 'm_EditorVersion: 2022.3.20f1\n', 'utf8');
+      await fs.writeFile(
+        path.join(tempDir, 'ProjectSettings', 'ProjectVersion.txt'),
+        'm_EditorVersion: 2022.3.20f1\n',
+        'utf8',
+      );
       // vcsDetection shells out to git and throws if the project path isn't a repo.
       await new Promise((resolve, reject) => {
         const child = spawn('git', ['init', tempDir]);
         child.on('error', reject);
-        child.on('exit', (code) => (code === 0 ? resolve(undefined) : reject(new Error(`git init exited with ${code}`))));
+        child.on('exit', (code) =>
+          code === 0 ? resolve(undefined) : reject(new Error(`git init exited with ${code}`)),
+        );
       });
 
       const previousEmail = process.env.UNITY_EMAIL;
@@ -122,6 +128,206 @@ describe('Cli env var option mapping', () => {
         if (previousEmail === undefined) delete process.env.UNITY_EMAIL;
         else process.env.UNITY_EMAIL = previousEmail;
       }
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('Cli config profiles', () => {
+  // Mirrors the ProjectSettings + git-init setup used in the env-var
+  // mapping tests above - `activate` needs a real-looking Unity project
+  // dir, and vcsDetection shells out to git and throws if it isn't a repo.
+  async function makeProjectDir() {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'game-ci-cli-profiles-'));
+    await fs.mkdir(path.join(tempDir, 'ProjectSettings'), { recursive: true });
+    await fs.writeFile(
+      path.join(tempDir, 'ProjectSettings', 'ProjectVersion.txt'),
+      'm_EditorVersion: 2022.3.20f1\n',
+      'utf8',
+    );
+    await new Promise((resolve, reject) => {
+      const child = spawn('git', ['init', tempDir]);
+      child.on('error', reject);
+      child.on('exit', (code) => (code === 0 ? resolve(undefined) : reject(new Error(`git init exited with ${code}`))));
+    });
+
+    return tempDir;
+  }
+
+  async function parseOptions(tempDir: string, configPath: string, extraArgs: string[] = []) {
+    const cli = new Cli(['activate', tempDir, '--config', configPath, ...extraArgs], process.cwd());
+    await cli.setup();
+    await cli.registerCommands();
+    await cli.registerSchemaForChosenCommand();
+    const { options } = await cli.validateAndParseArguments();
+
+    return options;
+  }
+
+  it('applies the selected profile on top of base cliOptions (YAML)', async () => {
+    const tempDir = await makeProjectDir();
+    try {
+      const configPath = path.join(tempDir, '.game-ci.yml');
+      await fs.writeFile(
+        configPath,
+        `cliOptions:
+  verbose: false
+
+profiles:
+  loud:
+    verbose: true
+`,
+        'utf8',
+      );
+
+      const options = await parseOptions(tempDir, configPath, ['--profile', 'loud']);
+
+      expect(options.logLevel).toBe(1); // verbose: true from the profile
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('applies the selected profile on top of base cliOptions (JSON)', async () => {
+    const tempDir = await makeProjectDir();
+    try {
+      const configPath = path.join(tempDir, '.game-ci.json');
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          cliOptions: { verbose: false },
+          profiles: { loud: { verbose: true } },
+        }),
+        'utf8',
+      );
+
+      const options = await parseOptions(tempDir, configPath, ['--profile', 'loud']);
+
+      expect(options.logLevel).toBe(1); // verbose: true from the profile
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('profile options win over base cliOptions on key conflicts', async () => {
+    const tempDir = await makeProjectDir();
+    try {
+      const configPath = path.join(tempDir, '.game-ci.yml');
+      await fs.writeFile(
+        configPath,
+        `cliOptions:
+  verbose: true
+
+profiles:
+  quiet-profile:
+    verbose: false
+`,
+        'utf8',
+      );
+
+      const withoutProfile = await parseOptions(tempDir, configPath);
+      expect(withoutProfile.logLevel).toBe(1); // base cliOptions.verbose: true
+
+      const withProfile = await parseOptions(tempDir, configPath, ['--profile', 'quiet-profile']);
+      expect(withProfile.logLevel).toBe(0); // profile's verbose: false wins over base
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('explicit CLI flags still win over the selected profile', async () => {
+    const tempDir = await makeProjectDir();
+    try {
+      const configPath = path.join(tempDir, '.game-ci.yml');
+      await fs.writeFile(
+        configPath,
+        `cliOptions:
+  verbose: false
+
+profiles:
+  loud:
+    verbose: true
+`,
+        'utf8',
+      );
+
+      // --profile loud sets verbose: true, but the explicit --verbose=false
+      // flag on the command line must win over both the profile and base cliOptions.
+      const options = await parseOptions(tempDir, configPath, ['--profile', 'loud', '--verbose=false']);
+
+      expect(options.logLevel).toBe(0);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails with a clear, actionable error listing available profiles for an unknown --profile name', async () => {
+    const tempDir = await makeProjectDir();
+    try {
+      const configPath = path.join(tempDir, '.game-ci.yml');
+      await fs.writeFile(
+        configPath,
+        `cliOptions:
+  verbose: false
+
+profiles:
+  webgl-demo:
+    verbose: true
+  windows-release:
+    verbose: true
+`,
+        'utf8',
+      );
+
+      await expect(parseOptions(tempDir, configPath, ['--profile', 'does-not-exist'])).rejects.toThrow(
+        /Unknown profile "does-not-exist".*webgl-demo.*windows-release/s,
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('is a zero behavior change when no --profile flag is passed (regression check)', async () => {
+    const tempDir = await makeProjectDir();
+    try {
+      const configPath = path.join(tempDir, '.game-ci.yml');
+      await fs.writeFile(
+        configPath,
+        `cliOptions:
+  verbose: true
+
+profiles:
+  loud:
+    verbose: false
+`,
+        'utf8',
+      );
+
+      const options = await parseOptions(tempDir, configPath);
+
+      // Only base cliOptions applies - the profiles: block is ignored entirely.
+      expect(options.logLevel).toBe(1);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('is a zero behavior change for configs that have no profiles: block at all', async () => {
+    const tempDir = await makeProjectDir();
+    try {
+      const configPath = path.join(tempDir, '.game-ci.yml');
+      await fs.writeFile(
+        configPath,
+        `cliOptions:
+  verbose: true
+`,
+        'utf8',
+      );
+
+      const options = await parseOptions(tempDir, configPath);
+
+      expect(options.logLevel).toBe(1);
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ export class Cli {
   private readonly cliPath: string;
   private readonly cliDistPath: string;
   private readonly configFileName!: string;
+  private readonly rawArgs: string[];
   private readonly currentWorkDir: string;
   private readonly homeDir: string;
   private readonly isRunningLocally: boolean;
@@ -28,6 +29,7 @@ export class Cli {
 
   constructor(args: string[], cwd: string) {
     this.yargs = yargs(args);
+    this.rawArgs = args;
     this.currentWorkDir = cwd;
     this.configFileName = '.game-ci.yml';
 
@@ -136,7 +138,6 @@ export class Cli {
   protected configureGlobalSettings() {
     const defaultCanonicalPath = `${this.cliStorageCanonicalPath}/${this.configFileName}`;
 
-
     this.yargs
       .parserConfiguration({
         'dot-notation': false,
@@ -154,19 +155,18 @@ export class Cli {
       .exitProcess(true) // Fixes broken `_handle` in yargs 17.0.0
       .strict(true);
 
-      // Deliberately not using yargs' blanket .env(): combined with strict(true)
-      // it treats every process env var (not just game-ci-relevant ones) as an
-      // unrecognized argument and fails. Secret-bearing options set their own
-      // env fallback in their .option() default instead - see unityEmail etc.
-      // in unity-options.ts.
+    // Deliberately not using yargs' blanket .env(): combined with strict(true)
+    // it treats every process env var (not just game-ci-relevant ones) as an
+    // unrecognized argument and fails. Secret-bearing options set their own
+    // env fallback in their .option() default instead - see unityEmail etc.
+    // in unity-options.ts.
   }
 
   protected configureGlobalOptions() {
     const defaultAbsolutePath = `${this.cliStoragePath}/${this.configFileName}`;
     this.yargs
       .option('plugin', {
-        description:
-          'Load an external plugin from npm, a local path, github:<repo>, or executable:<path>',
+        description: 'Load an external plugin from npm, a local path, github:<repo>, or executable:<path>',
         type: 'string',
         array: true,
       })
@@ -174,6 +174,11 @@ export class Cli {
         description: 'Alias for --plugin to support config-driven plugin arrays',
         type: 'string',
         array: true,
+      })
+      .option('profile', {
+        description: 'Select a named build profile from the profiles: map in the config file',
+        type: 'string',
+        demandOption: false,
       })
       .config('config', `default: .game-ci.yml`, (override: string) => {
         // Todo - remove hardcoded. Yargs override seems to be bugged though.
@@ -258,21 +263,18 @@ export class Cli {
   }
 
   protected loadConfig(configPath: string) {
+    let rootConfig: any;
+
     try {
       const { readFileSync } = require('node:fs');
       const configFile = readFileSync(configPath, 'utf-8');
 
       try {
-        const jsonConfig = JSON.parse(configFile).cliOptions;
-        if (log.isMaxVerbose) log.debug('jsonConfig', jsonConfig);
-
-        return jsonConfig;
+        rootConfig = JSON.parse(configFile);
+        if (log.isMaxVerbose) log.debug('jsonConfig', rootConfig?.cliOptions);
       } catch {
-        const yamlConfigRaw = yaml.parse(configFile) as any;
-        const yamlConfig = yamlConfigRaw.cliOptions;
-        if (log.isMaxVerbose) log.debug('yamlConfig', yamlConfig);
-
-        return yamlConfig;
+        rootConfig = yaml.parse(configFile) as any;
+        if (log.isMaxVerbose) log.debug('yamlConfig', rootConfig?.cliOptions);
       }
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
@@ -281,6 +283,58 @@ export class Cli {
 
       throw new Error(`Could not parse config file ${configPath}`);
     }
+
+    return this.resolveCliOptions(rootConfig, configPath);
+  }
+
+  // Merges the base `cliOptions:` block with the selected `--profile`'s
+  // overrides (profile wins on key conflicts) *before* handing the result
+  // back to yargs' .config() callback. This keeps yargs' own (already
+  // correct) precedence between config-sourced values and explicit CLI
+  // flags intact - explicit flags still win over whatever this returns.
+  private resolveCliOptions(rootConfig: any, configPath: string): Record<string, unknown> {
+    const cliOptions = (rootConfig?.cliOptions ?? {}) as Record<string, unknown>;
+    const profiles = (rootConfig?.profiles ?? {}) as Record<string, unknown>;
+    const profileName = this.getRequestedProfileName();
+
+    if (!profileName) {
+      return cliOptions;
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(profiles, profileName)) {
+      const availableProfiles = Object.keys(profiles);
+      const availableList = availableProfiles.length > 0 ? availableProfiles.join(', ') : '(no profiles defined)';
+
+      throw new Error(
+        `Unknown profile "${profileName}" passed via --profile. ` +
+          `Available profiles in ${configPath}: ${availableList}`,
+      );
+    }
+
+    const profileOptions = profiles[profileName] as Record<string, unknown>;
+
+    return { ...cliOptions, ...profileOptions };
+  }
+
+  // --profile is read directly from the raw argv rather than from a parsed
+  // yargs result: this method is called from inside the yargs .config()
+  // callback, which only receives the resolved "config" value - not the
+  // rest of the parsed argv - so we can't rely on yargs having parsed
+  // --profile yet at this point.
+  private getRequestedProfileName(): string | undefined {
+    for (let index = 0; index < this.rawArgs.length; index++) {
+      const arg = this.rawArgs[index];
+
+      if (arg === '--profile') {
+        return this.rawArgs[index + 1];
+      }
+
+      if (arg?.startsWith('--profile=')) {
+        return arg.slice('--profile='.length);
+      }
+    }
+
+    return undefined;
   }
 
   protected async nonStrict(fn: () => void) {


### PR DESCRIPTION
## Summary

Adds a `profiles:` map alongside the existing `cliOptions:` block in `.game-ci.yml` — each key a named set of option overrides, selected with `--profile <name>`.

```yaml
cliOptions:
  verbose: true

profiles:
  webgl-demo:
    targetPlatform: WebGL
    buildsPath: dist/webgl-demo
    buildMethod: BuildScripts.BuildWebGLDemo
  windows-release:
    targetPlatform: StandaloneWindows64
    buildsPath: dist/windows-release
```

```bash
game-ci build --profile webgl-demo
```

This is the portable slice of a larger "multi-profile fan-out" idea evaluated this session against a real external studio's CI system — deliberately scoped to profile **selection** only, not workflow-file-generation or CI-provider trigger-ownership (which are inherently GitHub-Actions-specific concerns that don't belong in a build CLI, and stay entirely the calling repo's own concern).

## Precedence

**Explicit CLI flags > selected profile > base `cliOptions`.** The profile and base `cliOptions` are merged (profile wins on key conflicts) *before* being handed to yargs' own `.config()` callback, so yargs' already-correct precedence between config-sourced values and explicit flags applies unmodified on top — verified via a throwaway repro before writing any implementation code, not assumed.

`--profile` is read directly from raw argv rather than parsed yargs output, since the `.config()` callback that needs it only receives the resolved config value, not the rest of parsed argv, at the point it runs.

An unknown `--profile` name **fails loudly** with the available profile list read from the config file, rather than silently falling back to base options — a typo'd profile name should never silently produce the wrong build.

## Verification

- `bun test ./src`: 187 pass / 3 skip / 0 fail, including 7 new tests: profile merge (YAML + JSON), profile-wins-over-base, explicit-flag-wins-over-profile, unknown-profile error with listing, and two regression guards (no `--profile` flag, and no `profiles:` block at all — both zero behavior change from today).
- `bun run build`: succeeds.
- **Live sanity check**: real `.game-ci.yml` with the example above, run with `--vvv` to inspect parsed options — `--profile webgl-demo` correctly resolved `targetPlatform`/`buildsPath`/`buildMethod`; `--profile webgl-demo --buildsPath /custom/path` confirmed the explicit flag won over the profile's `buildsPath` while the profile's other fields still applied; `--profile typo-profile` threw the expected clear error listing `webgl-demo, windows-release`.

## Note

An unrelated pre-existing quirk, confirmed but not touched: `.game-ci.yml`'s `cliOptions:` (and now `profiles:`) only actually take effect when `--config <path>` is passed explicitly — there's no auto-discovery of `.game-ci.yml` through yargs itself today (a `// Todo` comment in the file already acknowledges this). Profiles behave exactly the same way as existing `cliOptions:`, so this doesn't introduce a new inconsistency, just inherits the existing one.

## Test plan

- [x] `bun test ./src` passes
- [x] `bun run build` succeeds
- [x] Live 3-way precedence check (flag > profile > base) confirmed correct
- [x] Unknown-profile error path confirmed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for selecting configuration profiles with the `--profile` option.
  - Profiles can be defined in YAML or JSON configuration files.
  - Profile settings override base configuration, while explicit command-line options take precedence.
  - Unknown profiles now produce an error listing available profiles.

- **Bug Fixes**
  - Preserved existing behavior when profiles are unused or not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->