### PR TITLE
feat: wire UnityRetryService into the local provider's build retry (opt-in)

### DIFF
--- a/plugins/orchestrator/src/cli-plugin/build-parameters-adapter.ts
+++ b/plugins/orchestrator/src/cli-plugin/build-parameters-adapter.ts
@@ -153,6 +153,7 @@ export function createBuildParametersFromCliOptions(options: Record<string, any>
   // ── reliability ───────────────────────────────────────────────────
   bp.gitIntegrityCheck = options.gitIntegrityCheck === true || options.gitIntegrityCheck === 'true';
   bp.gitAutoRecover = options.gitAutoRecover === true || options.gitAutoRecover === 'true';
+  bp.enableBuildRetry = options.enableBuildRetry === true || options.enableBuildRetry === 'true';
   bp.cleanReservedFilenames =
     options.cleanReservedFilenames === true || options.cleanReservedFilenames === 'true';
   bp.buildArchiveEnabled =

--- a/plugins/orchestrator/src/cli-plugin/orchestrator-options-plugin.ts
+++ b/plugins/orchestrator/src/cli-plugin/orchestrator-options-plugin.ts
@@ -346,6 +346,16 @@ export function configureOrchestratorOptions(yargs: any): void {
     default: false,
   });
 
+  yargs.option('enableBuildRetry', {
+    description:
+      'Enable automatic classify/decide/retry recovery for failed Unity builds on the bare-host ' +
+      '`local`/`local-system` provider strategy (UnityRetryService, budget-gated). Default off: a ' +
+      'single failed attempt still throws exactly as before -- retry can back up or nuke the Library ' +
+      'folder as a recovery action, which is a meaningful behavior change existing users must opt into.',
+    type: 'boolean',
+    default: false,
+  });
+
   yargs.option('skipInContainerClone', {
     description:
       'Skip the in-container git clone and reuse a pre-hydrated workspace bind-mounted by the caller. ' +

--- a/plugins/orchestrator/src/model/build-parameters.ts
+++ b/plugins/orchestrator/src/model/build-parameters.ts
@@ -150,6 +150,12 @@ class BuildParameters {
   // ── reliability ─────────────────────────────────────────────────────
   gitIntegrityCheck!: boolean;
   gitAutoRecover!: boolean;
+  // Opt-in (default false) automatic classify -> decide -> retry loop for
+  // failed Unity runs on the bare-host `local`/`local-system` provider's
+  // build path only (see UnityRetryService). Off by default because retry
+  // can nuke/backup the Library folder as a recovery action -- a meaningful
+  // behavior change that must not silently activate for existing users.
+  enableBuildRetry!: boolean;
   cleanReservedFilenames!: boolean;
   buildArchiveEnabled!: boolean;
   buildArchivePath!: string;

--- a/plugins/orchestrator/src/model/orchestrator/providers/local/index.retry.test.ts
+++ b/plugins/orchestrator/src/model/orchestrator/providers/local/index.retry.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, afterEach, vi, type Mocked } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+vi.mock('node:fs');
+vi.mock('../../services/core/orchestrator-system', () => ({
+  OrchestratorSystem: { Run: vi.fn() },
+}));
+vi.mock('../../services/reliability/unity-retry-service', () => ({
+  UnityRetryService: { executeWithRetry: vi.fn() },
+}));
+vi.mock('../../services/reliability/unity-recovery-service', () => ({
+  UnityRecoveryService: { createDefaultBudgets: vi.fn(() => ({ mocked: true })) },
+}));
+
+import LocalOrchestrator from './index';
+import { OrchestratorSystem } from '../../services/core/orchestrator-system';
+import { UnityRetryService } from '../../services/reliability/unity-retry-service';
+import { UnityRecoveryService } from '../../services/reliability/unity-recovery-service';
+import Orchestrator from '../../orchestrator';
+import BuildParameters from '../../../build-parameters';
+
+const mockFs = fs as Mocked<typeof fs>;
+const mockRun = OrchestratorSystem.Run as unknown as Mocked<typeof OrchestratorSystem.Run>;
+const mockExecuteWithRetry = UnityRetryService.executeWithRetry as unknown as Mocked<
+  typeof UnityRetryService.executeWithRetry
+>;
+
+/**
+ * Integration coverage for the --enableBuildRetry wiring point: the
+ * isBareLocalProvider path inside LocalOrchestrator.runTaskInWorkflow that
+ * decides between "single attempt, throw on failure" (today's behavior,
+ * default) and "delegate to UnityRetryService.executeWithRetry" (opt-in).
+ * UnityRetryService's own retry/recovery algorithm is covered exhaustively
+ * in unity-retry-service.test.ts -- this file only asserts the call pattern
+ * difference at the provider boundary.
+ */
+describe('LocalOrchestrator.runTaskInWorkflow -- enableBuildRetry wiring', () => {
+  const originalPlatform = process.platform;
+  const provider = new LocalOrchestrator();
+
+  const runTask = () =>
+    provider.runTaskInWorkflow('build-guid', 'unity-image', 'echo hi', '/mnt', '/mnt/', [], []);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    mockFs.readFileSync.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('enableBuildRetry=false (default): calls OrchestratorSystem.Run directly once and never touches UnityRetryService', async () => {
+    Orchestrator.buildParameters = { enableBuildRetry: false, projectPath: '.' } as BuildParameters;
+    mockRun.mockResolvedValue('build output');
+
+    const result = await runTask();
+
+    expect(result).toBe('build output');
+    expect(mockRun).toHaveBeenCalledTimes(1);
+    expect(mockRun).toHaveBeenCalledWith('echo hi');
+    expect(mockExecuteWithRetry).not.toHaveBeenCalled();
+  });
+
+  it('enableBuildRetry left unset behaves identically to false (safe default for hosts not on this build parameters version)', async () => {
+    Orchestrator.buildParameters = { projectPath: '.' } as BuildParameters;
+    mockRun.mockResolvedValue('build output');
+
+    await runTask();
+
+    expect(mockRun).toHaveBeenCalledTimes(1);
+    expect(mockExecuteWithRetry).not.toHaveBeenCalled();
+  });
+
+  it('enableBuildRetry=false still throws exactly as before on failure -- zero behavior change for the common case', async () => {
+    Orchestrator.buildParameters = { enableBuildRetry: false, projectPath: '.' } as BuildParameters;
+    mockRun.mockRejectedValue('raw wrapper output');
+
+    await expect(runTask()).rejects.toBe('raw wrapper output');
+    expect(mockExecuteWithRetry).not.toHaveBeenCalled();
+  });
+
+  it('enableBuildRetry=true: delegates to UnityRetryService.executeWithRetry with UnityRecoveryService default budgets instead of calling OrchestratorSystem.Run directly', async () => {
+    Orchestrator.buildParameters = {
+      enableBuildRetry: true,
+      projectPath: 'MyProject',
+    } as BuildParameters;
+    mockExecuteWithRetry.mockResolvedValue({
+      succeeded: true,
+      attempts: 2,
+      lastDiagnostics: { failureCategory: 'SUCCESS' } as any,
+      actionsPerformed: ['retry-licensing'],
+    });
+
+    const result = await runTask();
+
+    expect(result).toBe('');
+    expect(mockRun).not.toHaveBeenCalled();
+    expect(mockExecuteWithRetry).toHaveBeenCalledTimes(1);
+    expect(UnityRecoveryService.createDefaultBudgets).toHaveBeenCalledTimes(1);
+
+    const [projectPathArgument, runUnityArgument, optionsArgument] =
+      mockExecuteWithRetry.mock.calls[0];
+    expect(projectPathArgument).toBe(path.join(process.cwd(), 'MyProject'));
+    expect(typeof runUnityArgument).toBe('function');
+    expect(optionsArgument).toEqual({ budgets: { mocked: true } });
+  });
+
+  it('enableBuildRetry=true and the retry loop ultimately fails: throws a descriptive Error (not the raw output string)', async () => {
+    Orchestrator.buildParameters = { enableBuildRetry: true, projectPath: '.' } as BuildParameters;
+    mockExecuteWithRetry.mockResolvedValue({
+      succeeded: false,
+      attempts: 6,
+      lastDiagnostics: {
+        failureCategory: 'CRASH',
+        failureSummary: { remediationHint: 'Clear ScriptAssemblies or nuke Library.' },
+      } as any,
+      actionsPerformed: ['nuke-library'],
+    });
+
+    await expect(runTask()).rejects.toThrow(
+      /Unity build failed after 6 attempt\(s\).*\[CRASH\].*nuke-library/s,
+    );
+  });
+
+  it('the runUnity callback passed to UnityRetryService runs the command with suppressError=true, captures the real exit code, and prefers the on-disk Editor log over wrapper stdout', async () => {
+    Orchestrator.buildParameters = { enableBuildRetry: true, projectPath: '.' } as BuildParameters;
+
+    let capturedRunUnity:
+      | (() => Promise<{
+          exitCode: number;
+          logText: string;
+          runtimeSeconds: number;
+        }>)
+      | undefined;
+
+    mockExecuteWithRetry.mockImplementation(async (_projectPath, runUnity) => {
+      capturedRunUnity = runUnity;
+
+      return {
+        succeeded: true,
+        attempts: 1,
+        lastDiagnostics: { failureCategory: 'SUCCESS' } as any,
+        actionsPerformed: [],
+      };
+    });
+    mockRun.mockImplementation(
+      async (
+        _command: string,
+        _suppressError?: boolean,
+        _suppressLogs?: boolean,
+        _outputCallback?: (output: string) => void,
+        onExitCode?: (code: number) => void,
+      ) => {
+        onExitCode?.(1);
+
+        return 'wrapper stdout only';
+      },
+    );
+    mockFs.readFileSync.mockReturnValue('genuine Unity Editor log content' as any);
+
+    await runTask();
+
+    expect(capturedRunUnity).toBeDefined();
+    const attemptResult = await capturedRunUnity!();
+
+    expect(mockRun).toHaveBeenCalledWith('echo hi', true, false, undefined, expect.any(Function));
+    expect(attemptResult.exitCode).toBe(1);
+    expect(attemptResult.logText).toBe('genuine Unity Editor log content');
+    expect(mockFs.readFileSync).toHaveBeenCalledWith(
+      path.join(process.cwd(), 'temp', 'job-log.txt'),
+      'utf8',
+    );
+  });
+
+  it('falls back to wrapper stdout as logText when the Editor log file cannot be read', async () => {
+    Orchestrator.buildParameters = { enableBuildRetry: true, projectPath: '.' } as BuildParameters;
+
+    let capturedRunUnity: (() => Promise<{ exitCode: number; logText: string }>) | undefined;
+    mockExecuteWithRetry.mockImplementation(async (_projectPath, runUnity) => {
+      capturedRunUnity = runUnity as any;
+
+      return {
+        succeeded: true,
+        attempts: 1,
+        lastDiagnostics: { failureCategory: 'SUCCESS' } as any,
+        actionsPerformed: [],
+      };
+    });
+    mockRun.mockResolvedValue('wrapper stdout only');
+    mockFs.readFileSync.mockImplementation(() => {
+      throw new Error('ENOENT: no such file');
+    });
+
+    await runTask();
+    const attemptResult = await capturedRunUnity!();
+
+    expect(attemptResult.logText).toBe('wrapper stdout only');
+  });
+});

--- a/plugins/orchestrator/src/model/orchestrator/providers/local/index.ts
+++ b/plugins/orchestrator/src/model/orchestrator/providers/local/index.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import BuildParameters from '../../../build-parameters';
 import { OrchestratorSystem } from '../../services/core/orchestrator-system';
 import OrchestratorEnvironmentVariable from '../../options/orchestrator-environment-variable';
@@ -7,6 +9,9 @@ import OrchestratorSecret from '../../options/orchestrator-secret';
 import { ProviderResource } from '../provider-resource';
 import { ProviderWorkflow } from '../provider-workflow';
 import { quote } from 'shell-quote';
+import Orchestrator from '../../orchestrator';
+import { UnityRetryService } from '../../services/reliability/unity-retry-service';
+import { UnityRecoveryService } from '../../services/reliability/unity-recovery-service';
 
 class LocalOrchestrator implements ProviderInterface {
   listResources(): Promise<ProviderResource[]> {
@@ -89,6 +94,7 @@ class LocalOrchestrator implements ProviderInterface {
     OrchestratorLogger.log(commands);
 
     // On Windows, many built-in hooks use POSIX shell syntax. Execute via bash if available.
+    let command = commands;
     if (process.platform === 'win32') {
       const inline = commands
         .replace(/\r/g, '')
@@ -97,12 +103,94 @@ class LocalOrchestrator implements ProviderInterface {
         .join(' ; ');
 
       // Use shell-quote to properly escape the command string, preventing command injection
-      const bashWrapped = `bash -lc ${quote([inline])}`;
-
-      return await OrchestratorSystem.Run(bashWrapped);
+      command = `bash -lc ${quote([inline])}`;
     }
 
-    return await OrchestratorSystem.Run(commands);
+    // Opt-in (--enableBuildRetry, default off): wrap the whole invocation in
+    // UnityRetryService's classify -> decide -> retry loop, entirely
+    // encapsulated inside this provider. Every provider strategy other than
+    // local/local-system goes through their own OrchestratorSystem.Run calls
+    // untouched, and the ProviderInterface contract is unchanged -- callers
+    // above (e.g. BuildAutomationWorkflow) keep awaiting a plain
+    // Promise<string>, same as before this feature existed.
+    if (Orchestrator.buildParameters?.enableBuildRetry) {
+      return await LocalOrchestrator.runWithRetry(command);
+    }
+
+    return await OrchestratorSystem.Run(command);
+  }
+
+  /**
+   * Runs `command` under UnityRetryService.executeWithRetry: on a non-zero
+   * exit, classify the failure (UnityBuildDiagnosticsService), decide on a
+   * budget-gated recovery action (UnityRecoveryService -- may back up/nuke
+   * the Library folder or clear subfolders), perform it, then retry the
+   * same command again, up to UnityRetryService's own attempt cap.
+   *
+   * `logText` is read from the real Unity Editor log rather than only the
+   * wrapper's captured stdout/stderr: dist/platforms/ubuntu/steps/runsteps.sh
+   * (via build.sh/activate.sh) invokes `unity-editor -logfile /dev/stdout`,
+   * and BuildAutomationWorkflow.BuildWorkflow pipes that whole pipeline
+   * through `node <builder> -m remote-cli-log-stream --logFile "$LOG_FILE"`,
+   * which appends every line to $LOG_FILE. For the bare-local provider,
+   * $LOG_FILE is exported as `$(pwd)/temp/job-log.txt` (see
+   * BuildAutomationWorkflow.BuildWorkflow), so that file accumulates the
+   * genuine Editor log content that UnityBuildDiagnosticsService's crash/
+   * license/compile patterns are meant to match against -- not just whatever
+   * subset `command`'s own stdout capture happens to contain.
+   */
+  private static async runWithRetry(command: string): Promise<string> {
+    const bp = Orchestrator.buildParameters;
+    const projectPath = path.isAbsolute(bp.projectPath || '')
+      ? bp.projectPath
+      : path.join(process.cwd(), bp.projectPath || '.');
+    const logFilePath = path.join(process.cwd(), 'temp', 'job-log.txt');
+
+    let lastOutput = '';
+
+    const result = await UnityRetryService.executeWithRetry(
+      projectPath,
+      async () => {
+        const startedAtMs = Date.now();
+        let exitCode = 0;
+
+        // suppressError=true: on a non-zero exit, OrchestratorSystem.Run
+        // resolves with the captured output instead of throwing, so the
+        // retry loop can inspect the result and decide whether to retry --
+        // exactly mirroring how the non-retry path above lets a throw
+        // propagate on the single, non-retried attempt.
+        const stdout = await OrchestratorSystem.Run(command, true, false, undefined, (code) => {
+          exitCode = code;
+        });
+        lastOutput = stdout;
+
+        const runtimeSeconds = (Date.now() - startedAtMs) / 1000;
+        const logText = LocalOrchestrator.readEditorLog(logFilePath) || stdout;
+
+        return { exitCode, logText, runtimeSeconds };
+      },
+      { budgets: UnityRecoveryService.createDefaultBudgets() },
+    );
+
+    if (!result.succeeded) {
+      const category = result.lastDiagnostics?.failureCategory ?? 'UNKNOWN';
+      const hint = result.lastDiagnostics?.failureSummary?.remediationHint ?? '';
+      throw new Error(
+        `Unity build failed after ${result.attempts} attempt(s) via UnityRetryService ` +
+          `[${category}]${hint ? `: ${hint}` : ''}. Actions performed: ` +
+          `${result.actionsPerformed.join(', ') || 'none'}.\n${lastOutput}`,
+      );
+    }
+
+    return lastOutput;
+  }
+
+  private static readEditorLog(logFilePath: string): string {
+    try {
+      return fs.readFileSync(logFilePath, 'utf8');
+    } catch {
+      return '';
+    }
   }
 }
 export default LocalOrchestrator;

--- a/plugins/orchestrator/src/model/orchestrator/services/core/orchestrator-system.ts
+++ b/plugins/orchestrator/src/model/orchestrator/services/core/orchestrator-system.ts
@@ -22,6 +22,13 @@ export class OrchestratorSystem {
     suppressLogs = false,
     // eslint-disable-next-line no-unused-vars
     outputCallback?: (output: string) => void,
+    // Invoked with the real (non-normalized) child process exit code right
+    // before the promise settles -- on both the success and failure paths.
+    // Purely additive: existing callers that don't pass this get identical
+    // behavior (same thrown string, same resolved output) to before this
+    // parameter was added.
+    // eslint-disable-next-line no-unused-vars
+    onExitCode?: (code: number) => void,
   ) {
     for (const element of command.split(`\n`)) {
       if (!suppressLogs) {
@@ -53,6 +60,7 @@ export class OrchestratorSystem {
         if (!suppressLogs) {
           RemoteClientLogger.log(`[${code}]`);
         }
+        onExitCode?.(code ?? -1);
         if (code !== 0 && !suppressError) {
           throwError(output);
         }

--- a/plugins/orchestrator/src/model/orchestrator/services/reliability/unity-recovery-service.test.ts
+++ b/plugins/orchestrator/src/model/orchestrator/services/reliability/unity-recovery-service.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from 'vitest';
+import { UnityRecoveryService, UnityRecoveryBudgets } from './unity-recovery-service';
+import {
+  UnityBuildDiagnosticsService,
+  UnityRunDiagnostics,
+} from './unity-build-diagnostics-service';
+
+function diagnosticsFor(
+  overrides: Partial<Parameters<typeof UnityBuildDiagnosticsService.analyzeRun>[0]>,
+): UnityRunDiagnostics {
+  return UnityBuildDiagnosticsService.analyzeRun({
+    exitCode: 1,
+    runtimeSeconds: 100,
+    logText: '',
+    ...overrides,
+  });
+}
+
+describe('UnityRecoveryService.createDefaultBudgets', () => {
+  it('returns the documented default budget caps with zero usage', () => {
+    const budgets = UnityRecoveryService.createDefaultBudgets();
+
+    expect(budgets).toEqual({
+      licensingRace: { max: 2, used: 0 },
+      lfsPointer: { max: 1, used: 0 },
+      packageCache: { max: 1, used: 0 },
+      apiUpdater: { max: 1, used: 0 },
+      twoPhaseImport: { max: 1, used: 0 },
+      libraryNuke: { max: 1, used: 0 },
+      sourceAssetDbReset: { max: 1, used: 0 },
+    });
+  });
+
+  it('returns a fresh object on every call (no shared mutable state across builds)', () => {
+    const a = UnityRecoveryService.createDefaultBudgets();
+    const b = UnityRecoveryService.createDefaultBudgets();
+
+    a.licensingRace.used = 99;
+
+    expect(b.licensingRace.used).toBe(0);
+  });
+});
+
+describe('UnityRecoveryService.decide', () => {
+  it('recommends a delayed retry-licensing decision without touching Library', () => {
+    const diagnostics = diagnosticsFor({
+      exitCode: -1,
+      runtimeSeconds: 20,
+      logText: 'Access token is unavailable',
+    });
+    const budgets = UnityRecoveryService.createDefaultBudgets();
+
+    const decision = UnityRecoveryService.decide(diagnostics, budgets);
+
+    expect(decision.action).toBe('retry-licensing');
+    expect(decision.shouldRetry).toBe(true);
+    expect(decision.nukeLibrary).toBe(false);
+    expect(decision.preserveLibrary).toBe(true);
+    expect(decision.clearSubfolders).toEqual([]);
+    expect(decision.delaySeconds).toBe(30);
+    expect(budgets.licensingRace.used).toBe(1);
+  });
+
+  it('recommends nuke-library for crash evidence found after import completed', () => {
+    const diagnostics = diagnosticsFor({
+      exitCode: -1073741819,
+      runtimeSeconds: 300,
+      logText: 'InitialRefresh started\nRefresh completed\nSegmentation fault',
+    });
+    const budgets = UnityRecoveryService.createDefaultBudgets();
+
+    const decision = UnityRecoveryService.decide(diagnostics, budgets);
+
+    expect(decision.action).toBe('nuke-library');
+    expect(decision.shouldRetry).toBe(true);
+    expect(decision.nukeLibrary).toBe(true);
+    expect(decision.preserveLibrary).toBe(false);
+    expect(decision.clearSubfolders).toEqual(['Library']);
+    expect(budgets.libraryNuke.used).toBe(1);
+  });
+
+  it('recommends clearing PackageCache for GUID compile errors', () => {
+    const diagnostics = diagnosticsFor({
+      exitCode: 1,
+      logText: 'error CS0246: Library/PackageCache/com.foo/Bar.cs: type not found',
+    });
+    const budgets = UnityRecoveryService.createDefaultBudgets();
+
+    const decision = UnityRecoveryService.decide(diagnostics, budgets);
+
+    expect(decision.action).toBe('retry-package-cache');
+    expect(decision.clearSubfolders).toEqual(['PackageCache']);
+    expect(decision.nukeLibrary).toBe(false);
+  });
+
+  it('recommends retry-lfs-pull when LFS pointer DLLs are present', () => {
+    const diagnostics = diagnosticsFor({ exitCode: 1, logText: '' });
+    diagnostics.lfsPointerDllFound = true;
+    diagnostics.recommendedAction =
+      UnityBuildDiagnosticsService.recommendRecoveryAction(diagnostics);
+
+    const decision = UnityRecoveryService.decide(
+      diagnostics,
+      UnityRecoveryService.createDefaultBudgets(),
+    );
+
+    expect(decision.action).toBe('retry-lfs-pull');
+    expect(decision.delaySeconds).toBe(0);
+  });
+
+  it('returns shouldRetry=false with a success decision on a successful run', () => {
+    const diagnostics = diagnosticsFor({
+      exitCode: 0,
+      logText: 'Executing method BuildCommand.PerformBuild',
+    });
+
+    const decision = UnityRecoveryService.decide(
+      diagnostics,
+      UnityRecoveryService.createDefaultBudgets(),
+    );
+
+    expect(decision.action).toBe('success');
+    expect(decision.shouldRetry).toBe(false);
+    expect(decision.preserveLibrary).toBe(true);
+  });
+
+  it('returns shouldRetry=false with fail when nothing matched (generic failure)', () => {
+    const diagnostics = diagnosticsFor({
+      exitCode: 1,
+      runtimeSeconds: 500,
+      logText: 'some unrecognized failure output',
+    });
+
+    const decision = UnityRecoveryService.decide(
+      diagnostics,
+      UnityRecoveryService.createDefaultBudgets(),
+    );
+
+    expect(decision.action).toBe('fail');
+    expect(decision.shouldRetry).toBe(false);
+  });
+
+  it('stops retrying once a budget is exhausted (circuit breaker)', () => {
+    const diagnostics = diagnosticsFor({
+      exitCode: -1,
+      runtimeSeconds: 20,
+      logText: 'Access token is unavailable',
+    });
+    const budgets: UnityRecoveryBudgets = UnityRecoveryService.createDefaultBudgets();
+    budgets.licensingRace.used = budgets.licensingRace.max;
+
+    const decision = UnityRecoveryService.decide(diagnostics, budgets);
+
+    expect(decision.action).toBe('fail');
+    expect(decision.shouldRetry).toBe(false);
+    expect(decision.reason).toMatch(/budget exhausted/i);
+    // Budget usage must not be incremented past max by the exhausted attempt.
+    expect(budgets.licensingRace.used).toBe(budgets.licensingRace.max);
+  });
+
+  it('increments budget usage across successive decide() calls for the same category', () => {
+    const diagnostics = diagnosticsFor({
+      exitCode: -1,
+      runtimeSeconds: 20,
+      logText: 'Access token is unavailable',
+    });
+    const budgets = UnityRecoveryService.createDefaultBudgets();
+
+    const first = UnityRecoveryService.decide(diagnostics, budgets);
+    expect(first.shouldRetry).toBe(true);
+    expect(budgets.licensingRace.used).toBe(1);
+
+    const second = UnityRecoveryService.decide(diagnostics, budgets);
+    expect(second.shouldRetry).toBe(true);
+    expect(budgets.licensingRace.used).toBe(2);
+
+    // licensingRace max is 2 -- a third attempt must exhaust the budget.
+    const third = UnityRecoveryService.decide(diagnostics, budgets);
+    expect(third.shouldRetry).toBe(false);
+    expect(third.action).toBe('fail');
+  });
+
+  it('always echoes the (possibly-mutated) budgets object back on the decision', () => {
+    const diagnostics = diagnosticsFor({ exitCode: 0, logText: 'executeMethod invoked' });
+    const budgets = UnityRecoveryService.createDefaultBudgets();
+
+    const decision = UnityRecoveryService.decide(diagnostics, budgets);
+
+    expect(decision.budgets).toBe(budgets);
+  });
+
+  it('defaults to a fresh budget set when none is supplied', () => {
+    const diagnostics = diagnosticsFor({
+      exitCode: -1,
+      runtimeSeconds: 20,
+      logText: 'Access token is unavailable',
+    });
+
+    const decision = UnityRecoveryService.decide(diagnostics);
+
+    expect(decision.shouldRetry).toBe(true);
+    expect(decision.budgets.licensingRace.used).toBe(1);
+  });
+});

--- a/plugins/orchestrator/src/model/orchestrator/services/reliability/unity-retry-service.test.ts
+++ b/plugins/orchestrator/src/model/orchestrator/services/reliability/unity-retry-service.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, beforeEach, vi, type Mocked } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { UnityRetryService } from './unity-retry-service';
+import { UnityRecoveryService } from './unity-recovery-service';
+
+vi.mock('node:fs');
+
+const mockFs = fs as Mocked<typeof fs>;
+
+const PROJECT_PATH = '/project';
+
+describe('UnityRetryService.executeWithRetry', () => {
+  let removedPaths: Set<string>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    removedPaths = new Set<string>();
+
+    // A path "exists" until it has been removed/renamed away from -- lets
+    // BuildReliabilityService.removeDirectoryWithRetry succeed on its first
+    // attempt instead of looping through its real (blocking) retry/delay.
+    // ArtifactDB defaults to absent, i.e. import has not completed yet --
+    // individual tests override this via matching log text when needed.
+    mockFs.existsSync.mockImplementation((p: any) => {
+      const target = String(p);
+      if (target.endsWith('ArtifactDB')) return false;
+
+      return !removedPaths.has(target);
+    });
+    mockFs.rmSync.mockImplementation((p: any) => {
+      removedPaths.add(String(p));
+    });
+    mockFs.renameSync.mockImplementation((oldPath: any) => {
+      removedPaths.add(String(oldPath));
+    });
+    // No LFS pointer DLLs by default -- UnityBuildDiagnosticsService.analyzeRun
+    // scans Assets/Packages via readdirSync on every call.
+    mockFs.readdirSync.mockReturnValue([] as any);
+  });
+
+  it('returns succeeded=true after a single successful attempt, with no recovery actions', async () => {
+    const runUnity = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      logText: 'Executing method BuildCommand.PerformBuild\nBuild succeeded',
+      runtimeSeconds: 42,
+    });
+
+    const result = await UnityRetryService.executeWithRetry(PROJECT_PATH, runUnity);
+
+    expect(result.succeeded).toBe(true);
+    expect(result.attempts).toBe(1);
+    expect(result.actionsPerformed).toEqual([]);
+    expect(result.lastDiagnostics.failureCategory).toBe('SUCCESS');
+    expect(runUnity).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a licensing race after the recommended delay and succeeds on the second attempt', async () => {
+    vi.useFakeTimers();
+
+    const runUnity = vi
+      .fn()
+      .mockResolvedValueOnce({
+        exitCode: -1,
+        logText: 'Access token is unavailable',
+        runtimeSeconds: 15,
+      })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        logText: 'Executing method BuildCommand.PerformBuild\nBuild succeeded',
+        runtimeSeconds: 60,
+      });
+
+    const resultPromise = UnityRetryService.executeWithRetry(PROJECT_PATH, runUnity);
+
+    // First attempt runs synchronously up to the licensing delay (30s).
+    await vi.advanceTimersByTimeAsync(30_000);
+    const result = await resultPromise;
+
+    expect(result.succeeded).toBe(true);
+    expect(result.attempts).toBe(2);
+    expect(result.actionsPerformed).toEqual(['retry-licensing']);
+    expect(runUnity).toHaveBeenCalledTimes(2);
+    // Licensing recovery must not touch the Library folder.
+    expect(mockFs.renameSync).not.toHaveBeenCalled();
+    expect(mockFs.rmSync).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it('nukes the Library folder (with backup) on dense crash evidence after import completed', async () => {
+    const denseCrashLog = [
+      'InitialRefresh started',
+      'Refresh completed',
+      'Segmentation fault',
+      'SIGSEGV',
+      'Crash!!!',
+    ].join('\n');
+
+    const runUnity = vi
+      .fn()
+      .mockResolvedValueOnce({ exitCode: -1073741819, logText: denseCrashLog, runtimeSeconds: 200 })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        logText: 'Executing method BuildCommand.PerformBuild\nBuild succeeded',
+        runtimeSeconds: 90,
+      });
+
+    const result = await UnityRetryService.executeWithRetry(PROJECT_PATH, runUnity);
+
+    expect(result.succeeded).toBe(true);
+    expect(result.attempts).toBe(2);
+    expect(result.actionsPerformed).toEqual(['nuke-library']);
+    // Library must be backed up (renamed) before being removed.
+    expect(mockFs.renameSync).toHaveBeenCalledWith(
+      path.join(PROJECT_PATH, 'Library'),
+      expect.stringContaining('Library.backup-'),
+    );
+  });
+
+  it('clears only ScriptAssemblies (no Library backup/nuke) for light crash evidence before import completes', async () => {
+    // No "Refresh completed" marker and no ArtifactDB (mocked absent by
+    // default) -- import has not completed, so recommendRecoveryAction picks
+    // 'retry-two-phase-import' rather than 'nuke-library'. That decision's
+    // own nukeLibrary flag is false, so performRecovery falls through to the
+    // CRASH-category branch, which only escalates to a full Library nuke
+    // when 3+ crash patterns matched -- here there is only one ("Crash!!!").
+    const lightCrashLog = ['some early build log line', 'Crash!!!'].join('\n');
+
+    const runUnity = vi
+      .fn()
+      .mockResolvedValueOnce({ exitCode: -1073741819, logText: lightCrashLog, runtimeSeconds: 200 })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        logText: 'Executing method BuildCommand.PerformBuild\nBuild succeeded',
+        runtimeSeconds: 90,
+      });
+
+    const result = await UnityRetryService.executeWithRetry(PROJECT_PATH, runUnity);
+
+    expect(result.succeeded).toBe(true);
+    expect(result.actionsPerformed).toEqual(['retry-two-phase-import']);
+    expect(mockFs.renameSync).not.toHaveBeenCalled();
+    expect(mockFs.rmSync).toHaveBeenCalledWith(
+      path.join(PROJECT_PATH, 'Library', 'ScriptAssemblies'),
+      expect.objectContaining({ recursive: true, force: true }),
+    );
+  });
+
+  it('clears PackageCache (and ScriptAssemblies for GUID errors) on package corruption', async () => {
+    const runUnity = vi
+      .fn()
+      .mockResolvedValueOnce({
+        exitCode: 1,
+        logText: 'error CS0246: Library/PackageCache/com.foo/Bar.cs: type not found',
+        runtimeSeconds: 50,
+      })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        logText: 'Executing method BuildCommand.PerformBuild\nBuild succeeded',
+        runtimeSeconds: 55,
+      });
+
+    const result = await UnityRetryService.executeWithRetry(PROJECT_PATH, runUnity);
+
+    expect(result.succeeded).toBe(true);
+    expect(result.actionsPerformed).toEqual(['retry-package-cache']);
+    expect(mockFs.rmSync).toHaveBeenCalledWith(
+      path.join(PROJECT_PATH, 'Library', 'PackageCache'),
+      expect.objectContaining({ recursive: true, force: true }),
+    );
+    expect(mockFs.rmSync).toHaveBeenCalledWith(
+      path.join(PROJECT_PATH, 'Library', 'ScriptAssemblies'),
+      expect.objectContaining({ recursive: true, force: true }),
+    );
+  });
+
+  it('gives up once the recovery budget is exhausted and reports the failure diagnostics', async () => {
+    vi.useFakeTimers();
+
+    // licensingRace budget max is 2 -- a third consecutive licensing failure
+    // must stop retrying instead of looping forever.
+    const runUnity = vi.fn().mockResolvedValue({
+      exitCode: -1,
+      logText: 'Access token is unavailable',
+      runtimeSeconds: 15,
+    });
+
+    const resultPromise = UnityRetryService.executeWithRetry(PROJECT_PATH, runUnity);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(30_000);
+    const result = await resultPromise;
+
+    expect(result.succeeded).toBe(false);
+    expect(result.attempts).toBe(3);
+    expect(result.actionsPerformed).toEqual(['retry-licensing', 'retry-licensing']);
+    expect(result.lastDiagnostics.failureCategory).toBe('LICENSE');
+    expect(runUnity).toHaveBeenCalledTimes(3);
+
+    vi.useRealTimers();
+  });
+
+  it('never exceeds the internal MAX_TOTAL_RETRIES cap even if a larger maxRetries is requested', async () => {
+    const runUnity = vi.fn().mockResolvedValue({
+      exitCode: 1,
+      logText: 'some unrecognized failure output',
+      runtimeSeconds: 10,
+    });
+
+    const result = await UnityRetryService.executeWithRetry(PROJECT_PATH, runUnity, {
+      maxRetries: 999,
+    });
+
+    // GENERIC failures have no matching recovery action, so this should
+    // stop after the very first attempt regardless of the retry cap.
+    expect(result.succeeded).toBe(false);
+    expect(result.attempts).toBe(1);
+    expect(result.actionsPerformed).toEqual([]);
+  });
+
+  it('caps total attempts at 6 (1 initial + 5 retries) when every attempt is independently retryable', async () => {
+    // Alternate between two distinct LFS-pointer-DLL-triggering failures so
+    // each attempt consumes a *different* budget bucket, isolating the
+    // MAX_TOTAL_RETRIES cap from any single budget's own max.
+    mockFs.readdirSync.mockImplementation((dir: any) => {
+      if (String(dir).endsWith('Assets')) {
+        return [{ name: 'Pointer.dll', isDirectory: () => false, isFile: () => true }] as any;
+      }
+
+      return [] as any;
+    });
+    mockFs.statSync.mockReturnValue({ size: 50 } as any);
+    mockFs.readFileSync.mockReturnValue('version https://git-lfs.github.com/spec/v1\n' as any);
+
+    const runUnity = vi.fn().mockResolvedValue({
+      exitCode: 1,
+      logText: 'irrelevant, lfsPointerDllFound drives the decision',
+      runtimeSeconds: 5,
+    });
+
+    const result = await UnityRetryService.executeWithRetry(PROJECT_PATH, runUnity, {
+      maxRetries: 20,
+    });
+
+    expect(result.succeeded).toBe(false);
+    // lfsPointer budget max is 1, so only the first retry is granted; the
+    // second attempt's decide() call exhausts the budget and stops.
+    expect(result.attempts).toBe(2);
+    expect(runUnity).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes explicit budgets through to UnityRecoveryService.decide', async () => {
+    const budgets = UnityRecoveryService.createDefaultBudgets();
+    budgets.licensingRace.max = 0;
+
+    const runUnity = vi.fn().mockResolvedValue({
+      exitCode: -1,
+      logText: 'Access token is unavailable',
+      runtimeSeconds: 15,
+    });
+
+    const result = await UnityRetryService.executeWithRetry(PROJECT_PATH, runUnity, { budgets });
+
+    expect(result.succeeded).toBe(false);
+    expect(result.attempts).toBe(1);
+    expect(runUnity).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

`UnityBuildDiagnosticsService` (failure classifier), `UnityRecoveryService` (budget-gated recovery decision), and `UnityRetryService` (the full retry-loop driver — including real Library backup/nuke recovery actions) were all fully built with **zero live callers anywhere in the pipeline**. No lifecycle point existed between a Unity build's exit code and orchestrator's success/failure decision — every non-zero exit was treated identically, whether it was a known-transient condition (licensing race, stale `ScriptAssemblies`) or a genuine failure.

## What changed

- **`OrchestratorSystem.Run`** gets one purely-additive optional trailing parameter: `onExitCode?: (code: number) => void`, invoked with the real exit code right before the promise settles either way. `OrchestratorSystem.Run` has 212 non-test call sites across 28 files — confirmed via grep that none of them pass a 5th positional argument today, so this is genuinely zero-risk: every existing caller gets identical behavior (same thrown string on failure, same resolved output on success).
- **`LocalOrchestrator.runTaskInWorkflow`** wraps the invocation in a retry loop **entirely encapsulated inside the provider**, gated on `--enableBuildRetry` (default `false` — automatic Library-nuking recovery is a meaningful behavior change that shouldn't silently activate for existing users). The `ProviderInterface` contract and `standardBuildAutomation`'s call site are completely untouched — zero ripple into `aws`/`k8s`/`gcp-cloud-run`/`azure-aci`/`github-actions`/`gitlab-ci`/`remote-powershell`/`ansible`/`cli` providers.
- `logText` fed to the classifier reads the **real Unity Editor log content** (`$LOG_FILE`, exported by `BuildAutomationWorkflow.BuildWorkflow` for the bare-local path, populated by `remote-cli-log-stream` from `unity-editor -logfile`'s own output) rather than just the wrapper's stdout capture — `UnityBuildDiagnosticsService`'s crash/license/compile patterns need genuine Editor log content to classify correctly.
- Uses `UnityRecoveryService.createDefaultBudgets()` unchanged — no new budget-configuration CLI surface added, kept deliberately tight in scope.
- Scoped to `build` only (not `test`), `local`/`local-system` provider only.
- Adds the test coverage that didn't exist before this: `unity-recovery-service.test.ts` and `unity-retry-service.test.ts` (neither file existed).

## Verification

- `tsc --noEmit` (orchestrator): clean
- `bunx oxfmt --check` on all 8 touched/added files: clean
- `bun run test:ci` (orchestrator, vitest): 992-993 passed (small variance from parallel-run noise), 2 pre-existing failures confirmed unrelated (`orchestrator-rclone-steps.test.ts` needs a prior build's `dist/`, absent in a fresh worktree; `cli-integration.test.ts` subprocess-timeout flake, passes 9/9 standalone)
- `bun test ./src` (root cli): 180 pass / 3 skip / 0 fail
- `bun run build`: succeeds for both packages
- **Live sanity check**: full CLI path hits the same documented pre-existing `remote-cli-log-stream` bug noted in earlier PRs on this branch (no built `dist/` in a fresh worktree), so verified directly: drove `LocalOrchestrator.runTaskInWorkflow` with `enableBuildRetry=true` and `OrchestratorSystem.Run` monkey-patched to fail twice (licensing race) then succeed — confirmed `UnityRetryService` classified `LICENSE`, applied the 30s `retry-licensing` delay twice, and succeeded on attempt 3 with exactly 3 calls to `OrchestratorSystem.Run`. The classify→decide→retry loop is genuinely exercised end-to-end.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `bunx oxfmt --check` clean
- [x] `bun run test:ci` passes (pre-existing failures aside)
- [x] `bun run build` succeeds for both packages
- [x] Off-by-default confirmed as zero behavior change
- [x] Live retry loop exercised end-to-end (licensing-race retry-then-succeed)
- [ ] Follow-up: same wiring for the `test`/`RUN_TESTS` path, if wanted
- [ ] Follow-up: decide whether to also thread this through `plugin-lifecycle.ts`'s cross-repo `afterLocalBuild` surface (explicitly out of scope here)