### PR TITLE
feat: engine-generic launch wrapper for precise process-level hooks

### DIFF
--- a/dist/platforms/ubuntu/steps/activate.sh
+++ b/dist/platforms/ubuntu/steps/activate.sh
@@ -28,7 +28,7 @@ if [[ -n "$UNITY_LICENSE" ]] || [[ -n "$UNITY_LICENSE_FILE" ]]; then
   fi
 
   # Activate license
-  ACTIVATION_OUTPUT=$(unity-editor \
+  ACTIVATION_OUTPUT=$(${ENGINE_LAUNCH_WRAPPER:-} unity-editor \
       -logFile /dev/stdout \
       -quit \
       -manualLicenseFile $FILE_PATH)
@@ -64,7 +64,7 @@ elif [[ -n "$UNITY_SERIAL" && -n "$UNITY_EMAIL" && -n "$UNITY_PASSWORD" ]]; then
   echo "Requesting activation (professional license)"
 
   # Activate license
-  unity-editor \
+  ${ENGINE_LAUNCH_WRAPPER:-} unity-editor \
     -logFile /dev/stdout \
     -quit \
     -serial "$UNITY_SERIAL" \

--- a/dist/platforms/ubuntu/steps/build.sh
+++ b/dist/platforms/ubuntu/steps/build.sh
@@ -132,7 +132,7 @@ if [ -n "$BUILD_PROFILE" ]; then
   BUILD_PROFILE_FLAGS="-activeBuildProfile $BUILD_PROFILE"
 fi
 
-unity-editor \
+${ENGINE_LAUNCH_WRAPPER:-} unity-editor \
   -logfile /dev/stdout \
   $QUIT_FLAG \
   -customBuildName "$BUILD_NAME" \

--- a/dist/platforms/ubuntu/steps/test.sh
+++ b/dist/platforms/ubuntu/steps/test.sh
@@ -89,7 +89,7 @@ if [ "$PACKAGE_MODE" = "true" ]; then
 
   TEMP_PROJECT_PATH="./TempProject"
 
-  unity-editor \
+  ${ENGINE_LAUNCH_WRAPPER:-} unity-editor \
     -batchmode \
     -createProject "$TEMP_PROJECT_PATH" \
     -quit
@@ -225,7 +225,7 @@ for platform in ${TEST_PLATFORMS//;/ }; do
   # let CUSTOM_PARAMETERS (user-controlled, via the action's own input)
   # inject arbitrary shell syntax - array expansion gets the same splitting
   # without that risk.
-  unity-editor \
+  ${ENGINE_LAUNCH_WRAPPER:-} unity-editor \
     -batchmode \
     -logFile "$FULL_ARTIFACTS_PATH/$platform.log" \
     -projectPath "$UNITY_PROJECT_PATH" \

--- a/dist/platforms/windows/steps/activate.ps1
+++ b/dist/platforms/windows/steps/activate.ps1
@@ -36,7 +36,7 @@ try {
       ((Get-Content -Raw $Env:UNITY_LICENSE_FILE) -replace "`r", '') | Set-Content -Path $FilePath -NoNewline
     }
 
-    & $UnityExePath -logFile $LogPath -quit -manualLicenseFile $FilePath | Out-Host
+    Invoke-UnityLaunch -ExePath $UnityExePath -logFile $LogPath -quit -manualLicenseFile $FilePath | Out-Host
     $global:UNITY_EXIT_CODE = $LASTEXITCODE
 
     # The exit code for personal activation is always 1; determine whether
@@ -56,7 +56,7 @@ try {
     Write-Host 'Requesting activation (professional license)'
 
     $LogPath = Join-Path $Env:ACTIVATE_LICENSE_PATH 'activate.log'
-    & $UnityExePath -logFile $LogPath -quit -serial $Env:UNITY_SERIAL -username $Env:UNITY_EMAIL -password $Env:UNITY_PASSWORD | Out-Host
+    Invoke-UnityLaunch -ExePath $UnityExePath -logFile $LogPath -quit -serial $Env:UNITY_SERIAL -username $Env:UNITY_EMAIL -password $Env:UNITY_PASSWORD | Out-Host
     $global:UNITY_EXIT_CODE = $LASTEXITCODE
     if (Test-Path $LogPath) { Get-Content $LogPath | Out-Host }
   } elseif ($Env:UNITY_LICENSING_SERVER) {

--- a/dist/platforms/windows/steps/build.ps1
+++ b/dist/platforms/windows/steps/build.ps1
@@ -118,7 +118,7 @@ try {
   $UnityExePath = Get-UnityEditorExePath
   $LogPath = Join-Path $BuildPathFull 'build.log'
 
-  & $UnityExePath @QuitArgs -batchmode -nographics `
+  Invoke-UnityLaunch -ExePath $UnityExePath @QuitArgs -batchmode -nographics `
     -logFile $LogPath `
     -customBuildName $Env:BUILD_NAME `
     -projectPath $Env:UNITY_PROJECT_PATH `

--- a/dist/platforms/windows/steps/resolve_unity_path.ps1
+++ b/dist/platforms/windows/steps/resolve_unity_path.ps1
@@ -45,6 +45,40 @@ function Get-UnityEditorExePath {
   return $exePath
 }
 
+# Invokes the Unity Editor executable, transparently prefixing the
+# invocation with $Env:ENGINE_LAUNCH_WRAPPER when it is set (e.g. a
+# self-hosted runner's own launch-serialization lock). When unset, this is
+# byte-identical to calling `& $ExePath @Arguments` directly - no wrapper
+# process is introduced. $Arguments is passed through unmodified via
+# splatting so each call site's exact existing argument list (flags, quit
+# args, custom-parameter arrays, etc.) is preserved unchanged.
+#
+# ENGINE_LAUNCH_WRAPPER may itself be a multi-word command (e.g.
+# "flock /tmp/unity.lock --"), matching the Linux side's unquoted
+# $ENGINE_LAUNCH_WRAPPER, which bash word-splits. PowerShell's `&` call
+# operator does not split a single string argument the same way - passing
+# the whole value as one token would make it look for a single (nonexistent)
+# executable literally named "flock /tmp/unity.lock --" - so it's split into
+# tokens here first, the same way this script set already splits
+# CUSTOM_PARAMETERS elsewhere (build.ps1/test.ps1).
+function Invoke-UnityLaunch {
+  param(
+    [Parameter(Mandatory)]
+    [string]$ExePath,
+    [Parameter(ValueFromRemainingArguments)]
+    [string[]]$Arguments
+  )
+
+  if ($Env:ENGINE_LAUNCH_WRAPPER) {
+    $WrapperParts = @($Env:ENGINE_LAUNCH_WRAPPER -split '\s+' | Where-Object { $_ -ne '' })
+    $WrapperExe = $WrapperParts[0]
+    $WrapperArgs = if ($WrapperParts.Length -gt 1) { $WrapperParts[1..($WrapperParts.Length - 1)] } else { @() }
+    & $WrapperExe @WrapperArgs $ExePath @Arguments
+  } else {
+    & $ExePath @Arguments
+  }
+}
+
 function Get-UnityLicensingClientExePath {
   $root = Get-UnityEditorRoot
   $exePath = Join-Path $root 'Editor\Data\Resources\Licensing\Client\Unity.Licensing.Client.exe'

--- a/dist/platforms/windows/steps/return_license.ps1
+++ b/dist/platforms/windows/steps/return_license.ps1
@@ -25,7 +25,7 @@ try {
     #
     $UnityExePath = Get-UnityEditorExePath
     $LogPath = Join-Path $Env:ACTIVATE_LICENSE_PATH 'return_license.log'
-    & $UnityExePath -logFile $LogPath -quit -returnlicense -projectPath $Env:ACTIVATE_LICENSE_PATH | Out-Host
+    Invoke-UnityLaunch -ExePath $UnityExePath -logFile $LogPath -quit -returnlicense -projectPath $Env:ACTIVATE_LICENSE_PATH | Out-Host
     if (Test-Path $LogPath) { Get-Content $LogPath | Out-Host }
   }
 } catch {

--- a/dist/platforms/windows/steps/test.ps1
+++ b/dist/platforms/windows/steps/test.ps1
@@ -67,7 +67,7 @@ if ($Env:PACKAGE_MODE -eq 'true') {
   Write-Host "Creating an empty Unity project to add the package $($Env:PACKAGE_NAME) to."
   $TempProjectPath = Join-Path (Get-Location) 'TempProject'
 
-  & $UnityExePath -batchmode -createProject $TempProjectPath -quit | Out-Host
+  Invoke-UnityLaunch -ExePath $UnityExePath -batchmode -createProject $TempProjectPath -quit | Out-Host
 
   Write-Host 'Adding package to the temporary project''s dependencies and testables...'
   Write-Host ''
@@ -191,7 +191,7 @@ foreach ($Platform in $Platforms) {
 
   $LogPath = Join-Path $FullArtifactsPath "$Platform.log"
 
-  & $UnityExePath -batchmode -logFile $LogPath -projectPath $Env:UNITY_PROJECT_PATH @RunTestsArgs @CoverageFlags @CustomParametersArray | Out-Host
+  Invoke-UnityLaunch -ExePath $UnityExePath -batchmode -logFile $LogPath -projectPath $Env:UNITY_PROJECT_PATH @RunTestsArgs @CoverageFlags @CustomParametersArray | Out-Host
   $TestExitCode = $LASTEXITCODE
 
   if (Test-Path $LogPath) { Get-Content $LogPath | Out-Host }

--- a/plugins/orchestrator/src/cli-plugin/build-parameters-adapter.ts
+++ b/plugins/orchestrator/src/cli-plugin/build-parameters-adapter.ts
@@ -63,6 +63,10 @@ export function createBuildParametersFromCliOptions(options: Record<string, any>
   // self-hosted runners with an already-licensed, long-lived Unity Hub
   // session, distinct from `game-ci activate`'s per-run activation.
   bp.skipActivation = options.skipActivation === true || options.skipActivation === 'true';
+  // Command to prefix the engine's process invocation with, for the local/local-system
+  // provider's generated build script (sets ENGINE_LAUNCH_WRAPPER for runsteps.sh) --
+  // e.g. a self-hosted runner's own launch-serialization lock. Empty by default.
+  bp.engineLaunchWrapper = options.engineLaunchWrapper || process.env.ENGINE_LAUNCH_WRAPPER || '';
   bp.skipInContainerClone =
     options.skipInContainerClone === true || options.skipInContainerClone === 'true';
   bp.repoPathOverride = options.repoPathOverride || '';

--- a/plugins/orchestrator/src/cli-plugin/cli-plugin.test.ts
+++ b/plugins/orchestrator/src/cli-plugin/cli-plugin.test.ts
@@ -72,6 +72,8 @@ describe('CLI Plugin Adapter', () => {
       expect(registered).toHaveProperty('ansibleInventory');
       expect(registered).toHaveProperty('skipActivation');
       expect(registered.skipActivation.default).toBe(false);
+      expect(registered).toHaveProperty('engineLaunchWrapper');
+      expect(registered.engineLaunchWrapper.default).toBe('');
       expect(registered).toHaveProperty('middlewarePipeline');
       expect(registered).toHaveProperty('middlewareFiles');
     });
@@ -178,6 +180,18 @@ describe('CLI Plugin Adapter', () => {
 
       const stringFalse = createBuildParametersFromCliOptions({ skipActivation: 'false' });
       expect(stringFalse.skipActivation).toBe(false);
+    });
+
+    it('maps engineLaunchWrapper from CLI options to BuildParameters', () => {
+      const bp = createBuildParametersFromCliOptions({
+        engineLaunchWrapper: 'flock /tmp/engine.lock --',
+      });
+      expect(bp.engineLaunchWrapper).toBe('flock /tmp/engine.lock --');
+    });
+
+    it('defaults engineLaunchWrapper to empty string when unset', () => {
+      const bp = createBuildParametersFromCliOptions({});
+      expect(bp.engineLaunchWrapper).toBe('');
     });
 
     it('maps middlewarePipeline from CLI options to BuildParameters', () => {

--- a/plugins/orchestrator/src/cli-plugin/orchestrator-options-plugin.ts
+++ b/plugins/orchestrator/src/cli-plugin/orchestrator-options-plugin.ts
@@ -346,6 +346,15 @@ export function configureOrchestratorOptions(yargs: any): void {
     default: false,
   });
 
+  yargs.option('engineLaunchWrapper', {
+    description:
+      "Command to prefix the engine's process invocation with (e.g. a self-hosted runner's own " +
+      'launch-serialization lock). Applied precisely around the engine launch itself, not the ' +
+      'surrounding build step. Only meaningful for providerStrategy=local(-system). Empty by default.',
+    type: 'string',
+    default: '',
+  });
+
   yargs.option('skipInContainerClone', {
     description:
       'Skip the in-container git clone and reuse a pre-hydrated workspace bind-mounted by the caller. ' +

--- a/plugins/orchestrator/src/model/build-parameters.ts
+++ b/plugins/orchestrator/src/model/build-parameters.ts
@@ -72,6 +72,10 @@ class BuildParameters {
   // provider's self-hosted-runner use case, where Unity is already licensed via
   // a long-lived Unity Hub session and per-run activation/return is unwanted.
   skipActivation!: boolean;
+  // Command to prefix the engine's process invocation with (ENGINE_LAUNCH_WRAPPER
+  // env var consumed by dist/platforms/*/steps/*.sh|ps1 and, for the local/local-system
+  // provider, threaded into the generated script below). Empty by default: no wrapper.
+  engineLaunchWrapper!: string;
   skipInContainerClone!: boolean;
   repoPathOverride!: string;
   lockedWorkspace!: string;
@@ -253,6 +257,11 @@ class BuildParameters {
     p.skipLfs = false;
     p.skipCache = false;
     p.skipActivation = Cli.options?.skipActivation ?? Input.getInput('skipActivation') === 'true';
+    p.engineLaunchWrapper =
+      Cli.options?.engineLaunchWrapper ??
+      Input.getInput('engineLaunchWrapper') ??
+      process.env.ENGINE_LAUNCH_WRAPPER ??
+      '';
     p.skipInContainerClone =
       Cli.options?.skipInContainerClone ?? Input.getInput('skipInContainerClone') === 'true';
     p.repoPathOverride = Cli.options?.repoPathOverride ?? Input.getInput('repoPathOverride') ?? '';

--- a/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.test.ts
+++ b/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.test.ts
@@ -98,6 +98,28 @@ describe('BuildAutomationWorkflow.BuildWorkflow (local/local-system branch)', ()
     expect(script).toContain('export SKIP_ACTIVATION=""');
   });
 
+  it('threads engineLaunchWrapper from BuildParameters into ENGINE_LAUNCH_WRAPPER in the generated script', () => {
+    Orchestrator.buildParameters = makeBuildParameters({
+      providerStrategy: 'local',
+      engineLaunchWrapper: 'flock /tmp/engine.lock --',
+    });
+
+    const script = getBuildWorkflow();
+
+    expect(script).toContain('export ENGINE_LAUNCH_WRAPPER="flock /tmp/engine.lock --"');
+  });
+
+  it('leaves ENGINE_LAUNCH_WRAPPER unset (empty) when engineLaunchWrapper is not set', () => {
+    Orchestrator.buildParameters = makeBuildParameters({
+      providerStrategy: 'local',
+      engineLaunchWrapper: '',
+    });
+
+    const script = getBuildWorkflow();
+
+    expect(script).toContain('export ENGINE_LAUNCH_WRAPPER=""');
+  });
+
   it('maps core BuildParameters fields to the env vars build.sh/activate.sh read', () => {
     Orchestrator.buildParameters = makeBuildParameters({
       providerStrategy: 'local',

--- a/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.ts
+++ b/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.ts
@@ -495,6 +495,7 @@ echo "CACHE_KEY=$CACHE_KEY"`;
     export MANUAL_EXIT="${bp.manualExit ? 'true' : ''}"
     export BUILD_PROFILE="${bp.buildProfile || ''}"
     export SKIP_ACTIVATION="${bp.skipActivation ? 'true' : ''}"
+    export ENGINE_LAUNCH_WRAPPER="${bp.engineLaunchWrapper || ''}"
     # entrypoint.sh normally creates this before sourcing runsteps.sh; replicated
     # here since we bypass entrypoint.sh entirely (see HostRunner.buildEnv).
     export ACTIVATE_LICENSE_PATH="$GITHUB_WORKSPACE/_activate-license~"

--- a/src/command-options/unity-options.ts
+++ b/src/command-options/unity-options.ts
@@ -63,7 +63,17 @@ export class UnityOptions implements IOptions {
           type: 'string',
           demandOption: false,
           default: '',
-        }
+        },
+        engineLaunchWrapper: {
+          description: String.dedent`
+            Command to prefix the engine's process invocation with (e.g. a
+            self-hosted runner's own launch-serialization lock). Applied
+            precisely around the engine launch itself, not the surrounding
+            build step. Empty by default, meaning no wrapper is used.`,
+          type: 'string',
+          demandOption: false,
+          default: process.env.ENGINE_LAUNCH_WRAPPER || '',
+        },
       })
       .coerce('unityLicense', async (arg: string) => {
         if (UnityLicense.isNonActivatedLicenseFile(arg)) {

--- a/src/command-options/unity-options.ts
+++ b/src/command-options/unity-options.ts
@@ -64,16 +64,6 @@ export class UnityOptions implements IOptions {
           demandOption: false,
           default: '',
         },
-        engineLaunchWrapper: {
-          description: String.dedent`
-            Command to prefix the engine's process invocation with (e.g. a
-            self-hosted runner's own launch-serialization lock). Applied
-            precisely around the engine launch itself, not the surrounding
-            build step. Empty by default, meaning no wrapper is used.`,
-          type: 'string',
-          demandOption: false,
-          default: process.env.ENGINE_LAUNCH_WRAPPER || '',
-        },
       })
       .coerce('unityLicense', async (arg: string) => {
         if (UnityLicense.isNonActivatedLicenseFile(arg)) {

--- a/src/logic/unity/environment.test.ts
+++ b/src/logic/unity/environment.test.ts
@@ -31,4 +31,22 @@ describe('UnityEnvironment', () => {
       expect(byName.GIT_CONFIG_EXTENSIONS).toBe('http.sslVerify=false');
     });
   });
+
+  describe('engineLaunchWrapper (ENGINE_LAUNCH_WRAPPER)', () => {
+    it('omits ENGINE_LAUNCH_WRAPPER when unset, byte-identical to before this option existed', () => {
+      const vars = UnityEnvironment.getVariables({} as any);
+      const byName = Object.fromEntries(vars.map((v) => [v.name, v.value]));
+
+      expect(byName.ENGINE_LAUNCH_WRAPPER).toBeUndefined();
+    });
+
+    it('passes engineLaunchWrapper through as ENGINE_LAUNCH_WRAPPER when set', () => {
+      const vars = UnityEnvironment.getVariables({
+        engineLaunchWrapper: 'flock /tmp/unity.lock --',
+      } as any);
+      const byName = Object.fromEntries(vars.map((v) => [v.name, v.value]));
+
+      expect(byName.ENGINE_LAUNCH_WRAPPER).toBe('flock /tmp/unity.lock --');
+    });
+  });
 });

--- a/src/logic/unity/environment.ts
+++ b/src/logic/unity/environment.ts
@@ -16,6 +16,7 @@ const UnityEnvironment = {
       { name: 'UNITY_PASSWORD', value: options.unityPassword },
       { name: 'UNITY_SERIAL', value: options.unitySerial },
       { name: 'UNITY_LICENSING_SERVER', value: options.unityLicensingServer },
+      { name: 'ENGINE_LAUNCH_WRAPPER', value: options.engineLaunchWrapper },
       { name: 'UNITY_VERSION', value: options.engineVersion },
       { name: 'USYM_UPLOAD_AUTH_TOKEN', value: options.uploadAuthToken },
       { name: 'ANDROID_VERSION_CODE', value: options.androidVersionCode },

--- a/src/logic/unity/environment.ts
+++ b/src/logic/unity/environment.ts
@@ -16,7 +16,13 @@ const UnityEnvironment = {
       { name: 'UNITY_PASSWORD', value: options.unityPassword },
       { name: 'UNITY_SERIAL', value: options.unitySerial },
       { name: 'UNITY_LICENSING_SERVER', value: options.unityLicensingServer },
-      { name: 'ENGINE_LAUNCH_WRAPPER', value: options.engineLaunchWrapper },
+      // Not a documented core CLI option (core build/test/activate stay
+      // lean) - this is Orchestrator's advanced-ops surface
+      // (--engineLaunchWrapper on `orchestrate`). Reading the raw env var
+      // directly here still lets it reach Docker.run's non-Unity branch for
+      // Godot/Unreal, since Orchestrator has no equivalent script chain for
+      // those engines to own this instead.
+      { name: 'ENGINE_LAUNCH_WRAPPER', value: options.engineLaunchWrapper || process.env.ENGINE_LAUNCH_WRAPPER },
       { name: 'UNITY_VERSION', value: options.engineVersion },
       { name: 'USYM_UPLOAD_AUTH_TOKEN', value: options.uploadAuthToken },
       { name: 'ANDROID_VERSION_CODE', value: options.androidVersionCode },

--- a/src/model/docker.test.ts
+++ b/src/model/docker.test.ts
@@ -123,6 +123,78 @@ describe('Docker', () => {
     expect(command).not.toContain('should-not-be-used');
   });
 
+  it('leaves the Godot commands string byte-identical when engineLaunchWrapper is unset', () => {
+    const command = (Docker as any).getLinuxCommand('game-ci/godot:latest', {
+      hostOS: 'linux',
+      currentWorkDir: '/home/runner/work/cli/cli',
+      homeDir: '/home/runner',
+      cliDistPath: '/home/runner/work/cli/cli/dist',
+      runnerTempPath: '/home/runner/work/_temp',
+      sshAgent: '',
+      gitPrivateToken: '',
+      dockerWorkspacePath: '/github/workspace',
+      engine: 'godot',
+      projectPath: 'test-project',
+      commands: 'godot --headless --export-release "Linux" build/output',
+    });
+
+    expect(command).toContain('game-ci/godot:latest godot --headless --export-release "Linux" build/output');
+  });
+
+  it('prefixes the Godot commands string with engineLaunchWrapper when set (Linux)', () => {
+    const command = (Docker as any).getLinuxCommand('game-ci/godot:latest', {
+      hostOS: 'linux',
+      currentWorkDir: '/home/runner/work/cli/cli',
+      homeDir: '/home/runner',
+      cliDistPath: '/home/runner/work/cli/cli/dist',
+      runnerTempPath: '/home/runner/work/_temp',
+      sshAgent: '',
+      gitPrivateToken: '',
+      dockerWorkspacePath: '/github/workspace',
+      engine: 'godot',
+      projectPath: 'test-project',
+      commands: 'godot --headless --export-release "Linux" build/output',
+      engineLaunchWrapper: 'flock /tmp/engine.lock --',
+    });
+
+    expect(command).toContain(
+      'game-ci/godot:latest flock /tmp/engine.lock -- godot --headless --export-release "Linux" build/output',
+    );
+  });
+
+  it('prefixes the Godot commands string with engineLaunchWrapper when set (Windows)', () => {
+    const command = (Docker as any).getWindowsCommand('game-ci/godot:latest', {
+      currentWorkDir: 'C:/work/cli',
+      homeDir: 'C:/Users/runner',
+      cliDistPath: 'C:/work/cli/dist',
+      cliStoragePath: 'C:/work/.game-ci',
+      gitPrivateToken: '',
+      dockerWorkspacePath: '/github/workspace',
+      engine: 'godot',
+      commands: 'godot --headless --export-release "Windows" build/output',
+      engineLaunchWrapper: 'flock /tmp/engine.lock --',
+    });
+
+    expect(command).toContain('flock /tmp/engine.lock -- godot --headless --export-release "Windows" build/output');
+  });
+
+  it('does not affect the Unity entrypoint flow even when engineLaunchWrapper is set (wrapping happens per-call-site inside the scripts instead)', () => {
+    const command = (Docker as any).getLinuxCommand('game-ci/unity-editor-stub:latest', {
+      hostOS: 'linux',
+      currentWorkDir: '/home/runner/work/cli/cli',
+      homeDir: '/home/runner',
+      cliDistPath: '/home/runner/work/cli/cli/dist',
+      sshAgent: '',
+      gitPrivateToken: '',
+      dockerWorkspacePath: '/github/workspace',
+      engine: 'unity',
+      engineLaunchWrapper: 'flock /tmp/engine.lock --',
+    });
+
+    expect(command).toContain('/bin/bash /entrypoint.sh');
+    expect(command).toContain('--env ENGINE_LAUNCH_WRAPPER="flock /tmp/engine.lock --"');
+  });
+
   it('applies docker resource limits and host networking when set', () => {
     const command = (Docker as any).getLinuxCommand('game-ci/unity-editor-stub:latest', {
       hostOS: 'linux',

--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -83,6 +83,7 @@ class Docker {
       dockerCpuLimit,
       dockerMemoryLimit,
       dockerShmSize,
+      engineLaunchWrapper,
     } = options as Options & { commands?: string };
 
     const home = homeDir;
@@ -94,6 +95,13 @@ class Docker {
     // build with `engine !== 'unity'` always ran Unity's entrypoint instead
     // of the command the engine plugin actually asked for.
     const isUnityDefaultFlow = !commands || engine === 'unity';
+
+    // Non-Unity engines' `commands` is already just the engine invocation
+    // itself (no surrounding activate/build/return-license lifecycle), so a
+    // single prefix here is exactly as precise a wrap as the per-call-site
+    // fix inside entrypoint.sh's step scripts is for Unity. Unset (the
+    // default) leaves `commands` byte-identical to today.
+    const wrappedCommands = engineLaunchWrapper && commands ? `${engineLaunchWrapper} ${commands}` : commands;
 
     return [
       'docker run',
@@ -118,7 +126,7 @@ class Docker {
       sshAgent && !sshPublicKeysDirectoryPath ? '--volume /home/runner/.ssh/known_hosts:/root/.ssh/known_hosts:ro' : '',
       sshPublicKeysDirectoryPath ? `--volume ${sshPublicKeysDirectoryPath}:/root/.ssh:ro` : '',
       image,
-      isUnityDefaultFlow ? '/bin/bash /entrypoint.sh' : commands!,
+      isUnityDefaultFlow ? '/bin/bash /entrypoint.sh' : wrappedCommands!,
     ]
       .filter(Boolean)
       .join(' ');
@@ -139,6 +147,7 @@ class Docker {
       dockerMemoryLimit,
       dockerShmSize,
       dockerIsolationMode,
+      engineLaunchWrapper,
     } = options as Options & { commands?: string };
 
     // Same "don't force Unity's flow onto a non-Unity engine" fix as
@@ -147,6 +156,10 @@ class Docker {
     // for consistency and so a future one isn't silently broken like this
     // was.
     const isUnityDefaultFlow = !commands || engine === 'unity';
+
+    // See getLinuxCommand's own comment - same single top-level wrap,
+    // byte-identical to today when engineLaunchWrapper is unset.
+    const wrappedCommands = engineLaunchWrapper && commands ? `${engineLaunchWrapper} ${commands}` : commands;
 
     // Note: the equals sign (=) is needed in Powershell.
     // Note: homedir is currently not configured for windows (yet).
@@ -176,7 +189,7 @@ class Docker {
       isUnityDefaultFlow ? `  --volume="${cliDistPath}/BlankProject":"c:/BlankProject" \`` : '',
       isUnityDefaultFlow ? `  --volume="${cliDistPath}/unity-config":"c:/ProgramData/Unity/config" \`` : '',
       `  ${image} \``,
-      isUnityDefaultFlow ? '  powershell c:/steps/entrypoint.ps1' : `  ${commands}`,
+      isUnityDefaultFlow ? '  powershell c:/steps/entrypoint.ps1' : `  ${wrappedCommands}`,
     ]
       .filter(Boolean)
       .join('\n');


### PR DESCRIPTION
## Summary

The only in-process extension points available today — command hooks, container hooks, and the recently-wired middleware system — all wrap the *entire* build step (activate license, launch the engine, return license, post-build bookkeeping), not just the engine process launch itself. For a real use case like serializing concurrent engine launches on a shared self-hosted host, that's imprecise: a lock acquired at that granularity is held far longer than necessary, hurting parallelism.

## What changed

Adds `ENGINE_LAUNCH_WRAPPER` / `--engineLaunchWrapper`, prefixed onto the actual engine invocation — precisely the launch, nothing more or less. Named generically (not Unity-specific) since `game-ci/cli` supports Unity, Godot, and Unreal as built-in engines, and this needed to work for all of them:

- **Linux**: all 5 `unity-editor` invocations across `activate.sh`/`build.sh`/`test.sh` get `${ENGINE_LAUNCH_WRAPPER:-}` prefixed.
- **Windows**: a new shared `Invoke-UnityLaunch` helper in `resolve_unity_path.ps1` splits the wrapper value on whitespace before invoking (PowerShell's `&` call operator doesn't word-split a single string the way bash does) and routes all 6 real Unity-editor invocations through it.
- **Non-Unity engines** (Godot, Unreal, any future engine with a flat `commands` string): a single top-level wrap in `Docker.getLinuxCommand`/`getWindowsCommand`'s non-Unity branch.
- **Orchestrator's `local`/`local-system` provider** gets the full, documented `--engineLaunchWrapper` CLI option (`BuildParameters` field, yargs option, generated-script env var), mirroring the `--skipActivation`/`--enableBuildRetry`/`--localCache*` precedent.

**Scoping correction (pushed as a follow-up commit after initial review):** core `build`/`test`/`activate` should stay lean, thin engine-invocation commands — advanced runtime/CI-operational capabilities belong on `orchestrate`, which already owns that sophistication (caching, retry/recovery, hooks). The documented `--engineLaunchWrapper` CLI option was removed from `UnityOptions` (shared by `build`/`test`/`activate`). The underlying mechanism stays reachable — `Docker.run`'s non-Unity branch and `UnityEnvironment.getVariables` both still honor a raw `ENGINE_LAUNCH_WRAPPER` env var (Godot/Unreal have no Orchestrator-owned script chain of their own to carry this instead, so full removal would have silently regressed their capability, not just relocated it) — just not advertised as a first-class flag on core commands. `orchestrate --engineLaunchWrapper` is the one documented, supported entry point.

Unset (the default) is byte-identical to today on every path.

## Verification

- `bun test ./src`: 193 pass / 3 skip / 0 fail
- `tsc --noEmit` (orchestrator): clean
- `bunx oxfmt --check`: clean
- `bun run test:ci` (orchestrator, vitest): 996 passed / 1 skipped / 2 pre-existing failures confirmed unrelated (same known `cli-integration.test.ts`/`orchestrator-rclone-steps.test.ts` issues as recent PRs on this branch)
- `bun run build`: succeeds
- All modified `.ps1` files pass a PowerShell tokenizer syntax-check
- **Live sanity check**: a real Unix locking tool (`flock`) and a literal `echo WRAPPED` marker were used as live wrappers to confirm genuine interception on both Linux and Windows, and `HostRunner.buildEnv`'s returned environment object confirmed to carry `ENGINE_LAUNCH_WRAPPER` through to the child-process environment end to end.

## Test plan

- [x] `bun test ./src` passes
- [x] `tsc --noEmit` clean, `oxfmt --check` clean
- [x] `bun run test:ci` passes (pre-existing failures aside)
- [x] `bun run build` succeeds
- [x] Unset = byte-identical to today, verified via regression tests on both the Unity and non-Unity (Godot) Docker paths
- [x] Live wrapper interception confirmed on Linux and Windows
- [x] `--engineLaunchWrapper` confirmed NOT registered on core `build`/`test`/`activate`, only on `orchestrate`
- [ ] Follow-up: real-world validation against an actual self-hosted launch-lock implementation