### PR TITLE
fix: register build-identification options on orchestrate

### DIFF
--- a/src/command-options/orchestrate-build-options.ts
+++ b/src/command-options/orchestrate-build-options.ts
@@ -1,0 +1,100 @@
+import type { YargsInstance } from '../dependencies.ts';
+import { IOptions } from './options-interface.ts';
+
+/**
+ * Build-identification options for `game-ci orchestrate`.
+ *
+ * `createBuildParametersFromCliOptions` (plugins/orchestrator/src/cli-plugin/
+ * build-parameters-adapter.ts) reads all of these straight off the parsed
+ * options object regardless of where they came from, but nothing previously
+ * registered them as yargs options for the `orchestrate` command itself -
+ * under yargs' global strict(true), that meant `game-ci orchestrate
+ * --targetPlatform=... ` failed with "Unknown argument: targetPlatform"
+ * before ever reaching the adapter, making `orchestrate` impossible to
+ * invoke for any concrete build target via its own documented flags.
+ *
+ * Mirrors the option names `build-parameters-adapter.ts` actually reads;
+ * does not duplicate anything `orchestrator-options-plugin.ts` (provider-
+ * specific options: cloud provider knobs, caching, hooks, etc.) already
+ * registers.
+ */
+export class OrchestrateBuildOptions implements IOptions {
+  public static async configure(yargs: YargsInstance): Promise<void> {
+    yargs
+      .option('targetPlatform', {
+        description: 'The platform to build your project for. Defaults to StandaloneLinux64.',
+        type: 'string',
+        demandOption: false,
+      })
+      .option('buildName', {
+        description: 'Name of the build (defaults to targetPlatform name)',
+        type: 'string',
+        demandOption: false,
+      })
+      .option('buildsPath', {
+        description: 'Path where the builds should be stored',
+        type: 'string',
+        demandOption: false,
+      })
+      .option('buildMethod', {
+        description: 'Path to a Namespace.Class.StaticMethod to run to perform the build',
+        type: 'string',
+        demandOption: false,
+      })
+      .option('buildProfile', {
+        description: 'Unity 6 build profile asset path (omits --buildTarget when set)',
+        type: 'string',
+        demandOption: false,
+      })
+      .option('buildVersion', {
+        description: 'Build version string. Defaults to 0.0.1.',
+        type: 'string',
+        demandOption: false,
+      })
+      .option('androidVersionCode', {
+        description: 'Android version code',
+        type: 'string',
+        demandOption: false,
+      })
+      .option('manualExit', {
+        description: "Skip Unity's own -quit flag; the build method calls EditorApplication.Exit itself",
+        type: 'boolean',
+        demandOption: false,
+      })
+      .option('enableGpu', {
+        description: 'Enable GPU access for the orchestrated job',
+        type: 'boolean',
+        demandOption: false,
+      })
+      .option('allowDirtyBuild', {
+        description: 'Allow builds from a dirty (uncommitted-changes) working tree',
+        type: 'boolean',
+        demandOption: false,
+      })
+      .option('cacheUnityInstallationOnMac', {
+        description: 'Cache the Unity installation on macOS runners',
+        type: 'boolean',
+        demandOption: false,
+      })
+      .option('chownFilesTo', {
+        description: 'User to chown output files to after the build',
+        type: 'string',
+        demandOption: false,
+      })
+      .option('sshAgent', {
+        description: 'Path to an SSH agent socket, for private git dependency access',
+        type: 'string',
+        demandOption: false,
+      })
+      .option('sshPublicKeysDirectoryPath', {
+        description: 'Directory of SSH public keys to trust for private git dependency access',
+        type: 'string',
+        demandOption: false,
+      })
+      .option('gitPrivateToken', {
+        description: 'Git private token for repository/submodule access',
+        type: 'string',
+        demandOption: false,
+      });
+  }
+}

--- a/src/command/orchestrate/unity-orchestrate-command.test.ts
+++ b/src/command/orchestrate/unity-orchestrate-command.test.ts
@@ -76,4 +76,49 @@ describe('UnityOrchestrateCommand', () => {
     expect(buildParametersArg.editorVersion).toBe('2022.3.20f1');
     expect(typeof baseImageArg).toBe('string');
   });
+
+  describe('configureOptions', () => {
+    // Regression test for a real bug: configureOptions previously only
+    // registered ProjectOptions + RemoteOptions, so under yargs' global
+    // strict(true) mode, `game-ci orchestrate --targetPlatform=...` failed
+    // with "Unknown argument: targetPlatform" before ever reaching
+    // createBuildParametersFromCliOptions, which reads that field (and
+    // buildName/buildsPath/buildMethod/etc.) unconditionally. This made
+    // `orchestrate` impossible to invoke for a concrete build target via
+    // its own documented flags - confirmed live, not just in theory: the
+    // exact command above returned exit 1 with that error before this fix.
+    it('registers targetPlatform and the other build-identification options build-parameters-adapter reads', async () => {
+      const registered: Record<string, any> = {};
+      const mockYargs: any = {
+        option(name: string, config: any) {
+          registered[name] = config;
+
+          return mockYargs;
+        },
+      };
+
+      const command = new UnityOrchestrateCommand('orchestrate');
+      await command.configureOptions(mockYargs);
+
+      for (const name of [
+        'targetPlatform',
+        'buildName',
+        'buildsPath',
+        'buildMethod',
+        'buildProfile',
+        'buildVersion',
+        'androidVersionCode',
+        'manualExit',
+        'enableGpu',
+        'allowDirtyBuild',
+        'cacheUnityInstallationOnMac',
+        'chownFilesTo',
+        'sshAgent',
+        'sshPublicKeysDirectoryPath',
+        'gitPrivateToken',
+      ]) {
+        expect(registered).toHaveProperty(name);
+      }
+    });
+  });
 });

--- a/src/command/orchestrate/unity-orchestrate-command.ts
+++ b/src/command/orchestrate/unity-orchestrate-command.ts
@@ -3,6 +3,7 @@ import type { YargsArguments, YargsInstance } from '../../dependencies.ts';
 import { CommandBase } from '../command-base.ts';
 import { RemoteOptions } from '../../command-options/remote-options.ts';
 import { ProjectOptions } from '../../command-options/project-options.ts';
+import { OrchestrateBuildOptions } from '../../command-options/orchestrate-build-options.ts';
 import { Orchestrator, ImageTag } from '../../../plugins/orchestrator/src/model/index.ts';
 import { createBuildParametersFromCliOptions } from '../../../plugins/orchestrator/src/cli-plugin/index.ts';
 
@@ -34,6 +35,7 @@ export class UnityOrchestrateCommand extends CommandBase implements CommandInter
 
   public async configureOptions(yargs: YargsInstance): Promise<void> {
     await ProjectOptions.configure(yargs);
+    await OrchestrateBuildOptions.configure(yargs);
     await RemoteOptions.configure(yargs);
   }
 }


### PR DESCRIPTION
## Summary

\`UnityOrchestrateCommand.configureOptions\` only registered \`ProjectOptions\` and \`RemoteOptions\` — \`targetPlatform\`, \`buildName\`, \`buildsPath\`, \`buildMethod\`, and the rest of what \`createBuildParametersFromCliOptions\` (\`build-parameters-adapter.ts\`) reads unconditionally were never registered as yargs options for \`orchestrate\` itself. Under yargs' global \`strict(true)\`, that meant **\`game-ci orchestrate --targetPlatform=StandaloneLinux64\` failed with \`Unknown argument: targetPlatform\` before ever reaching the adapter** — \`orchestrate\` was not actually invocable for a concrete build target via its own documented flags, despite everything downstream of option-parsing already supporting it.

Found independently by two parallel efforts working on unity-builder's new \`orchestrate\`/\`local-system\` integration this session, which this directly unblocks — cross-confirmed by both before I fixed it.

## What changed

New \`OrchestrateBuildOptions\` (\`src/command-options/orchestrate-build-options.ts\`) registers exactly the fields \`build-parameters-adapter.ts\` already reads: \`targetPlatform\`, \`buildName\`, \`buildsPath\`, \`buildMethod\`, \`buildProfile\`, \`buildVersion\`, \`androidVersionCode\`, \`manualExit\`, \`enableGpu\`, \`allowDirtyBuild\`, \`cacheUnityInstallationOnMac\`, \`chownFilesTo\`, \`sshAgent\`, \`sshPublicKeysDirectoryPath\`, \`gitPrivateToken\`. Verified no overlap with what \`orchestrator-options-plugin.ts\` already registers (provider-specific knobs: cloud credentials, caching, hooks, etc.) — this doesn't touch or duplicate any of that.

## Verification

- **Live reproduction and fix confirmation**: ran \`game-ci orchestrate --targetPlatform=StandaloneLinux64 --providerStrategy=local-system --projectPath=<synthetic project> --skipActivation\` — before the fix, failed immediately with \`Unknown argument: targetPlatform\`; after, it parsed cleanly and reached real orchestration output (provider selection, GitHub Check creation, etc.).
- New regression test in \`unity-orchestrate-command.test.ts\` asserting every one of these options is actually registered via \`configureOptions\` (mocked yargs, matching the pattern already used elsewhere in this codebase for option-registration tests).
- \`bun test ./src\`: 188 pass / 3 skip, plus 7 pre-existing timeout/dangling-process failures in \`cli.test.ts\`/\`system.test.ts\` — confirmed unrelated by reproducing the identical failures with my changes \`git stash\`ed out (i.e. present on the unmodified baseline too).
- \`bun run build\`: succeeds.

## Test plan

- [x] Live-reproduced the bug, confirmed the fix resolves it
- [x] New regression test passes
- [x] \`bun run build\` succeeds
- [x] Confirmed remaining test failures are pre-existing/unrelated via git-stash comparison

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional command-line options for configuring orchestrated builds, including versioning, execution, GPU, caching, file ownership, SSH, and Git access.
  * Added support for target-platform and build-related options in the Unity orchestration command.

* **Tests**
  * Added regression coverage to verify build option registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->