### PR TITLE
fix: always create registry-keys dir before Docker mounts it on Windows

### DIFF
--- a/src/logic/unity/platform-setup/setup-windows.test.ts
+++ b/src/logic/unity/platform-setup/setup-windows.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, mock, afterEach } from 'bun:test';
+import { SetupWindows } from './setup-windows.ts';
+import { fsSync as fs } from '../../../dependencies.ts';
+import { System } from '../../../model/system/system.ts';
+import { ValidateWindows } from '../platform-validation/validate-windows.ts';
+
+const originalEnsureDir = fs.ensureDir;
+const originalSystemRun = System.run;
+const originalValidate = ValidateWindows.validate;
+
+afterEach(() => {
+  fs.ensureDir = originalEnsureDir;
+  System.run = originalSystemRun;
+  ValidateWindows.validate = originalValidate;
+});
+
+describe('SetupWindows', () => {
+  // Regression test for a real bug: Docker.getWindowsCommand mounts
+  // `${cliStoragePath}/registry-keys` unconditionally for every
+  // Windows-Docker Unity build, but this directory was previously only
+  // created for StandaloneWindows/StandaloneWindows64/WSAPlayer targets -
+  // any other target (Android, iOS, WebGL, ...) hit "bind source path does
+  // not exist" on the Docker mount. Confirmed live in game-ci/unity-builder
+  // CI: an Android-targeted Windows Docker build failed with exactly this
+  // Docker error before this fix.
+  it('ensures the registry-keys directory exists for a non-Windows-SDK target platform (e.g. Android)', async () => {
+    ValidateWindows.validate = mock(() => {});
+    const ensureDirMock = mock(() => {});
+    fs.ensureDir = ensureDirMock as any;
+    const systemRunMock = mock(() => Promise.resolve(''));
+    System.run = systemRunMock as any;
+
+    await SetupWindows.setup({
+      targetPlatform: 'Android',
+      cliStoragePath: '/home/.game-ci',
+    } as any);
+
+    expect(ensureDirMock).toHaveBeenCalledWith('/home/.game-ci/registry-keys');
+    // No WinSDK registry export needed for a non-Windows target.
+    expect(systemRunMock).not.toHaveBeenCalled();
+  });
+
+  it('still ensures the directory AND runs the WinSDK registry export for StandaloneWindows64', async () => {
+    ValidateWindows.validate = mock(() => {});
+    const ensureDirMock = mock(() => {});
+    fs.ensureDir = ensureDirMock as any;
+    let capturedCommand = '';
+    const systemRunMock = mock((command: string) => {
+      capturedCommand = command;
+
+      return Promise.resolve('');
+    });
+    System.run = systemRunMock as any;
+
+    await SetupWindows.setup({
+      targetPlatform: 'StandaloneWindows64',
+      cliStoragePath: '/home/.game-ci',
+    } as any);
+
+    expect(ensureDirMock).toHaveBeenCalledWith('/home/.game-ci/registry-keys');
+    expect(systemRunMock).toHaveBeenCalledTimes(1);
+    expect(capturedCommand).toContain('reg export');
+    expect(capturedCommand).toContain('/home/.game-ci/registry-keys/winsdk.reg');
+  });
+});

--- a/src/logic/unity/platform-setup/setup-windows.ts
+++ b/src/logic/unity/platform-setup/setup-windows.ts
@@ -6,7 +6,24 @@ import { System } from '../../../model/system/system.ts';
 class SetupWindows {
   public static async setup(options: Options) {
     ValidateWindows.validate(options);
+    // Docker.getWindowsCommand mounts `${cliStoragePath}/registry-keys` as a
+    // bind volume unconditionally, for every Windows-Docker Unity build
+    // regardless of targetPlatform - not just the three platforms that
+    // actually need a WinSDK registry export below. Ensuring the directory
+    // exists here, unconditionally, keeps that mount from failing with
+    // "bind source path does not exist" for every other target platform
+    // (e.g. Android, iOS, WebGL) built via Windows Docker.
+    this.ensureRegistryKeysDir(options);
     await this.generateWinSdkRegistryKey(options);
+  }
+
+  private static ensureRegistryKeysDir(options: Options): string {
+    const { cliStoragePath } = options;
+    const registryKeysPath = `${cliStoragePath}/registry-keys`;
+
+    fs.ensureDir(registryKeysPath);
+
+    return registryKeysPath;
   }
 
   private static async generateWinSdkRegistryKey(options: Options) {
@@ -17,7 +34,6 @@ class SetupWindows {
     const registryKeysPath = `${cliStoragePath}/registry-keys`;
     const copyWinSdkRegistryKeyCommand = `reg export "HKLM\\SOFTWARE\\WOW6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v10.0" ${registryKeysPath}/winsdk.reg /y`;
 
-    fs.ensureDir(registryKeysPath);
     await System.run(copyWinSdkRegistryKeyCommand);
   }
 }


### PR DESCRIPTION
## Summary

Found while investigating unexplained CI failures on a downstream `unity-builder` PR: **`Docker.getWindowsCommand` mounts \`\${cliStoragePath}/registry-keys\` as a bind volume unconditionally for every Windows-Docker Unity build**, but \`SetupWindows.generateWinSdkRegistryKey\` only created that directory for \`targetPlatform\` in \`[StandaloneWindows, StandaloneWindows64, WSAPlayer]\`. Any other target platform (Android, iOS, WebGL, ...) built via Windows Docker hits \`bind source path does not exist\` on the mount, since the directory was simply never created for it.

## Live confirmation

Reproduced in \`game-ci/unity-builder\`'s real CI: an Android-targeted Windows Docker build failed deterministically (3/3 retry attempts, identical error each time):
\`\`\`
docker: Error response from daemon: invalid volume specification: 'C:\Users\runneradmin/.game-ci/registry-keys:c:/registry-keys': invalid mount config for type "bind": bind source path does not exist: c:\users\runneradmin\.game-ci\registry-keys
\`\`\`
Confirmed via \`gh api .../workflows/.../runs\` history that this has been breaking \`unity-builder\`'s Windows CI matrix for over a week, unrelated to any of that repo's own code.

## Fix

Split \`SetupWindows.generateWinSdkRegistryKey\` so directory creation (\`fs.ensureDir\`) happens unconditionally in \`setup()\` — every Windows-Docker build needs the mount point to exist, regardless of target platform — while the actual WinSDK registry export (\`reg export ...\`) stays conditional on the three platforms that actually need it, exactly as before.

## Verification

- New \`setup-windows.test.ts\` (didn't exist before): confirms the directory is created for a non-Windows-SDK target (Android) with no registry export attempted, and confirms StandaloneWindows64 still gets both the directory AND the export, matching prior behavior exactly for the platforms that already worked.
- \`bun test ./src\`: 190+ pass; the handful of failures present are the same known, pre-existing timeout/dangling-process flakiness cluster (\`cli.test.ts\` env-var mapping, \`Cli config profiles\`) already confirmed unrelated via git-stash comparison in earlier PRs on this branch's history.
- \`bun run build\`: succeeds.

## Test plan

- [x] New regression test confirms the fix for a previously-broken target platform
- [x] New regression test confirms unchanged behavior for the platforms that already worked
- [x] \`bun run build\` succeeds
- [x] Live-traced root cause via a real downstream CI failure, not speculative