### PR TITLE
fix: install Unity Hub as a Homebrew cask, not a versioned formula

### DIFF
--- a/src/logic/unity/platform-setup/setup-mac.test.ts
+++ b/src/logic/unity/platform-setup/setup-mac.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, mock, afterEach } from "bun:test";
+import { SetupMac } from "./setup-mac.ts";
+import { fsSync as fs } from "../../../dependencies.ts";
+import { System } from "../../../model/system/system.ts";
+
+const originalExistsSync = fs.existsSync;
+const originalSystemRun = System.run;
+
+afterEach(() => {
+  fs.existsSync = originalExistsSync;
+  System.run = originalSystemRun;
+});
+
+describe("SetupMac", () => {
+  // Regression test for a real bug: installUnityHub used to build
+  // `brew install unity-hub@<version>`, treating Unity Hub as a versioned
+  // Homebrew formula. Unity Hub is only distributed as a cask, so that
+  // command fails with "No available formula with the name ...". Confirmed
+  // live in game-ci/unity-builder CI: every Mac build failed at Unity Hub
+  // install with exactly this error before this fix, while the previously
+  // working (pre-thin-wrapper) code path ran the plain, unversioned
+  // `brew install unity-hub` cask install successfully.
+  it("installs the unversioned unity-hub cask when no version is pinned", async () => {
+    // Only the Hub paths are missing; the Editor path exists so setup() doesn't also
+    // fall into installUnity, which is unrelated to this fix.
+    fs.existsSync = mock((path: string) => !path.includes("Hub.app")) as any;
+    let capturedCommand = "";
+    const systemRunMock = mock((command: string) => {
+      capturedCommand = command;
+
+      return Promise.resolve({ status: { code: 0 }, output: "" });
+    });
+    System.run = systemRunMock as any;
+
+    await SetupMac.setup({
+      isRunningLocally: false,
+      unityHubVersionOnMac: "",
+      engineVersion: "2021.3.16f1",
+    } as any);
+
+    expect(capturedCommand).toBe("brew install --cask unity-hub");
+  });
+
+  it("pins the cask version when unityHubVersionOnMac is explicitly set", async () => {
+    fs.existsSync = mock((path: string) => !path.includes("Hub.app")) as any;
+    let capturedCommand = "";
+    const systemRunMock = mock((command: string) => {
+      capturedCommand = command;
+
+      return Promise.resolve({ status: { code: 0 }, output: "" });
+    });
+    System.run = systemRunMock as any;
+
+    await SetupMac.setup({
+      isRunningLocally: false,
+      unityHubVersionOnMac: "3.19.5",
+      engineVersion: "2021.3.16f1",
+    } as any);
+
+    expect(capturedCommand).toBe("brew install --cask unity-hub@3.19.5");
+  });
+});

--- a/src/logic/unity/platform-setup/setup-mac.ts
+++ b/src/logic/unity/platform-setup/setup-mac.ts
@@ -1,6 +1,6 @@
-import { fsSync as fs } from '../../../dependencies.ts';
-import type { Options } from '../../../dependencies.ts';
-import { System } from '../../../model/system/system.ts';
+import { fsSync as fs } from "../../../dependencies.ts";
+import type { Options } from "../../../dependencies.ts";
+import { System } from "../../../model/system/system.ts";
 
 class SetupMac {
   static unityHubBasePath = `/Applications/"Unity Hub.app"`;
@@ -23,7 +23,7 @@ class SetupMac {
         await SetupMac.installUnity(options);
       } else {
         throw new Error(String.dedent`Unity Editor ${options.engineVersion} is not installed at the default location.
-        Please install Unity Editor ${options.engineVersion} at the default location with the necessary modules and try again.`)
+        Please install Unity Editor ${options.engineVersion} at the default location with the necessary modules and try again.`);
       }
     }
 
@@ -31,13 +31,12 @@ class SetupMac {
   }
 
   private static async installUnityHub(options: Options, silent = false) {
-
-    const targetHubVersion =
-      options.unityHubVersionOnMac !== ''
-        ? options.unityHubVersionOnMac
-        : await SetupMac.getLatestUnityHubVersion();
-
-    const command = `brew install unity-hub@${targetHubVersion}`;
+    // Unity Hub is distributed on Homebrew as a cask, not a formula, so it has no `@version`
+    // formula-style pinning by default. Install the unversioned cask (always the latest available)
+    // unless the caller explicitly pinned a version, in which case we pass through the
+    // `<cask>@<version>` token Homebrew uses for casks that publish versioned taps.
+    const versionSuffix = options.unityHubVersionOnMac !== "" ? `@${options.unityHubVersionOnMac}` : "";
+    const command = `brew install --cask unity-hub${versionSuffix}`;
 
     if (!fs.existsSync(this.unityHubBasePath)) {
       try {
@@ -48,36 +47,23 @@ class SetupMac {
     }
   }
 
-  /**
-   * Gets the latest version of Unity Hub available on brew
-   */
-  private static async getLatestUnityHubVersion(): Promise<string> {
-    const hubVersionCommand = `/bin/bash -c "brew info unity-hub | grep -o '[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+'"`;
-    const result = await System.run(hubVersionCommand, undefined, { silent: true });
-    if (result.status?.code === 0 && result.output !== '') {
-      return result.output;
-    }
-
-    return '';
-  }
-
   private static getModuleParametersForTargetPlatform(targetPlatform: string): string {
-    let moduleArgument = '';
+    let moduleArgument = "";
     switch (targetPlatform) {
-      case 'iOS':
+      case "iOS":
         moduleArgument += `--module ios `;
         break;
-      case 'tvOS':
-        moduleArgument += '--module tvos ';
+      case "tvOS":
+        moduleArgument += "--module tvos ";
         break;
-      case 'StandaloneOSX':
+      case "StandaloneOSX":
         moduleArgument += `--module mac-il2cpp `;
         break;
-      case 'Android':
+      case "Android":
         moduleArgument += `--module android `;
         break;
-      case 'WebGL':
-        moduleArgument += '--module webgl ';
+      case "WebGL":
+        moduleArgument += "--module webgl ";
         break;
       default:
         throw new Error(`Unsupported module for target platform: ${targetPlatform}.`);


### PR DESCRIPTION
## Summary

Found while chasing why every Mac job in [game-ci/unity-builder#844](https://github.com/game-ci/unity-builder/pull/844)'s CI has been failing since the thin-wrapper rewrite:

```
[ERROR] Error: There was an error installing Unity Hub. See logs above for details.
Error: ::warning::No available formula with the name "unity-hub@3.19.5".
To install unity-hub, run:
  brew install --cask unity-hub
```

`SetupMac.installUnityHub` built `brew install unity-hub@<version>` — treating Unity Hub as a versioned Homebrew **formula**. Unity Hub is only distributed as a **cask**, and casks don't support that install syntax by default. Confirmed via CI history on `unity-builder`'s `thin-wrapper-unity-engine-core` branch: the last successful Mac run (2026-08-13, pre-rewrite code) ran the plain, unversioned `brew install unity-hub` (implicitly resolved as the cask) successfully; every run since (including the `v6.0.0-beta.1` tag itself) has failed at this exact step.

## What changed

- Default path (no `unityHubVersionOnMac` override — the common case): now runs `brew install --cask unity-hub` directly, matching the proven-working behavior. Previously this "auto" path round-tripped through `brew info unity-hub` to resolve a "latest" version number and then re-requested that exact version via the broken `@version` formula syntax — an unnecessary extra step that was itself the source of the bug, since a plain cask install already gets latest.
- Explicit `unityHubVersionOnMac` override: still pins a version, now via the `<cask>@<version>` token Homebrew casks use, with `--cask` added.
- Removed `getLatestUnityHubVersion()` — no longer needed since the default path no longer resolves-then-repins a version.

## Verification

- `tsc --noEmit`: same 737 pre-existing errors with and without this change (none in the touched files) — confirmed via `git stash` comparison.
- New `setup-mac.test.ts`: 2 tests — default path installs the unversioned cask, explicit override pins `@version`. Both pass.
- `bun test ./src`: 198 pass, 0 fail (root suite).
- `bun run build`: succeeds.

## Test plan

- [x] New regression tests cover both the default (unversioned) and explicit-version-override paths
- [x] `tsc --noEmit` shows no new errors vs. baseline
- [x] `bun test ./src` passes
- [x] `bun run build` succeeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unity Hub installation on macOS by using the correct Homebrew cask format.
  * Added support for installing either the latest Unity Hub version or a specified version.
  * Simplified installation behavior by removing unnecessary version lookup steps.

* **Tests**
  * Added regression coverage for versioned and unversioned Unity Hub installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->