### PR TITLE
feat: add steam-deploy plugin (game-ci deploy steam)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "@game-ci/cli",
       "dependencies": {
         "@game-ci/orchestrator": "workspace:*",
+        "@game-ci/steam-deploy": "workspace:*",
         "dotenv": "^16.3.1",
         "semver": "^7.5.4",
         "yaml": "^2.3.4",
@@ -65,6 +66,15 @@
         "ts-node": "10.8.1",
         "typescript": "4.7.4",
         "vite": "^7",
+        "vitest": "^4",
+      },
+    },
+    "plugins/steam-deploy": {
+      "name": "@game-ci/steam-deploy",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^17.0.23",
+        "typescript": "4.7.4",
         "vitest": "^4",
       },
     },
@@ -328,6 +338,8 @@
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@game-ci/orchestrator": ["@game-ci/orchestrator@workspace:plugins/orchestrator"],
+
+    "@game-ci/steam-deploy": ["@game-ci/steam-deploy@workspace:plugins/steam-deploy"],
 
     "@game-ci/unity-engine-core": ["@game-ci/unity-engine-core@workspace:plugins/unity"],
 
@@ -1554,6 +1566,8 @@
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@game-ci/orchestrator/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
+
+    "@game-ci/steam-deploy/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 
     "@game-ci/unity-engine-core/@types/node": ["@types/node@20.19.43", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA=="],
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@game-ci/orchestrator": "workspace:*",
+    "@game-ci/steam-deploy": "workspace:*",
     "dotenv": "^16.3.1",
     "semver": "^7.5.4",
     "yaml": "^2.3.4",

--- a/plugins/steam-deploy/package.json
+++ b/plugins/steam-deploy/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@game-ci/steam-deploy",
+  "version": "0.1.0",
+  "description": "Deploy a pre-built game output to Steam via SteamCMD. Engine-agnostic - works on any built output folder, regardless of what built it.",
+  "license": "MIT",
+  "repository": "git@github.com:game-ci/cli.git",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.23",
+    "typescript": "4.7.4",
+    "vitest": "^4"
+  },
+  "engines": {
+    "node": ">=18.x"
+  }
+}

--- a/plugins/steam-deploy/src/index.ts
+++ b/plugins/steam-deploy/src/index.ts
@@ -1,0 +1,32 @@
+import { SteamDeployCommand } from "./steam-deploy-command";
+
+/**
+ * Steam deploy plugin - `game-ci deploy steam <buildPath>`.
+ *
+ * Engine-agnostic: it deploys a pre-built output folder, so it doesn't
+ * matter whether Unity, Godot, Unreal, or anything else produced it.
+ * Registered with engine: '*' (see PluginRegistry.createCommand's wildcard
+ * handling), not tied to any specific engine's plugin.
+ */
+export const steamDeployPlugin = {
+  name: "steam-deploy",
+  version: "0.1.0",
+
+  commands: [
+    {
+      engine: "*",
+      createCommand(command: string, subCommands: string[]) {
+        if (command === "deploy" && subCommands[0] === "steam") {
+          return new SteamDeployCommand();
+        }
+        return null;
+      },
+    },
+  ],
+};
+
+export default steamDeployPlugin;
+export { SteamDeployCommand } from "./steam-deploy-command";
+export { generateAppVdf, generateDepotVdf } from "./vdf-generator";
+export { parseSteamCmdOutput } from "./parse-steamcmd-output";
+export { SteamCmdRunner } from "./steamcmd-runner";

--- a/plugins/steam-deploy/src/parse-steamcmd-output.test.ts
+++ b/plugins/steam-deploy/src/parse-steamcmd-output.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { parseSteamCmdOutput } from "./parse-steamcmd-output";
+
+describe("parseSteamCmdOutput", () => {
+  it("reports success and captures the BuildID when the output explicitly confirms success", () => {
+    const output = "Uploading content...\nSuccessfully finished AppID 123 build (BuildID 45678910).\n";
+
+    const result = parseSteamCmdOutput(output, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.buildId).toBe("45678910");
+  });
+
+  it("treats exit code 0 with no explicit confirmation and no error markers as success", () => {
+    // Real SteamCMD behavior: it doesn't always print the confirmation line even on a genuine success.
+    const output = "Uploading content...\ndone.\n";
+
+    const result = parseSteamCmdOutput(output, 0);
+
+    expect(result.success).toBe(true);
+    expect(result.buildId).toBe("");
+  });
+
+  it("reports failure with a specific reason when the Steam connection dropped", () => {
+    const output = "Logging in...\ndisconnected from steam\n";
+
+    const result = parseSteamCmdOutput(output, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.failureReason).toContain("connection dropped");
+  });
+
+  it("reports failure with a specific reason when the depot build itself failed, even at exit code 0", () => {
+    // Real SteamCMD behavior: a depot build failure can still exit 0 - the output text is the
+    // only reliable signal, which is exactly why exit code alone isn't trusted here.
+    const output = "ERROR! Build for depot 1000 failed.\n";
+
+    const result = parseSteamCmdOutput(output, 0);
+
+    expect(result.success).toBe(false);
+    expect(result.failureReason).toContain("depot build reported failure");
+  });
+
+  it("reports failure with a specific reason when the missing-chunks list failed", () => {
+    const output = "ERROR! Failed to get list of missing chunks.\n";
+
+    const result = parseSteamCmdOutput(output, 1);
+
+    expect(result.success).toBe(false);
+    expect(result.failureReason).toContain("missing chunks");
+  });
+
+  it("falls back to the raw exit code when no known failure signature is present", () => {
+    const output = "Something unexpected happened.\n";
+
+    const result = parseSteamCmdOutput(output, 7);
+
+    expect(result.success).toBe(false);
+    expect(result.failureReason).toBe("exit code 7");
+  });
+});

--- a/plugins/steam-deploy/src/parse-steamcmd-output.ts
+++ b/plugins/steam-deploy/src/parse-steamcmd-output.ts
@@ -1,0 +1,52 @@
+/**
+ * SteamCMD's exit code alone is not a reliable success/failure signal - a
+ * dropped Steam connection or a depot build failure can still exit 0, and a
+ * genuinely successful upload can occasionally exit non-zero after the
+ * upload itself completed. This heuristic (ported from a real, production
+ * PowerShell deploy script) reads the actual output text instead, in this
+ * priority order:
+ *
+ *  1. "Successfully finished" in the output - definitive success.
+ *  2. Exit code 0 with no explicit error markers - treated as success
+ *     (SteamCMD doesn't always print the confirmation line even on a real
+ *     success).
+ *  3. Otherwise: failure, with a specific reason extracted from known
+ *     SteamCMD failure signatures where possible (a dropped connection and
+ *     a missing-chunks list both mean the upload can usually just be
+ *     retried, whereas a depot build failure means the content itself was
+ *     rejected).
+ */
+
+export interface SteamCmdParseResult {
+  success: boolean;
+  /** The Steam BuildID, if one appears in the output. Empty string if not found, even on success. */
+  buildId: string;
+  /** Populated on failure with a specific, actionable reason where the output allows identifying one. */
+  failureReason?: string;
+}
+
+export function parseSteamCmdOutput(output: string, exitCode: number): SteamCmdParseResult {
+  const buildIdMatch = /BuildID\s+(\d+)/.exec(output);
+  const buildId = buildIdMatch ? buildIdMatch[1] : "";
+
+  const successConfirmed = /Successfully finished/.test(output);
+  const disconnected = /disconnected from steam/i.test(output);
+  const errorBuild = /ERROR!.*Build for depot.*failed/.test(output);
+  const errorChunks = /ERROR!.*Failed to get list of missing chunks/.test(output);
+
+  if (successConfirmed) {
+    return { success: true, buildId };
+  }
+
+  if (exitCode === 0 && !errorBuild && !errorChunks) {
+    return { success: true, buildId };
+  }
+
+  const reasons: string[] = [];
+  if (disconnected) reasons.push("Steam connection dropped (request revoked)");
+  if (errorChunks) reasons.push("failed to get list of missing chunks (lost connection)");
+  if (errorBuild) reasons.push("depot build reported failure");
+  if (reasons.length === 0) reasons.push(`exit code ${exitCode}`);
+
+  return { success: false, buildId: "", failureReason: reasons.join("; ") };
+}

--- a/plugins/steam-deploy/src/steam-deploy-command.ts
+++ b/plugins/steam-deploy/src/steam-deploy-command.ts
@@ -1,0 +1,134 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { generateAppVdf, generateDepotVdf } from "./vdf-generator";
+import { SteamCmdRunner } from "./steamcmd-runner";
+
+export interface SteamDeployOptions {
+  buildPath?: string;
+  appId?: string;
+  depotId?: string;
+  branch?: string;
+  description?: string;
+  mode?: string;
+  steamCmdPath?: string;
+  steamConfigDir?: string;
+  extraExclusions?: string;
+  [key: string]: unknown;
+}
+
+interface YargsLike {
+  option: (name: string, config: Record<string, unknown>) => YargsLike;
+}
+
+export class SteamDeployCommand {
+  public readonly name = "Deploy steam";
+
+  public async configureOptions(yargs: YargsLike): Promise<void> {
+    yargs
+      .option("appId", {
+        describe: "Steam App ID",
+        type: "string",
+        demandOption: true,
+      })
+      .option("depotId", {
+        describe: "Steam Depot ID",
+        type: "string",
+        demandOption: true,
+      })
+      .option("branch", {
+        describe: 'Steam branch to publish to (SteamCMD\'s "setlive" field)',
+        type: "string",
+        default: "default",
+      })
+      .option("description", {
+        describe:
+          "Build description shown in the Steam build history. Defaults to the branch name and current timestamp.",
+        type: "string",
+      })
+      .option("mode", {
+        describe: "How to run steamcmd: auto (default), local, or docker",
+        type: "string",
+        default: "auto",
+      })
+      .option("steamCmdPath", {
+        describe: "Explicit path to the steamcmd executable. Recommended for CI determinism; skips auto-detection.",
+        type: "string",
+      })
+      .option("steamConfigDir", {
+        describe:
+          "Host directory containing Steam's config.vdf, mounted into the container in docker mode so login sessions persist.",
+        type: "string",
+      })
+      .option("extraExclusions", {
+        describe:
+          "Comma-separated extra file-exclusion glob patterns for the depot, beyond the built-in defaults (*.pdb, *.log, *.vdf, Burst debug/backup folders).",
+        type: "string",
+      });
+  }
+
+  public async execute(options: SteamDeployOptions): Promise<boolean> {
+    const buildPath = options.buildPath;
+    if (!buildPath) {
+      throw new Error("A build path is required: game-ci deploy steam <buildPath>");
+    }
+    if (!fs.existsSync(buildPath)) {
+      throw new Error(`Build path does not exist: ${buildPath}`);
+    }
+
+    const username = process.env.STEAM_USERNAME;
+    const password = process.env.STEAM_PASSWORD;
+    if (!username || !password) {
+      throw new Error(
+        "STEAM_USERNAME and STEAM_PASSWORD must be set as environment variables (never as CLI arguments - argv can leak through process listings).",
+      );
+    }
+
+    const appId = options.appId!;
+    const depotId = options.depotId!;
+    const branch = options.branch ?? "default";
+    const description = options.description ?? `${branch} build ${new Date().toISOString()}`;
+    const mode = (options.mode ?? "auto") as "auto" | "local" | "docker";
+    const extraExclusions = options.extraExclusions
+      ? options.extraExclusions.split(",").map((s) => s.trim())
+      : undefined;
+
+    const absoluteBuildPath = path.resolve(buildPath);
+    const contentRoot = mode === "docker" ? "/build" : absoluteBuildPath.replace(/\\/g, "/");
+    const depotFileName = `depot_build_${depotId}.vdf`;
+
+    const depotVdf = generateDepotVdf({ depotId, extraExclusions });
+    const appVdf = generateAppVdf({ appId, depotId, branch, description, depotVdfFileName: depotFileName })
+      // generateAppVdf's contentroot/buildoutput default to "./" - override to
+      // the path the running steamcmd process will actually see (an absolute
+      // host path for local mode, or the container mount point for docker).
+      .replace('"contentroot" "./"', `"contentroot" "${contentRoot}"`)
+      .replace('"buildoutput" "./"', `"buildoutput" "${contentRoot}"`);
+
+    fs.writeFileSync(path.join(absoluteBuildPath, depotFileName), depotVdf, "utf8");
+    fs.writeFileSync(path.join(absoluteBuildPath, "manifest.vdf"), appVdf, "utf8");
+
+    console.log(`Deploying ${absoluteBuildPath} to Steam app ${appId}, depot ${depotId}, branch "${branch}"`);
+
+    const runner = new SteamCmdRunner();
+    const result = await runner.run({
+      buildDir: absoluteBuildPath,
+      username,
+      password,
+      mode,
+      steamCmdPath: options.steamCmdPath,
+      steamConfigDir: options.steamConfigDir,
+    });
+
+    if (!result.success) {
+      throw new Error(`Steam deployment failed: ${result.failureReason}`);
+    }
+
+    if (result.buildId) {
+      console.log(`Steam deployment succeeded. BuildID: ${result.buildId}`);
+    } else {
+      console.log("Steam deployment succeeded (no BuildID found in output).");
+    }
+
+    return true;
+  }
+}

--- a/plugins/steam-deploy/src/steamcmd-runner.ts
+++ b/plugins/steam-deploy/src/steamcmd-runner.ts
@@ -1,0 +1,94 @@
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import { parseSteamCmdOutput, type SteamCmdParseResult } from "./parse-steamcmd-output";
+
+export interface RunSteamCmdOptions {
+  /** Directory containing manifest.vdf and the depot VDF(s), already patched with correct ContentRoot/BuildOutput. */
+  buildDir: string;
+  username: string;
+  password: string;
+  /** 'local' runs steamcmd directly; 'docker' runs it via the cm2network/steamcmd image; 'auto' picks whichever is available, preferring local. */
+  mode: "auto" | "local" | "docker";
+  /** Explicit path to steamcmd's executable. Skips PATH/common-location auto-detection when set - recommended for CI determinism. */
+  steamCmdPath?: string;
+  /** Host directory containing Steam's own config.vdf, mounted into the Docker container so login sessions persist across runs. */
+  steamConfigDir?: string;
+}
+
+type SpawnFn = typeof spawn;
+
+const LOCAL_STEAMCMD_CANDIDATES =
+  process.platform === "win32"
+    ? ["C:\\steamcmd\\steamcmd.exe", "C:\\Steam\\steamcmd.exe", "C:\\Program Files (x86)\\Steam\\steamcmd.exe"]
+    : ["/usr/games/steamcmd", "/usr/bin/steamcmd", `${process.env.HOME}/steamcmd/steamcmd.sh`];
+
+function findLocalSteamCmd(explicitPath?: string): string | null {
+  if (explicitPath) return fs.existsSync(explicitPath) ? explicitPath : null;
+  return LOCAL_STEAMCMD_CANDIDATES.find((candidate) => fs.existsSync(candidate)) ?? null;
+}
+
+function runProcess(spawnFn: SpawnFn, command: string, args: string[]): Promise<{ output: string; exitCode: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawnFn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let output = "";
+    child.stdout?.on("data", (chunk) => (output += chunk.toString()));
+    child.stderr?.on("data", (chunk) => (output += chunk.toString()));
+    child.on("error", reject);
+    child.on("close", (exitCode) => resolve({ output, exitCode: exitCode ?? 1 }));
+  });
+}
+
+export class SteamCmdRunner {
+  constructor(private readonly spawnFn: SpawnFn = spawn) {}
+
+  async run(options: RunSteamCmdOptions): Promise<SteamCmdParseResult> {
+    const localPath = findLocalSteamCmd(options.steamCmdPath);
+    const useDocker = options.mode === "docker" || (options.mode === "auto" && !localPath);
+
+    if (useDocker) {
+      return this.runInDocker(options);
+    }
+
+    if (!localPath) {
+      throw new Error(
+        "steamcmd was not found locally (checked --steamCmdPath and common install locations). " +
+          "Pass --steamCmdPath explicitly, or use --mode=docker.",
+      );
+    }
+
+    const manifestPath = `${options.buildDir}/manifest.vdf`.replace(/\\/g, "/");
+    const { output, exitCode } = await runProcess(this.spawnFn, localPath, [
+      "+login",
+      options.username,
+      options.password,
+      "+run_app_build",
+      manifestPath,
+      "+quit",
+    ]);
+
+    return parseSteamCmdOutput(output, exitCode);
+  }
+
+  private async runInDocker(options: RunSteamCmdOptions): Promise<SteamCmdParseResult> {
+    const dockerArgs = ["run", "--rm", "-v", `${options.buildDir}:/build`];
+
+    if (options.steamConfigDir) {
+      dockerArgs.push("-v", `${options.steamConfigDir}:/home/steam/Steam`);
+    }
+
+    dockerArgs.push(
+      "cm2network/steamcmd:latest",
+      "/home/steam/steamcmd/steamcmd.sh",
+      "+login",
+      options.username,
+      options.password,
+      "+run_app_build",
+      "/build/manifest.vdf",
+      "+quit",
+    );
+
+    const { output, exitCode } = await runProcess(this.spawnFn, "docker", dockerArgs);
+
+    return parseSteamCmdOutput(output, exitCode);
+  }
+}

--- a/plugins/steam-deploy/src/vdf-generator.test.ts
+++ b/plugins/steam-deploy/src/vdf-generator.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { generateAppVdf, generateDepotVdf } from "./vdf-generator";
+
+describe("generateDepotVdf", () => {
+  it("includes the depot id and default Unity-build file exclusions", () => {
+    const vdf = generateDepotVdf({ depotId: "12345" });
+
+    expect(vdf).toContain('"depotid" "12345"');
+    expect(vdf).toContain('"FileExclusion"\t"*.pdb"');
+    expect(vdf).toContain('"FileExclusion"\t"*_BurstDebugInformation_DoNotShip*"');
+    expect(vdf).toContain('"FileExclusion"\t"*_BackUpThisFolder_ButDontShipItWithYourGame*"');
+  });
+
+  it("appends extra exclusions without dropping the defaults", () => {
+    const vdf = generateDepotVdf({ depotId: "12345", extraExclusions: ["*.debug"] });
+
+    expect(vdf).toContain('"FileExclusion"\t"*.pdb"');
+    expect(vdf).toContain('"FileExclusion"\t"*.debug"');
+  });
+});
+
+describe("generateAppVdf", () => {
+  it("produces a manifest referencing the depot VDF file by name", () => {
+    const vdf = generateAppVdf({
+      appId: "999",
+      depotId: "1000",
+      branch: "beta",
+      description: "Test build",
+      depotVdfFileName: "depot_build_1000.vdf",
+    });
+
+    expect(vdf).toContain('"appid" "999"');
+    expect(vdf).toContain('"setlive" "beta"');
+    expect(vdf).toContain('"desc" "Test build"');
+    expect(vdf).toContain('"1000" "depot_build_1000.vdf"');
+  });
+});

--- a/plugins/steam-deploy/src/vdf-generator.ts
+++ b/plugins/steam-deploy/src/vdf-generator.ts
@@ -1,0 +1,67 @@
+/**
+ * Generates SteamCMD's two VDF (Valve Data Format) files: the app build
+ * manifest and a depot definition. Ported from a real, production
+ * PowerShell script (BuildVdfFiles.ps1) - the file-exclusion list in
+ * particular reflects real hard-won Unity-build knowledge (Burst debug
+ * info and backup folders that shouldn't ship to Steam).
+ */
+
+export interface DepotVdfOptions {
+  depotId: string;
+  /** Glob-style exclusion patterns, e.g. "*.pdb". Applied in addition to the built-in defaults. */
+  extraExclusions?: string[];
+}
+
+const DEFAULT_EXCLUSIONS = [
+  "*.pdb",
+  "*.log",
+  "*.vdf",
+  "*_BurstDebugInformation_DoNotShip*",
+  "*_BackUpThisFolder_ButDontShipItWithYourGame*",
+];
+
+export function generateDepotVdf(options: DepotVdfOptions): string {
+  const exclusions = [...DEFAULT_EXCLUSIONS, ...(options.extraExclusions ?? [])];
+  const exclusionLines = exclusions.map((pattern) => `    "FileExclusion"\t"${pattern}"`).join("\n");
+
+  return [
+    '"DepotBuildConfig"',
+    "{",
+    `    "depotid" "${options.depotId}"`,
+    '    "FileMapping"',
+    "    {",
+    '        "LocalPath"\t"./*"',
+    '        "DepotPath"\t"."',
+    '        "recursive"\t"1"',
+    "    }",
+    exclusionLines,
+    "}",
+  ].join("\n");
+}
+
+export interface AppVdfOptions {
+  appId: string;
+  depotId: string;
+  /** Steam branch to publish to (Steam's "setlive" field), e.g. "default", "beta". */
+  branch: string;
+  /** Human-readable build description shown in the Steam build history. */
+  description: string;
+  depotVdfFileName: string;
+}
+
+export function generateAppVdf(options: AppVdfOptions): string {
+  return [
+    '"appbuild"',
+    "{",
+    `    "appid" "${options.appId}"`,
+    `    "desc" "${options.description}"`,
+    '    "contentroot" "./"',
+    '    "buildoutput" "./"',
+    `    "setlive" "${options.branch}"`,
+    '    "depots"',
+    "    {",
+    `        "${options.depotId}" "${options.depotVdfFileName}"`,
+    "    }",
+    "}",
+  ].join("\n");
+}

--- a/plugins/steam-deploy/tsconfig.json
+++ b/plugins/steam-deploy/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "dist"]
+}

--- a/src/cli-commands.ts
+++ b/src/cli-commands.ts
@@ -1,5 +1,5 @@
-import type { YargsInstance } from './dependencies.ts';
-import { ProjectOptions } from './command-options/project-options.ts';
+import type { YargsInstance } from "./dependencies.ts";
+import { ProjectOptions } from "./command-options/project-options.ts";
 
 /**
  * Register commands
@@ -27,6 +27,7 @@ export class CliCommands {
     await this.buildImageCommand();
     await this.orchestrateCommand();
     await this.remoteCommands();
+    await this.deployCommand();
 
     // This is needed to run the engine and vcs detection middleware.
     // Their output is used to register the correct commands based on the detected engine and vcs.
@@ -34,37 +35,45 @@ export class CliCommands {
   }
 
   private async configCommand() {
-    await this.yargs.command('config', 'GameCI CLI configuration', async (yargs: YargsInstance) => {
-      yargs.command('open', 'Opens the CLI configuration folder', async (yargs: YargsInstance) => {});
+    await this.yargs.command("config", "GameCI CLI configuration", async (yargs: YargsInstance) => {
+      yargs.command("open", "Opens the CLI configuration folder", async (yargs: YargsInstance) => {});
       this.register(yargs);
     });
   }
 
   private async testCommand() {
-    await this.yargs.command('test [projectPath]', 'Runs the tests of a given project', async (yargs: YargsInstance) => {
-      ProjectOptions.preConfigure(yargs);
-      this.register(yargs);
-    });
+    await this.yargs.command(
+      "test [projectPath]",
+      "Runs the tests of a given project",
+      async (yargs: YargsInstance) => {
+        ProjectOptions.preConfigure(yargs);
+        this.register(yargs);
+      },
+    );
   }
 
   private async buildCommand() {
-    await this.yargs.command('build [projectPath]', 'Builds a given project', async (yargs: YargsInstance) => {
+    await this.yargs.command("build [projectPath]", "Builds a given project", async (yargs: YargsInstance) => {
       ProjectOptions.preConfigure(yargs);
       this.register(yargs);
     });
   }
 
   private async activateCommand() {
-    await this.yargs.command('activate [projectPath]', 'Activates a license, leaving it active for a later step', async (yargs: YargsInstance) => {
-      ProjectOptions.preConfigure(yargs);
-      this.register(yargs);
-    });
+    await this.yargs.command(
+      "activate [projectPath]",
+      "Activates a license, leaving it active for a later step",
+      async (yargs: YargsInstance) => {
+        ProjectOptions.preConfigure(yargs);
+        this.register(yargs);
+      },
+    );
   }
 
   private async buildImageCommand() {
     await this.yargs.command(
-      'build-unity-image [baseOs] [modules]',
-      'Build a Unity editor Docker image with specified modules',
+      "build-unity-image [baseOs] [modules]",
+      "Build a Unity editor Docker image with specified modules",
       async (yargs: YargsInstance) => {
         this.register(yargs);
       },
@@ -72,24 +81,42 @@ export class CliCommands {
   }
 
   private async orchestrateCommand() {
-    await this.yargs.command('orchestrate [projectPath]', 'Run an engine job through a provider plugin', async (yargs: YargsInstance) => {
-      ProjectOptions.preConfigure(yargs);
-      this.register(yargs);
-    });
+    await this.yargs.command(
+      "orchestrate [projectPath]",
+      "Run an engine job through a provider plugin",
+      async (yargs: YargsInstance) => {
+        ProjectOptions.preConfigure(yargs);
+        this.register(yargs);
+      },
+    );
+  }
+
+  private async deployCommand() {
+    // Deliberately generic - core doesn't know the names of any specific
+    // deploy targets (steam, itch, etc). <target> is resolved to a concrete
+    // command by whichever deploy plugin is loaded, via PluginRegistry's '*'
+    // engine wildcard - see CommandFactory.
+    await this.yargs.command(
+      "deploy <target> [buildPath]",
+      "Deploy a pre-built output to a distribution target",
+      async (yargs: YargsInstance) => {
+        this.register(yargs);
+      },
+    );
   }
 
   private async remoteCommands() {
-    await this.yargs.command('remote', false, async (yargs: YargsInstance) => {
+    await this.yargs.command("remote", false, async (yargs: YargsInstance) => {
       yargs
-        .command('run [projectPath]', false, async (yargs: YargsInstance) => {
+        .command("run [projectPath]", false, async (yargs: YargsInstance) => {
           ProjectOptions.preConfigure(yargs);
           this.register(yargs);
         })
-        .command('build [projectPath]', false, async (yargs: YargsInstance) => {
+        .command("build [projectPath]", false, async (yargs: YargsInstance) => {
           ProjectOptions.preConfigure(yargs);
           this.register(yargs);
         })
-        .command('otherSubCommand', 'Other sub command', async (yargs: YargsInstance) => {
+        .command("otherSubCommand", "Other sub command", async (yargs: YargsInstance) => {
           // Todo - implement all subcommands
           ProjectOptions.preConfigure(yargs);
           this.register(yargs);

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -43,6 +43,19 @@ describe("Cli plugin loading", () => {
     expect(PluginRegistry.getRegisteredPlugins().some((plugin) => plugin.name === "orchestrator")).toBe(true);
   });
 
+  it("loads steam-deploy through PluginLoader and resolves `deploy steam` without engine detection", async () => {
+    const cli = new Cli([], process.cwd());
+
+    await cli.setup();
+
+    expect(PluginRegistry.getRegisteredPlugins().some((plugin) => plugin.name === "steam-deploy")).toBe(true);
+
+    // No engine detected (Engine.unknown) - deploy must resolve via the '*'
+    // wildcard bypass in CommandFactory, not the normal engine-scoped path.
+    const command = new CommandFactory().createCommand(["deploy", "steam"]);
+    expect(command.name).toBe("Deploy steam");
+  });
+
   it("loads executable plugins from config during setup", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "game-ci-cli-"));
     try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,6 +70,7 @@ export class Cli {
     // (@game-ci/orchestrator/cli-plugin), never a relative path into its
     // src/ tree.
     await PluginLoader.load("@game-ci/orchestrator/cli-plugin");
+    await PluginLoader.load("@game-ci/steam-deploy");
 
     const options = await this.getPreCommandOptions();
     const pluginSources = this.getPluginSources(options);
@@ -251,9 +252,15 @@ export class Cli {
   }
 
   private registerCommand(args: YargsArguments) {
-    const { engine, engineVersion, _: command } = args;
+    const { engine, engineVersion, _: command, target } = args;
     const commandCast = command as string[];
-    this.command = new CommandFactory().selectEngine(engine, engineVersion).createCommand(commandCast);
+    // `deploy <target> [buildPath]`'s <target> is a named yargs positional
+    // (e.g. args.target === 'steam'), not part of `_` - yargs only puts
+    // bare, undeclared trailing tokens into `_`. Fold it back in so
+    // CommandFactory's [command, ...subCommands] dispatch still sees it as
+    // subCommands[0], exactly as if it actually were the second `_` entry.
+    const fullCommand = target ? [...commandCast, target as string] : commandCast;
+    this.command = new CommandFactory().selectEngine(engine, engineVersion).createCommand(fullCommand);
   }
 
   protected async finalParse() {

--- a/src/command/command-factory.ts
+++ b/src/command/command-factory.ts
@@ -1,9 +1,9 @@
-import { NonExistentCommand } from './null/non-existent-command.ts';
-import { CommandInterface } from './command-interface.ts';
-import { Engine } from '../model/engine/engine.ts';
-import { OpenConfigFolderCommand } from './config/open-config-folder-command.ts';
-import { BuildImageCommand } from './build-image/build-image-command.ts';
-import { PluginRegistry } from '../plugin/plugin-registry.ts';
+import { NonExistentCommand } from "./null/non-existent-command.ts";
+import { CommandInterface } from "./command-interface.ts";
+import { Engine } from "../model/engine/engine.ts";
+import { OpenConfigFolderCommand } from "./config/open-config-folder-command.ts";
+import { BuildImageCommand } from "./build-image/build-image-command.ts";
+import { PluginRegistry } from "../plugin/plugin-registry.ts";
 
 export class CommandFactory {
   private engine: string = Engine.unknown;
@@ -22,17 +22,31 @@ export class CommandFactory {
     // Structure looks like:  _: [ "build" ], or _: [ "config", "open" ]
     const [command, ...subCommands] = commandArray;
 
-    if (command === 'config') {
+    if (command === "config") {
       return this.createConfigCommand(command, subCommands);
     }
 
     // build-unity-image doesn't require engine detection
-    if (command === 'build-unity-image') {
+    if (command === "build-unity-image") {
       return new BuildImageCommand(command);
     }
 
+    // deploy doesn't require engine detection either - it operates on a
+    // pre-built output folder (e.g. `game-ci deploy steam ./build`), and
+    // that folder's contents don't carry any Unity/Godot/Unreal project
+    // markers for detectEngine() to find. Dispatched via the '*' engine
+    // wildcard in PluginRegistry.createCommand.
+    if (command === "deploy") {
+      const pluginCommand = PluginRegistry.createCommand("*", command, subCommands);
+      if (pluginCommand) {
+        return pluginCommand;
+      }
+
+      return new NonExistentCommand([command, ...subCommands].join(" "));
+    }
+
     if (this.engine === Engine.unknown) {
-      throw new Error('Engine not detected from projectPath');
+      throw new Error("Engine not detected from projectPath");
     }
 
     // Query the plugin registry for a command matching this engine
@@ -46,10 +60,10 @@ export class CommandFactory {
 
   private createConfigCommand(command: string, subCommands: string[]) {
     switch (subCommands[0]) {
-      case 'open':
+      case "open":
         return new OpenConfigFolderCommand(command);
       default:
-        return new NonExistentCommand([command, ...subCommands].join(' '));
+        return new NonExistentCommand([command, ...subCommands].join(" "));
     }
   }
 }

--- a/src/plugin/plugin-registry.ts
+++ b/src/plugin/plugin-registry.ts
@@ -4,11 +4,11 @@ import type {
   CommandPlugin,
   OptionsPlugin,
   ProviderPlugin,
-} from './plugin-interface.ts';
-import type { YargsInstance } from '../dependencies.ts';
-import { CommandInterface } from '../command/command-interface.ts';
+} from "./plugin-interface.ts";
+import type { YargsInstance } from "../dependencies.ts";
+import { CommandInterface } from "../command/command-interface.ts";
 
-const globalLogger = typeof globalThis !== 'undefined' && 'log' in globalThis ? (globalThis as any).log : undefined;
+const globalLogger = typeof globalThis !== "undefined" && "log" in globalThis ? (globalThis as any).log : undefined;
 
 /**
  * Central plugin registry.
@@ -52,7 +52,7 @@ export class PluginRegistry {
       await plugin.onLoad();
     }
 
-    globalLogger?.info?.(`Plugin registered: ${plugin.name}${plugin.version ? ` v${plugin.version}` : ''}`);
+    globalLogger?.info?.(`Plugin registered: ${plugin.name}${plugin.version ? ` v${plugin.version}` : ""}`);
   }
 
   /**
@@ -80,21 +80,32 @@ export class PluginRegistry {
   static detectEngine(projectPath: string): { engine: string; engineVersion: string } {
     for (const detector of PluginRegistry.engineDetectors) {
       const result = detector.detect(projectPath);
-      if (result && result.engine !== 'unknown') {
+      if (result && result.engine !== "unknown") {
         return result;
       }
     }
 
-    return { engine: 'unknown', engineVersion: 'unknown' };
+    return { engine: "unknown", engineVersion: "unknown" };
   }
 
   /**
    * Create a command for the given engine. Queries registered command plugins
-   * for the engine, returning the first match.
+   * for the engine, returning the first match. Plugins registered with
+   * engine '*' are engine-agnostic (e.g. deploy commands, which apply to a
+   * pre-built output folder regardless of which engine produced it) and are
+   * checked after exact-engine matches, mirroring configureOptions' existing
+   * '*' handling for options plugins.
    */
   static createCommand(engine: string, command: string, subCommands: string[]): CommandInterface | null {
     for (const plugin of PluginRegistry.commandPlugins) {
       if (plugin.engine === engine) {
+        const cmd = plugin.createCommand(command, subCommands);
+        if (cmd) return cmd;
+      }
+    }
+
+    for (const plugin of PluginRegistry.commandPlugins) {
+      if (plugin.engine === "*") {
         const cmd = plugin.createCommand(command, subCommands);
         if (cmd) return cmd;
       }
@@ -108,7 +119,7 @@ export class PluginRegistry {
    */
   static async configureOptions(engine: string, yargs: YargsInstance): Promise<void> {
     for (const plugin of PluginRegistry.optionsPlugins) {
-      if (plugin.engine === engine || plugin.engine === '*') {
+      if (plugin.engine === engine || plugin.engine === "*") {
         await plugin.configure(yargs);
       }
     }


### PR DESCRIPTION
## Summary

New `plugins/steam-deploy` package: `game-ci deploy steam <buildPath> --appId --depotId [--branch] [--mode] [--steamCmdPath] [--steamConfigDir] [--extraExclusions]`.

Thin-wrapper-migrated from a real, production Steam deployment action, not reimplemented from scratch. Only the genuinely portable Steam-domain logic was ported; everything gameclient-private was deliberately excluded.

**Ported** (real Steam-domain logic, generically useful to any studio):
- VDF generation (app build manifest + depot definition), including the file-exclusion list reflecting real hard-won Unity-build knowledge (Burst debug info, backup folders that shouldn't ship).
- Local-vs-Docker steamcmd execution, with Steam config dir mounting for auth persistence in Docker mode.
- SteamCMD's output-parsing success/failure heuristic: exit code alone isn't reliable (a dropped connection or depot failure can still exit 0), so this reads `"Successfully finished"` / BuildID / known error signatures from the actual output text, exactly as the production script does.

**Deliberately NOT ported** (gameclient-private, doesn't belong in an open-source plugin):
- Project-name auto-detection from path string matching and hardcoded per-project Steam AppIDs.
- `ProfileLoader.ps1`/`frameworks.yml` integration.
- A custom git-checkout-with-broker-token fallback (unrelated to Steam deployment anyway).
- A step posting build metadata to a private internal dashboard.
- Hardcoded drive-letter/folder-convention build-path discovery — replaced with an explicit `--buildPath` argument.

`STEAM_USERNAME`/`STEAM_PASSWORD` are read from environment only, never CLI arguments (argv can leak through process listings).

## Plugin system changes

`deploy` is the first command with no associated engine, which needed two small, generic extensions:

- `PluginRegistry.createCommand` now checks command plugins registered with `engine: '*'` after exact-engine matches, mirroring `configureOptions`' existing `'*'` handling for options plugins.
- `CommandFactory` special-cases `deploy` to skip engine detection entirely (same pattern already used for `build-unity-image`) — a deploy target's contents don't carry Unity/Godot/Unreal project markers for `detectEngine()` to find.
- `cli.ts`'s `registerCommand` middleware folds yargs' named `target` positional (from `deploy <target> [buildPath]`) back into the command array passed to `CommandFactory`, since yargs only puts *undeclared* trailing tokens into `_` — a named positional never lands there. Caught via a real functional smoke test, not just types/unit tests: `deploy steam <path> --appId=... --depotId=...` initially failed with `"Unknown arguments: appId, depotId"` because `configureOptions` was silently never reached; fixed, then reverified end-to-end.

`steam-deploy` is loaded exactly like orchestrator — via `PluginLoader.load('@game-ci/steam-deploy')`, never a static import — matching the app/plugin boundary fixed in #121, not repeating that mistake for a second plugin.

## Verification

- `tsc --noEmit`: 737 errors, matching baseline exactly (confirmed via `git stash -u` comparison, correctly including the new untracked plugin directory in the baseline).
- `plugins/steam-deploy`'s own `tsc --noEmit`: clean.
- `bun test ./src`: 202 pass, 0 fail (was 199 before this PR), including a new integration test confirming steam-deploy loads via `PluginLoader` and `deploy steam` resolves without engine detection.
- `plugins/steam-deploy`'s own vitest: 9/9 pass (VDF generation, SteamCMD output-parsing heuristic — the pure, most reusable, most valuable logic from the original script).
- `bun run build`: succeeds.
- **Real functional smoke test end-to-end**: ran `deploy steam /tmp/fake-build --appId=123 --depotId=456 --mode=local` with `STEAM_USERNAME`/`STEAM_PASSWORD` set — VDF files were written with correct absolute content-root paths, and it failed at exactly the expected final step (no steamcmd binary installed on this dev machine), proving the whole chain (yargs registration → option parsing → command dispatch → VDF generation → steamcmd invocation attempt) works.
- `oxfmt --check`: clean.

## Test plan

- [x] New unit tests: VDF generation (depot exclusions, app manifest fields)
- [x] New unit tests: SteamCMD output-parsing heuristic (success confirmation, silent-success-via-exit-0, connection-dropped, depot-build-failure, missing-chunks, unknown-failure fallback)
- [x] New integration test: plugin loads via `PluginLoader`, `deploy steam` resolves without engine detection
- [x] Real end-to-end functional smoke test (see above)
- [x] `tsc --noEmit` / `oxfmt --check` clean
- [x] `bun test ./src` passes
- [x] `bun run build` succeeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Steam deployment support through a new `deploy steam` command.
  * Supports local, Docker, and automatic SteamCMD execution modes.
  * Generates Steam app and depot configurations, validates credentials and build paths, and reports deployment results with BuildID details.
  * Added options for Steam IDs, branches, descriptions, configuration paths, executable locations, and file exclusions.
* **Tests**
  * Added coverage for deployment configuration generation, SteamCMD result parsing, and CLI plugin registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->