### PR TITLE
draft: @game-ci/rpg-maker plugin (structural skeleton)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -69,6 +69,15 @@
         "vitest": "^4",
       },
     },
+    "plugins/rpg-maker": {
+      "name": "@game-ci/rpg-maker",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^17.0.23",
+        "typescript": "4.7.4",
+        "vitest": "^4",
+      },
+    },
     "plugins/steam-deploy": {
       "name": "@game-ci/steam-deploy",
       "version": "0.1.0",
@@ -338,6 +347,8 @@
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@game-ci/orchestrator": ["@game-ci/orchestrator@workspace:plugins/orchestrator"],
+
+    "@game-ci/rpg-maker": ["@game-ci/rpg-maker@workspace:plugins/rpg-maker"],
 
     "@game-ci/steam-deploy": ["@game-ci/steam-deploy@workspace:plugins/steam-deploy"],
 
@@ -1566,6 +1577,8 @@
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@game-ci/orchestrator/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
+
+    "@game-ci/rpg-maker/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 
     "@game-ci/steam-deploy/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 

--- a/plugins/rpg-maker/README.md
+++ b/plugins/rpg-maker/README.md
@@ -1,0 +1,30 @@
+# @game-ci/rpg-maker (draft)
+
+RPG Maker (MV/MZ) engine plugin. **Not functional yet** - structural skeleton
+only. Not wired into core's default load list; loadable via
+`--plugin @game-ci/rpg-maker` once it's real.
+
+## Why RPG Maker
+
+Large, passionate, completely unserved niche today - no official build CLI
+exists (export is a manual Editor step), and the community currently
+hand-rolls fragile packaging scripts around NW.js. Real automation pain,
+genuinely underserved.
+
+## What's real vs. TODO
+
+- Plugin registration shape: real, follows the same pattern as
+  `godot-plugin.ts`.
+- Project detection: stubbed, returns `false` unconditionally.
+- Build command: throws immediately, pointing here.
+
+## Remaining work before this is real
+
+1. Verify MV vs MZ project detection (data/System.json plus MV's `www/` or
+   MZ's `js/` folder) against real project exports from both versions.
+2. Work out the actual NW.js packaging steps per target platform - this is
+   the fiddliest part, since there's no official CLI to shell out to; the
+   plugin likely needs to assemble the NW.js runtime + game data itself.
+3. Decide how platform-specific packaging (Windows/Mac/Linux NW.js
+   binaries) maps onto `targetPlatform`.
+4. Tests once the above is real.

--- a/plugins/rpg-maker/package.json
+++ b/plugins/rpg-maker/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@game-ci/rpg-maker",
+  "version": "0.0.1",
+  "description": "RPG Maker engine plugin (draft). Wraps RPG Maker MV/MZ's NW.js export packaging.",
+  "license": "MIT",
+  "repository": "git@github.com:game-ci/cli.git",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.23",
+    "typescript": "4.7.4",
+    "vitest": "^4"
+  },
+  "engines": {
+    "node": ">=18.x"
+  }
+}

--- a/plugins/rpg-maker/src/index.ts
+++ b/plugins/rpg-maker/src/index.ts
@@ -1,0 +1,51 @@
+/**
+ * RPG Maker (MV/MZ) engine plugin - DRAFT.
+ *
+ * Plan: detect an RPG Maker project via its data folder structure
+ * (data/System.json plus a www/ or js/ folder, depending on MV vs MZ),
+ * and build by packaging the project through NW.js per-platform, since
+ * RPG Maker has no official build CLI of its own - export is normally a
+ * manual Editor step. This is the fiddliest of the new engine plugins and
+ * needs real verification against the actual NW.js packaging structure
+ * before it's functional.
+ */
+
+function isRpgMakerProject(_projectPath: string): boolean {
+  // TODO: check for data/System.json plus MV's www/ or MZ's js/ folder.
+  return false;
+}
+
+export const rpgMakerPlugin = {
+  name: "rpg-maker",
+  version: "0.0.1",
+
+  engineDetectors: [
+    {
+      name: "rpg-maker",
+      detect(projectPath: string) {
+        if (isRpgMakerProject(projectPath)) {
+          // TODO: distinguish MV vs MZ, and read the actual RPG Maker version.
+          return { engine: "rpg-maker", engineVersion: "unknown" };
+        }
+        return null;
+      },
+    },
+  ],
+
+  commands: [
+    {
+      engine: "rpg-maker",
+      createCommand(command: string, _subCommands: string[]) {
+        if (command === "build") {
+          throw new Error(
+            "RPG Maker build support is not implemented yet (draft plugin). " +
+              "See plugins/rpg-maker/README.md for the planned NW.js packaging approach.",
+          );
+        }
+        return null;
+      },
+    },
+  ],
+};
+
+export default rpgMakerPlugin;

--- a/plugins/rpg-maker/tsconfig.json
+++ b/plugins/rpg-maker/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "dist"]
+}


### PR DESCRIPTION
Structural skeleton for an RPG Maker (MV/MZ) engine plugin. **Not functional yet.** RPG Maker has no official build CLI (export is a manual Editor step), making this the fiddliest of the new engine plugins - detection and NW.js packaging logic are documented TODOs. Not wired into core's default load list.

See `plugins/rpg-maker/README.md` for what's real vs. TODO.