### PR TITLE
draft: @game-ci/renpy plugin (structural skeleton)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -69,6 +69,15 @@
         "vitest": "^4",
       },
     },
+    "plugins/renpy": {
+      "name": "@game-ci/renpy",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^17.0.23",
+        "typescript": "4.7.4",
+        "vitest": "^4",
+      },
+    },
     "plugins/steam-deploy": {
       "name": "@game-ci/steam-deploy",
       "version": "0.1.0",
@@ -338,6 +347,8 @@
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@game-ci/orchestrator": ["@game-ci/orchestrator@workspace:plugins/orchestrator"],
+
+    "@game-ci/renpy": ["@game-ci/renpy@workspace:plugins/renpy"],
 
     "@game-ci/steam-deploy": ["@game-ci/steam-deploy@workspace:plugins/steam-deploy"],
 
@@ -1566,6 +1577,8 @@
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@game-ci/orchestrator/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
+
+    "@game-ci/renpy/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 
     "@game-ci/steam-deploy/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 

--- a/plugins/renpy/README.md
+++ b/plugins/renpy/README.md
@@ -1,0 +1,26 @@
+# @game-ci/renpy (draft)
+
+Ren'Py engine plugin. **Not functional yet** - structural skeleton only.
+Not wired into core's default load list; loadable via `--plugin
+@game-ci/renpy` once real.
+
+## Why Ren'Py
+
+Passionate, completely unserved visual-novel niche. Unlike RPG Maker,
+Ren'Py does ship a real CLI (`renpy.exe <project> distribute`), so this
+should be more tractable than RPG Maker once verified.
+
+## What's real vs. TODO
+
+- Plugin registration shape: real, follows the `godot-plugin.ts` pattern.
+- Project detection: stubbed, returns `false` unconditionally.
+- Build command: throws immediately, pointing here.
+
+## Remaining work before this is real
+
+1. Verify the exact `renpy.exe <project> distribute` flags and output
+   archive structure against a real Ren'Py SDK install.
+2. Map Ren'Py's own platform packaging options onto `targetPlatform`.
+3. Decide Docker story - is there a viable Ren'Py SDK container image, or
+   does this need a `--customImage` requirement like Unreal?
+4. Tests once the above is real.

--- a/plugins/renpy/package.json
+++ b/plugins/renpy/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@game-ci/renpy",
+  "version": "0.0.1",
+  "description": "Ren'Py engine plugin (draft). Wraps Ren'Py's distribute command for cross-platform archive builds.",
+  "license": "MIT",
+  "repository": "git@github.com:game-ci/cli.git",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.23",
+    "typescript": "4.7.4",
+    "vitest": "^4"
+  },
+  "engines": {
+    "node": ">=18.x"
+  }
+}

--- a/plugins/renpy/src/index.ts
+++ b/plugins/renpy/src/index.ts
@@ -1,0 +1,49 @@
+/**
+ * Ren'Py engine plugin - DRAFT.
+ *
+ * Plan: detect a Ren'Py project via its game/ folder plus a game/*.rpy
+ * script, and build via Ren'Py's own `renpy.exe <project> distribute`
+ * command (a real CLI Ren'Py ships), which produces per-platform
+ * distribution archives. Needs verification against Ren'Py's actual
+ * distribute output structure before this is functional.
+ */
+
+function isRenpyProject(_projectPath: string): boolean {
+  // TODO: check for a game/ folder containing at least one *.rpy file.
+  return false;
+}
+
+export const renpyPlugin = {
+  name: "renpy",
+  version: "0.0.1",
+
+  engineDetectors: [
+    {
+      name: "renpy",
+      detect(projectPath: string) {
+        if (isRenpyProject(projectPath)) {
+          // TODO: read the actual Ren'Py SDK version this project was built with.
+          return { engine: "renpy", engineVersion: "unknown" };
+        }
+        return null;
+      },
+    },
+  ],
+
+  commands: [
+    {
+      engine: "renpy",
+      createCommand(command: string, _subCommands: string[]) {
+        if (command === "build") {
+          throw new Error(
+            "Ren'Py build support is not implemented yet (draft plugin). " +
+              "See plugins/renpy/README.md for the planned `renpy.exe distribute` invocation.",
+          );
+        }
+        return null;
+      },
+    },
+  ],
+};
+
+export default renpyPlugin;

--- a/plugins/renpy/tsconfig.json
+++ b/plugins/renpy/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "dist"]
+}


### PR DESCRIPTION
Structural skeleton for a Ren'Py engine plugin. **Not functional yet.** Ren'Py does ship a real CLI (`renpy.exe <project> distribute`), so this should be more tractable than RPG Maker once its exact invocation shape is verified. Not wired into core's default load list.

See `plugins/renpy/README.md` for what's real vs. TODO.