### PR TITLE
draft: @game-ci/itch-deploy plugin (structural skeleton)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,15 @@
         "typescript": "^5.3.3",
       },
     },
+    "plugins/itch-deploy": {
+      "name": "@game-ci/itch-deploy",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^17.0.23",
+        "typescript": "4.7.4",
+        "vitest": "^4",
+      },
+    },
     "plugins/orchestrator": {
       "name": "@game-ci/orchestrator",
       "version": "1.0.0",
@@ -336,6 +345,8 @@
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
 
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
+
+    "@game-ci/itch-deploy": ["@game-ci/itch-deploy@workspace:plugins/itch-deploy"],
 
     "@game-ci/orchestrator": ["@game-ci/orchestrator@workspace:plugins/orchestrator"],
 
@@ -1564,6 +1575,8 @@
     "@deno/shim-deno/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@game-ci/itch-deploy/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 
     "@game-ci/orchestrator/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 

--- a/plugins/itch-deploy/README.md
+++ b/plugins/itch-deploy/README.md
@@ -1,0 +1,34 @@
+# @game-ci/itch-deploy (draft)
+
+itch.io deploy plugin. **Not functional yet** - structural skeleton only.
+Mirrors `@game-ci/steam-deploy`'s shape: engine-agnostic, dispatched via
+the `deploy` command's `'*'` engine wildcard. Not wired into core's
+default load list.
+
+## Why itch.io
+
+Huge game-jam/indie audience, currently all ad hoc third-party GitHub
+Actions. itch.io's official `butler` CLI is straightforward, so this
+should be one of the faster ones to bring to real functionality once
+someone picks it up.
+
+## What's real vs. TODO
+
+- Plugin/command registration shape: real, mirrors `steam-deploy`'s
+  `deploy <target>` dispatch.
+- `execute()`: throws immediately, pointing here.
+
+## Remaining work before this is real
+
+1. Wrap `butler push <buildPath> <user>/<game>:<channel>`, including
+   butler's own login/credential handling (an API key, likely via
+   `BUTLER_API_KEY` env var, matching steam-deploy's env-var-only
+   credential convention - never CLI args).
+2. Decide how `game-ci deploy itch` needs core's `deploy <target>
+[buildPath]` yargs registration extended, if at all (steam-deploy
+   already required a core change here - see game-ci/cli#123 - itch may
+   reuse it as-is once its own options are registered via
+   `configureOptions`).
+3. Tests mirroring `steam-deploy`'s `parse-steamcmd-output.test.ts` and
+   `vdf-generator.test.ts` pattern - butler's own output has a similar
+   "did this actually succeed" ambiguity worth checking.

--- a/plugins/itch-deploy/package.json
+++ b/plugins/itch-deploy/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@game-ci/itch-deploy",
+  "version": "0.0.1",
+  "description": "itch.io deploy plugin (draft). Wraps butler push for itch.io channel deploys.",
+  "license": "MIT",
+  "repository": "git@github.com:game-ci/cli.git",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.23",
+    "typescript": "4.7.4",
+    "vitest": "^4"
+  },
+  "engines": {
+    "node": ">=18.x"
+  }
+}

--- a/plugins/itch-deploy/src/index.ts
+++ b/plugins/itch-deploy/src/index.ts
@@ -1,0 +1,41 @@
+/**
+ * itch.io deploy plugin - DRAFT.
+ *
+ * Plan: `game-ci deploy itch <buildPath> --user --game --channel`,
+ * wrapping itch.io's official `butler push` CLI. Structurally identical
+ * to @game-ci/steam-deploy (engine-agnostic, dispatched via the '*'
+ * engine wildcard on the `deploy` command) - butler's actual invocation
+ * shape and channel-naming conventions need verification before this is
+ * functional.
+ */
+
+export const itchDeployPlugin = {
+  name: "itch-deploy",
+  version: "0.0.1",
+
+  commands: [
+    {
+      engine: "*",
+      createCommand(command: string, subCommands: string[]) {
+        if (command === "deploy" && subCommands[0] === "itch") {
+          return {
+            name: "Deploy itch",
+            async configureOptions() {
+              // TODO: register --user, --game, --channel options, matching
+              // butler's <user>/<game>:<channel> target format.
+            },
+            async execute(): Promise<boolean> {
+              throw new Error(
+                "itch.io deploy is not implemented yet (draft plugin). " +
+                  "See plugins/itch-deploy/README.md for the planned `butler push` invocation.",
+              );
+            },
+          };
+        }
+        return null;
+      },
+    },
+  ],
+};
+
+export default itchDeployPlugin;

--- a/plugins/itch-deploy/tsconfig.json
+++ b/plugins/itch-deploy/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "dist"]
+}


### PR DESCRIPTION
Structural skeleton for an itch.io deploy plugin (`game-ci deploy itch`), mirroring `@game-ci/steam-deploy`'s shape exactly (engine-agnostic, dispatched via the `deploy` command's `'*'` engine wildcard). **Not functional yet** - `execute()` throws, pointing to the README. Should be one of the faster ones to bring to real functionality, since itch.io's `butler` CLI is straightforward.

See `plugins/itch-deploy/README.md` for what's real vs. TODO.