### PR TITLE
draft: @game-ci/crash-symbol-upload plugin (structural skeleton)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,15 @@
         "typescript": "^5.3.3",
       },
     },
+    "plugins/crash-symbol-upload": {
+      "name": "@game-ci/crash-symbol-upload",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^17.0.23",
+        "typescript": "4.7.4",
+        "vitest": "^4",
+      },
+    },
     "plugins/orchestrator": {
       "name": "@game-ci/orchestrator",
       "version": "1.0.0",
@@ -336,6 +345,8 @@
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
 
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
+
+    "@game-ci/crash-symbol-upload": ["@game-ci/crash-symbol-upload@workspace:plugins/crash-symbol-upload"],
 
     "@game-ci/orchestrator": ["@game-ci/orchestrator@workspace:plugins/orchestrator"],
 
@@ -1564,6 +1575,8 @@
     "@deno/shim-deno/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@game-ci/crash-symbol-upload/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 
     "@game-ci/orchestrator/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 

--- a/plugins/crash-symbol-upload/README.md
+++ b/plugins/crash-symbol-upload/README.md
@@ -1,0 +1,21 @@
+# @game-ci/crash-symbol-upload (draft)
+
+Uploads platform-specific debug symbols (dSYM, PDB, breakpad `.sym`) to a
+crash-reporting service post-build, so production crash stack traces can
+be symbolicated. **Not functional yet**, and its `upload-symbols` command
+is not yet registered anywhere in core's CLI - a follow-up core PR is
+needed before this can be invoked at all, even once the logic is real.
+
+## Remaining work before this is real
+
+1. Add `upload-symbols <buildPath>` to core's `CliCommands` (see how
+   game-ci/cli#123 added `deploy` for the precedent/gotchas - yargs
+   positional-vs-`_` handling in particular).
+2. Symbol-format detection per platform (dSYM on macOS/iOS, PDB on
+   Windows, breakpad `.sym` elsewhere) and the actual upload API for at
+   least one real service (Sentry's CLI/API is the most likely first
+   target - it's well-documented and has an existing `sentry-cli`
+   reference implementation to verify against).
+3. Auth token via environment variable only, matching steam-deploy's
+   credential convention.
+4. Tests once the above is real.

--- a/plugins/crash-symbol-upload/package.json
+++ b/plugins/crash-symbol-upload/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@game-ci/crash-symbol-upload",
+  "version": "0.0.1",
+  "description": "Crash-symbol upload plugin (draft). Uploads dSYM/PDB debug symbols to a crash-reporting service (Sentry/Backtrace-style) after a build.",
+  "license": "MIT",
+  "repository": "git@github.com:game-ci/cli.git",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.23",
+    "typescript": "4.7.4",
+    "vitest": "^4"
+  },
+  "engines": {
+    "node": ">=18.x"
+  }
+}

--- a/plugins/crash-symbol-upload/src/index.ts
+++ b/plugins/crash-symbol-upload/src/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Crash-symbol upload plugin - DRAFT.
+ *
+ * Plan: `game-ci upload-symbols <buildPath> --service=sentry|backtrace
+ * --project --authToken`, uploading platform-specific debug symbols
+ * (dSYM on macOS/iOS, PDB on Windows, breakpad .sym elsewhere) so a
+ * crash-reporting service can symbolicate stack traces from production
+ * crashes. Engine-agnostic, same '*' wildcard shape as deploy plugins.
+ *
+ * NOTE: `upload-symbols` is not yet registered as a core CLI command
+ * (unlike `deploy`, which game-ci/cli#123 added) - this plugin cannot
+ * actually be invoked yet even once its logic is implemented, without a
+ * follow-up core change adding that yargs command registration.
+ */
+
+export const crashSymbolUploadPlugin = {
+  name: "crash-symbol-upload",
+  version: "0.0.1",
+
+  commands: [
+    {
+      engine: "*",
+      createCommand(command: string, _subCommands: string[]) {
+        if (command === "upload-symbols") {
+          return {
+            name: "Upload symbols",
+            async configureOptions() {
+              // TODO: register --service, --project, --authToken (env-var preferred for the token).
+            },
+            async execute(): Promise<boolean> {
+              throw new Error(
+                "Crash-symbol upload is not implemented yet (draft plugin), and `upload-symbols` " +
+                  "is not yet registered as a core command either. See plugins/crash-symbol-upload/README.md.",
+              );
+            },
+          };
+        }
+        return null;
+      },
+    },
+  ],
+};
+
+export default crashSymbolUploadPlugin;

--- a/plugins/crash-symbol-upload/tsconfig.json
+++ b/plugins/crash-symbol-upload/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "dist"]
+}


### PR DESCRIPTION
Structural skeleton for a crash-symbol upload plugin (Sentry/Backtrace-style dSYM/PDB upload after a build, so production crashes can be symbolicated). **Not functional yet**, and `upload-symbols` is not yet registered as a core CLI command either - a follow-up core PR is needed before this can even be invoked, following the precedent/gotchas from #123's `deploy` addition.

See `plugins/crash-symbol-upload/README.md` for what's real vs. TODO.