### PR TITLE
draft: @game-ci/screen-capture plugin (structural skeleton, GPU-required)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -69,6 +69,15 @@
         "vitest": "^4",
       },
     },
+    "plugins/screen-capture": {
+      "name": "@game-ci/screen-capture",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^17.0.23",
+        "typescript": "4.7.4",
+        "vitest": "^4",
+      },
+    },
     "plugins/steam-deploy": {
       "name": "@game-ci/steam-deploy",
       "version": "0.1.0",
@@ -338,6 +347,8 @@
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@game-ci/orchestrator": ["@game-ci/orchestrator@workspace:plugins/orchestrator"],
+
+    "@game-ci/screen-capture": ["@game-ci/screen-capture@workspace:plugins/screen-capture"],
 
     "@game-ci/steam-deploy": ["@game-ci/steam-deploy@workspace:plugins/steam-deploy"],
 
@@ -1566,6 +1577,8 @@
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@game-ci/orchestrator/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
+
+    "@game-ci/screen-capture/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 
     "@game-ci/steam-deploy/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 

--- a/plugins/screen-capture/README.md
+++ b/plugins/screen-capture/README.md
@@ -1,0 +1,22 @@
+# @game-ci/screen-capture (draft, GPU-required)
+
+Baseline-vs-current frame diffing and QA evidence capture. **Not
+functional yet**, and `capture` is not yet registered anywhere in core's
+CLI. Requires a GPU-capable runner - unlike most plugins in this batch.
+
+## Why this, distinct from marketing screenshots
+
+Deliberately separate concern from a store-screenshot/marketing-asset
+plugin: this is about catching visual regressions with orphan-process
+cleanup and baseline comparison, not generating polished store assets.
+
+## Remaining work before this is real
+
+1. Add `capture <buildPath>` to core's `CliCommands`.
+2. Define capture checkpoints - how does a game project mark "capture a
+   frame here" (likely an in-game hook similar to
+   runtime-test-framework's harness)?
+3. Baseline storage/diffing strategy (perceptual diff threshold, not
+   exact-pixel-match, to tolerate benign renderer/driver noise).
+4. Orphaned-capture-process cleanup for killed/crashed runs.
+5. Tests once the above is real.

--- a/plugins/screen-capture/package.json
+++ b/plugins/screen-capture/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@game-ci/screen-capture",
+  "version": "0.0.1",
+  "description": "Screen Capture and Visual Regression plugin (draft, GPU-required). Baseline-vs-current frame diffing and QA evidence capture, distinct from marketing-asset generation.",
+  "license": "MIT",
+  "repository": "git@github.com:game-ci/cli.git",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.23",
+    "typescript": "4.7.4",
+    "vitest": "^4"
+  },
+  "engines": {
+    "node": ">=18.x"
+  }
+}

--- a/plugins/screen-capture/src/index.ts
+++ b/plugins/screen-capture/src/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Screen Capture & Visual Regression plugin - DRAFT (GPU-required).
+ *
+ * Plan: `game-ci capture <buildPath> --baseline <dir>` launches the built
+ * player, captures screenshots/video at defined checkpoints, and diffs
+ * against a maintained baseline to catch visual regressions - QA
+ * evidence, deliberately distinct in purpose from marketing-asset
+ * screenshot generation (a different, unrelated capability). Requires a
+ * GPU-capable runner, unlike most of this batch.
+ *
+ * NOTE: `capture` is not yet registered as a core CLI command.
+ */
+
+export const screenCapturePlugin = {
+  name: "screen-capture",
+  version: "0.0.1",
+
+  commands: [
+    {
+      engine: "*",
+      createCommand(command: string, _subCommands: string[]) {
+        if (command === "capture") {
+          return {
+            name: "Screen capture",
+            async configureOptions() {
+              // TODO: register --baseline, --diffThreshold, --outputDir.
+            },
+            async execute(): Promise<boolean> {
+              throw new Error(
+                "Screen Capture & Visual Regression is not implemented yet (draft plugin), and " +
+                  "`capture` is not yet registered as a core command either. See plugins/screen-capture/README.md.",
+              );
+            },
+          };
+        }
+        return null;
+      },
+    },
+  ],
+};
+
+export default screenCapturePlugin;

--- a/plugins/screen-capture/tsconfig.json
+++ b/plugins/screen-capture/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "dist"]
+}


### PR DESCRIPTION
Structural skeleton for a screen-capture & visual-regression plugin: baseline-vs-current frame diffing for QA evidence, deliberately distinct in purpose from marketing-asset screenshot generation. **Not functional yet**, and `capture` is not yet registered as a core CLI command. Requires a GPU-capable runner, unlike most of the other drafts.

See `plugins/screen-capture/README.md` for what's real vs. TODO.