### PR TITLE
draft: @game-ci/live-show plugin (structural skeleton)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,15 @@
         "typescript": "^5.3.3",
       },
     },
+    "plugins/live-show": {
+      "name": "@game-ci/live-show",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^17.0.23",
+        "typescript": "4.7.4",
+        "vitest": "^4",
+      },
+    },
     "plugins/orchestrator": {
       "name": "@game-ci/orchestrator",
       "version": "1.0.0",
@@ -336,6 +345,8 @@
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
 
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
+
+    "@game-ci/live-show": ["@game-ci/live-show@workspace:plugins/live-show"],
 
     "@game-ci/orchestrator": ["@game-ci/orchestrator@workspace:plugins/orchestrator"],
 
@@ -1564,6 +1575,8 @@
     "@deno/shim-deno/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@game-ci/live-show/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 
     "@game-ci/orchestrator/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 

--- a/plugins/live-show/README.md
+++ b/plugins/live-show/README.md
@@ -1,0 +1,22 @@
+# @game-ci/live-show (draft)
+
+Scripted/AI-driven attract-mode playthrough that auto-restarts on crash
+and can stream output. **Not functional yet**, and `live-show` is not yet
+registered anywhere in core's CLI.
+
+## Why this
+
+Doubles as an unattended long-duration soak test - useful both for public
+demo/kiosk builds and as a crash-finding tool that just keeps running.
+
+## Remaining work before this is real
+
+1. Add `live-show <buildPath>` to core's `CliCommands`.
+2. Decide the "script" mechanism: recorded input replay (shares real
+   infrastructure with the input-replay-regression idea from the plugin
+   roadmap, if that ever gets built) vs. a genuinely AI-driven agent
+   playing live.
+3. Crash-restart supervision loop with backoff.
+4. Streaming integration (RTMP/Discord/Twitch) - likely just shelling out
+   to ffmpeg once capture is wired up.
+5. Tests once the above is real.

--- a/plugins/live-show/package.json
+++ b/plugins/live-show/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@game-ci/live-show",
+  "version": "0.0.1",
+  "description": "Live Show / Automated Demo plugin (draft). Scripted or AI-driven attract-mode playthrough that auto-restarts on crash and can stream output; doubles as an unattended soak test.",
+  "license": "MIT",
+  "repository": "git@github.com:game-ci/cli.git",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.23",
+    "typescript": "4.7.4",
+    "vitest": "^4"
+  },
+  "engines": {
+    "node": ">=18.x"
+  }
+}

--- a/plugins/live-show/src/index.ts
+++ b/plugins/live-show/src/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Live Show / Automated Demo plugin - DRAFT.
+ *
+ * Plan: `game-ci live-show <buildPath>` runs a scripted or AI-driven
+ * attract-mode playthrough on a loop, auto-restarting on crash and
+ * optionally streaming output (RTMP/Discord/Twitch). Doubles as an
+ * unattended long-duration soak test, since it's exercising the game
+ * continuously.
+ *
+ * NOTE: `live-show` is not yet registered as a core CLI command.
+ */
+
+export const liveShowPlugin = {
+  name: "live-show",
+  version: "0.0.1",
+
+  commands: [
+    {
+      engine: "*",
+      createCommand(command: string, _subCommands: string[]) {
+        if (command === "live-show") {
+          return {
+            name: "Live show",
+            async configureOptions() {
+              // TODO: register --script (input-replay/AI-driver source), --streamUrl, --restartOnCrash.
+            },
+            async execute(): Promise<boolean> {
+              throw new Error(
+                "Live Show / Automated Demo is not implemented yet (draft plugin), and `live-show` " +
+                  "is not yet registered as a core command either. See plugins/live-show/README.md.",
+              );
+            },
+          };
+        }
+        return null;
+      },
+    },
+  ],
+};
+
+export default liveShowPlugin;

--- a/plugins/live-show/tsconfig.json
+++ b/plugins/live-show/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "dist"]
+}


### PR DESCRIPTION
Structural skeleton for a live-show/automated-demo plugin: a scripted or AI-driven attract-mode playthrough that auto-restarts on crash and can optionally stream output, doubling as an unattended long-duration soak test. **Not functional yet**, and `live-show` is not yet registered as a core CLI command.

See `plugins/live-show/README.md` for what's real vs. TODO.