### PR TITLE
draft: @game-ci/dedicated-server-provisioning plugin (structural skeleton)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,15 @@
         "typescript": "^5.3.3",
       },
     },
+    "plugins/dedicated-server-provisioning": {
+      "name": "@game-ci/dedicated-server-provisioning",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^17.0.23",
+        "typescript": "4.7.4",
+        "vitest": "^4",
+      },
+    },
     "plugins/orchestrator": {
       "name": "@game-ci/orchestrator",
       "version": "1.0.0",
@@ -336,6 +345,8 @@
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
 
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
+
+    "@game-ci/dedicated-server-provisioning": ["@game-ci/dedicated-server-provisioning@workspace:plugins/dedicated-server-provisioning"],
 
     "@game-ci/orchestrator": ["@game-ci/orchestrator@workspace:plugins/orchestrator"],
 
@@ -1564,6 +1575,8 @@
     "@deno/shim-deno/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@game-ci/dedicated-server-provisioning/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 
     "@game-ci/orchestrator/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 

--- a/plugins/dedicated-server-provisioning/README.md
+++ b/plugins/dedicated-server-provisioning/README.md
@@ -1,0 +1,24 @@
+# @game-ci/dedicated-server-provisioning (draft)
+
+Generates docker-compose/systemd units, firewall/port config, and a
+health-check endpoint for self-hosters. **Not functional yet**, and
+`provision-server` is not yet registered anywhere in core's CLI.
+
+## Why this, distinct from a server-build plugin
+
+Complements rather than duplicates a build-time headless-server-packaging
+step: this is the ops/setup half - "I have a headless server binary, now
+help me actually run it" - not the build itself.
+
+## Remaining work before this is real
+
+1. Add `provision-server <buildPath>` to core's `CliCommands`.
+2. Docker-compose/systemd unit templates, parameterized by port and
+   resource limits.
+3. A minimal generic health-check endpoint the game process can expose
+   (or a TCP-connect fallback for engines that can't easily add an HTTP
+   endpoint).
+4. Optionally fold in the nginx-based routing concept from the Dev Tunnel
+   plugin's design discussion, if multiple server instances behind one
+   host is a real need.
+5. Tests once the above is real.

--- a/plugins/dedicated-server-provisioning/package.json
+++ b/plugins/dedicated-server-provisioning/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@game-ci/dedicated-server-provisioning",
+  "version": "0.0.1",
+  "description": "Dedicated Server Provisioning plugin (draft). Generates docker-compose/systemd units, firewall/port config, and a health-check endpoint for self-hosters.",
+  "license": "MIT",
+  "repository": "git@github.com:game-ci/cli.git",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.23",
+    "typescript": "4.7.4",
+    "vitest": "^4"
+  },
+  "engines": {
+    "node": ">=18.x"
+  }
+}

--- a/plugins/dedicated-server-provisioning/src/index.ts
+++ b/plugins/dedicated-server-provisioning/src/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Dedicated Server Provisioning plugin - DRAFT.
+ *
+ * Plan: `game-ci provision-server <buildPath>` generates the "stand this
+ * up" artifacts for self-hosters - docker-compose/systemd units,
+ * firewall/port config, a health-check endpoint - complementing (not
+ * duplicating) a separate dedicated-server *build* step that strips
+ * client-only assets and packages a headless binary.
+ *
+ * NOTE: `provision-server` is not yet registered as a core CLI command.
+ */
+
+export const dedicatedServerProvisioningPlugin = {
+  name: "dedicated-server-provisioning",
+  version: "0.0.1",
+
+  commands: [
+    {
+      engine: "*",
+      createCommand(command: string, _subCommands: string[]) {
+        if (command === "provision-server") {
+          return {
+            name: "Provision server",
+            async configureOptions() {
+              // TODO: register --port, --healthCheckPath, --composeOutputPath, etc.
+            },
+            async execute(): Promise<boolean> {
+              throw new Error(
+                "Dedicated Server Provisioning is not implemented yet (draft plugin), and " +
+                  "`provision-server` is not yet registered as a core command either. See plugins/dedicated-server-provisioning/README.md.",
+              );
+            },
+          };
+        }
+        return null;
+      },
+    },
+  ],
+};
+
+export default dedicatedServerProvisioningPlugin;

--- a/plugins/dedicated-server-provisioning/tsconfig.json
+++ b/plugins/dedicated-server-provisioning/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "dist"]
+}


### PR DESCRIPTION
Structural skeleton for a dedicated-server provisioning plugin: generates docker-compose/systemd units, firewall/port config, and a health-check endpoint for self-hosters - the "stand this up" ops half, complementing rather than duplicating a separate build-time server-packaging step. **Not functional yet**, and `provision-server` is not yet registered as a core CLI command.

See `plugins/dedicated-server-provisioning/README.md` for what's real vs. TODO.