### PR TITLE
draft: @game-ci/anti-cheat plugin (structural skeleton)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,15 @@
         "typescript": "^5.3.3",
       },
     },
+    "plugins/anti-cheat": {
+      "name": "@game-ci/anti-cheat",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^17.0.23",
+        "typescript": "4.7.4",
+        "vitest": "^4",
+      },
+    },
     "plugins/orchestrator": {
       "name": "@game-ci/orchestrator",
       "version": "1.0.0",
@@ -336,6 +345,8 @@
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
 
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
+
+    "@game-ci/anti-cheat": ["@game-ci/anti-cheat@workspace:plugins/anti-cheat"],
 
     "@game-ci/orchestrator": ["@game-ci/orchestrator@workspace:plugins/orchestrator"],
 
@@ -1564,6 +1575,8 @@
     "@deno/shim-deno/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@game-ci/anti-cheat/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 
     "@game-ci/orchestrator/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 

--- a/plugins/anti-cheat/README.md
+++ b/plugins/anti-cheat/README.md
@@ -1,0 +1,27 @@
+# @game-ci/anti-cheat (draft)
+
+Wraps EasyAntiCheat/BattlEye SDK integration into the build pipeline.
+**Not functional yet.** Unlike most of this batch, this is an _options_
+plugin, not a new command - anti-cheat integration happens as part of an
+existing build/orchestrate run, not as a separate verb.
+
+## Why this
+
+Real, fiddly, currently entirely hand-rolled per multiplayer studio -
+no existing game-ci coverage.
+
+## Remaining work before this is real
+
+1. Decide the actual integration point: most likely a post-build hook via
+   `plugins/orchestrator`'s existing middleware/hooks system (see its
+   `command-hooks`/`container-hooks` pattern) rather than a bespoke
+   mechanism here.
+2. EasyAntiCheat and BattlEye each have their own SDK integration steps
+   (binary signing/wrapping, game-ID registration) - needs real
+   verification against each SDK's actual documented integration process
+   before any of this is implemented, since both are commercial SDKs with
+   NDA-adjacent distribution terms worth checking first.
+3. Options surface: `--enableAntiCheat` (default off, matching game-ci's
+   convention for a real behavior change), `--antiCheatProvider`,
+   provider-specific game-ID options.
+4. Tests once the above is real.

--- a/plugins/anti-cheat/package.json
+++ b/plugins/anti-cheat/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@game-ci/anti-cheat",
+  "version": "0.0.1",
+  "description": "Anti-cheat / build-integrity plugin (draft). Wraps EasyAntiCheat/BattlEye SDK integration into the build pipeline.",
+  "license": "MIT",
+  "repository": "git@github.com:game-ci/cli.git",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.23",
+    "typescript": "4.7.4",
+    "vitest": "^4"
+  },
+  "engines": {
+    "node": ">=18.x"
+  }
+}

--- a/plugins/anti-cheat/src/index.ts
+++ b/plugins/anti-cheat/src/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Anti-cheat / build-integrity plugin - DRAFT.
+ *
+ * Plan: unlike the other plugins in this batch, this isn't a new
+ * top-level command - it's an *options* plugin (engine: '*', matching
+ * PluginRegistry.configureOptions' existing wildcard handling) that
+ * wraps EasyAntiCheat/BattlEye SDK integration into whatever build
+ * command already runs (build/orchestrate), adding options like
+ * --enableAntiCheat and --eacGameId. No command dispatch is needed here;
+ * the actual SDK integration is inherently build-process-level (signing,
+ * binary wrapping), not a separate verb.
+ */
+
+export const antiCheatPlugin = {
+  name: "anti-cheat",
+  version: "0.0.1",
+
+  options: [
+    {
+      engine: "*",
+      async configure(_yargs: unknown) {
+        // TODO: register --enableAntiCheat, --antiCheatProvider (eac|battleye),
+        // --eacGameId/--battleyeGameId, matching game-ci's convention of
+        // opt-in flags defaulting off for a real behavior change.
+      },
+    },
+  ],
+
+  // TODO: this plugin needs a real integration point into the build
+  // lifecycle (likely a post-build hook, once this plugin can register
+  // one - see plugins/orchestrator's middleware/hooks system for the
+  // existing pattern) to actually wrap the built binary with the chosen
+  // anti-cheat SDK. Throwing here documents that this isn't wired yet,
+  // rather than silently doing nothing.
+  async onLoad() {
+    console.warn(
+      "@game-ci/anti-cheat is a draft plugin - it registers options but does not yet wrap any build output. See plugins/anti-cheat/README.md.",
+    );
+  },
+};
+
+export default antiCheatPlugin;

--- a/plugins/anti-cheat/tsconfig.json
+++ b/plugins/anti-cheat/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "dist"]
+}


### PR DESCRIPTION
Structural skeleton for an anti-cheat/build-integrity plugin wrapping EasyAntiCheat/BattlEye SDK integration into the build pipeline. Unlike the other drafts in this batch, this is an **options** plugin (hooks into an existing build/orchestrate run), not a new command - anti-cheat integration is inherently build-process-level. **Not functional yet.**

See `plugins/anti-cheat/README.md` for what's real vs. TODO, including why the actual SDK integration steps need real verification before implementation (commercial, NDA-adjacent SDKs).