### PR TITLE
draft: @game-ci/pseudo-localization plugin (structural skeleton)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -69,6 +69,15 @@
         "vitest": "^4",
       },
     },
+    "plugins/pseudo-localization": {
+      "name": "@game-ci/pseudo-localization",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^17.0.23",
+        "typescript": "4.7.4",
+        "vitest": "^4",
+      },
+    },
     "plugins/steam-deploy": {
       "name": "@game-ci/steam-deploy",
       "version": "0.1.0",
@@ -338,6 +347,8 @@
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@game-ci/orchestrator": ["@game-ci/orchestrator@workspace:plugins/orchestrator"],
+
+    "@game-ci/pseudo-localization": ["@game-ci/pseudo-localization@workspace:plugins/pseudo-localization"],
 
     "@game-ci/steam-deploy": ["@game-ci/steam-deploy@workspace:plugins/steam-deploy"],
 
@@ -1566,6 +1577,8 @@
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@game-ci/orchestrator/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
+
+    "@game-ci/pseudo-localization/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 
     "@game-ci/steam-deploy/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 

--- a/plugins/pseudo-localization/README.md
+++ b/plugins/pseudo-localization/README.md
@@ -1,0 +1,22 @@
+# @game-ci/pseudo-localization (draft)
+
+Injects pseudo-loc strings pre-translation to catch UI overflow/
+truncation bugs. **Not functional yet**, and `pseudo-localize` is not yet
+registered anywhere in core's CLI.
+
+## Why this, distinct from translation sync
+
+UI _testing_, not translation management - deliberately different from a
+Crowdin/Lokalise-style sync plugin (which was considered and cut from the
+roadmap for not being game-specific enough).
+
+## Remaining work before this is real
+
+1. Add `pseudo-localize <projectPath>` to core's `CliCommands`.
+2. Pseudo-loc transform (accented characters, length expansion/padding,
+   bracket markers around each string) applied to whatever localization
+   table format the target engine uses - this is genuinely
+   engine-specific (Unity's Localization package format differs
+   completely from a flat JSON/CSV table), so the first real
+   implementation will likely need to pick one engine's format to start.
+3. Tests once the above is real.

--- a/plugins/pseudo-localization/package.json
+++ b/plugins/pseudo-localization/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@game-ci/pseudo-localization",
+  "version": "0.0.1",
+  "description": "Pseudo-localization QA plugin (draft). Injects pseudo-loc strings pre-translation to catch UI overflow/truncation bugs.",
+  "license": "MIT",
+  "repository": "git@github.com:game-ci/cli.git",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.23",
+    "typescript": "4.7.4",
+    "vitest": "^4"
+  },
+  "engines": {
+    "node": ">=18.x"
+  }
+}

--- a/plugins/pseudo-localization/src/index.ts
+++ b/plugins/pseudo-localization/src/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Pseudo-localization QA plugin - DRAFT.
+ *
+ * Plan: `game-ci pseudo-localize <projectPath>` injects pseudo-loc
+ * strings (accented/expanded characters standing in for real
+ * translations) into a project's localization tables pre-translation, so
+ * UI overflow/truncation bugs surface before real translation work ever
+ * starts. Distinct from a translation-*sync* plugin (pulling/pushing real
+ * strings to a vendor) - this is UI testing, not translation management.
+ *
+ * NOTE: `pseudo-localize` is not yet registered as a core CLI command.
+ */
+
+export const pseudoLocalizationPlugin = {
+  name: "pseudo-localization",
+  version: "0.0.1",
+
+  commands: [
+    {
+      engine: "*",
+      createCommand(command: string, _subCommands: string[]) {
+        if (command === "pseudo-localize") {
+          return {
+            name: "Pseudo-localize",
+            async configureOptions() {
+              // TODO: register --sourceLocale, --expansionFactor, --outputPath.
+            },
+            async execute(): Promise<boolean> {
+              throw new Error(
+                "Pseudo-localization QA is not implemented yet (draft plugin), and `pseudo-localize` " +
+                  "is not yet registered as a core command either. See plugins/pseudo-localization/README.md.",
+              );
+            },
+          };
+        }
+        return null;
+      },
+    },
+  ],
+};
+
+export default pseudoLocalizationPlugin;

--- a/plugins/pseudo-localization/tsconfig.json
+++ b/plugins/pseudo-localization/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "dist"]
+}


### PR DESCRIPTION
Structural skeleton for a pseudo-localization QA plugin: injects pseudo-loc strings pre-translation to catch UI overflow/truncation bugs before real translation work starts. UI *testing*, deliberately distinct from a translation-sync plugin (considered and cut from the roadmap for not being game-specific enough). **Not functional yet**, and `pseudo-localize` is not yet registered as a core CLI command.

See `plugins/pseudo-localization/README.md` for what's real vs. TODO.