### PR TITLE
draft: @game-ci/save-data-compat plugin (structural skeleton)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -69,6 +69,15 @@
         "vitest": "^4",
       },
     },
+    "plugins/save-data-compat": {
+      "name": "@game-ci/save-data-compat",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^17.0.23",
+        "typescript": "4.7.4",
+        "vitest": "^4",
+      },
+    },
     "plugins/steam-deploy": {
       "name": "@game-ci/steam-deploy",
       "version": "0.1.0",
@@ -338,6 +347,8 @@
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@game-ci/orchestrator": ["@game-ci/orchestrator@workspace:plugins/orchestrator"],
+
+    "@game-ci/save-data-compat": ["@game-ci/save-data-compat@workspace:plugins/save-data-compat"],
 
     "@game-ci/steam-deploy": ["@game-ci/steam-deploy@workspace:plugins/steam-deploy"],
 
@@ -1566,6 +1577,8 @@
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@game-ci/orchestrator/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
+
+    "@game-ci/save-data-compat/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 
     "@game-ci/steam-deploy/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 

--- a/plugins/save-data-compat/README.md
+++ b/plugins/save-data-compat/README.md
@@ -1,0 +1,21 @@
+# @game-ci/save-data-compat (draft)
+
+Verifies new builds can still load a maintained corpus of historical save
+files without crashing or losing data. **Not functional yet**, and
+`test-save-compat` is not yet registered anywhere in core's CLI.
+
+## Why this, distinct from the Runtime Test Framework
+
+A specific, well-scoped test type: data compatibility/migration across
+versions, not general gameplay-logic correctness.
+
+## Remaining work before this is real
+
+1. Add `test-save-compat <buildPath>` to core's `CliCommands`.
+2. Corpus management: where do historical save files live, how do new
+   ones get added over time, how large can this reasonably grow before it
+   needs its own storage strategy (likely Git LFS or an external bucket,
+   not committed directly).
+3. Load-and-verify harness - likely shares infrastructure with the
+   Runtime Test Framework's in-game hook mechanism once that exists.
+4. Tests once the above is real.

--- a/plugins/save-data-compat/package.json
+++ b/plugins/save-data-compat/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@game-ci/save-data-compat",
+  "version": "0.0.1",
+  "description": "Save-Data Cross-Version Compatibility plugin (draft). Verifies new builds can still load a maintained corpus of historical save files.",
+  "license": "MIT",
+  "repository": "git@github.com:game-ci/cli.git",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.23",
+    "typescript": "4.7.4",
+    "vitest": "^4"
+  },
+  "engines": {
+    "node": ">=18.x"
+  }
+}

--- a/plugins/save-data-compat/src/index.ts
+++ b/plugins/save-data-compat/src/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Save-Data Cross-Version Compatibility plugin - DRAFT.
+ *
+ * Plan: `game-ci test-save-compat <buildPath> --corpusPath <dir>`
+ * verifies that a new build can still load a maintained corpus of real
+ * historical save files without crashing or losing data - a specific,
+ * well-scoped test type complementing (not overlapping) the broader
+ * Runtime Test Framework idea.
+ *
+ * NOTE: `test-save-compat` is not yet registered as a core CLI command.
+ */
+
+export const saveDataCompatPlugin = {
+  name: "save-data-compat",
+  version: "0.0.1",
+
+  commands: [
+    {
+      engine: "*",
+      createCommand(command: string, _subCommands: string[]) {
+        if (command === "test-save-compat") {
+          return {
+            name: "Test save compatibility",
+            async configureOptions() {
+              // TODO: register --corpusPath, --failOnDataLoss.
+            },
+            async execute(): Promise<boolean> {
+              throw new Error(
+                "Save-Data Cross-Version Compatibility is not implemented yet (draft plugin), and " +
+                  "`test-save-compat` is not yet registered as a core command either. See plugins/save-data-compat/README.md.",
+              );
+            },
+          };
+        }
+        return null;
+      },
+    },
+  ],
+};
+
+export default saveDataCompatPlugin;

--- a/plugins/save-data-compat/tsconfig.json
+++ b/plugins/save-data-compat/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "dist"]
+}


### PR DESCRIPTION
Structural skeleton for a save-data cross-version compatibility plugin: verifies new builds can still load a maintained corpus of historical save files without crashing or losing data - a specific, well-scoped test type complementing (not overlapping) the broader Runtime Test Framework idea. **Not functional yet**, and `test-save-compat` is not yet registered as a core CLI command.

See `plugins/save-data-compat/README.md` for what's real vs. TODO.