### PR TITLE
draft: @game-ci/dev-tunnel plugin (structural skeleton)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,15 @@
         "typescript": "^5.3.3",
       },
     },
+    "plugins/dev-tunnel": {
+      "name": "@game-ci/dev-tunnel",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^17.0.23",
+        "typescript": "4.7.4",
+        "vitest": "^4",
+      },
+    },
     "plugins/orchestrator": {
       "name": "@game-ci/orchestrator",
       "version": "1.0.0",
@@ -336,6 +345,8 @@
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
 
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
+
+    "@game-ci/dev-tunnel": ["@game-ci/dev-tunnel@workspace:plugins/dev-tunnel"],
 
     "@game-ci/orchestrator": ["@game-ci/orchestrator@workspace:plugins/orchestrator"],
 
@@ -1564,6 +1575,8 @@
     "@deno/shim-deno/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@game-ci/dev-tunnel/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 
     "@game-ci/orchestrator/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 

--- a/plugins/dev-tunnel/README.md
+++ b/plugins/dev-tunnel/README.md
@@ -1,0 +1,34 @@
+# @game-ci/dev-tunnel (draft)
+
+nginx/Caddy local routing plus a Cloudflare quick tunnel for ephemeral,
+testing-only public exposure of a local dev endpoint, with an explicit
+public-vs-private publish mode for the resolved URL. **Not functional
+yet**, and `tunnel` is not yet registered anywhere in core's CLI.
+
+## Why this - and an important limitation to keep
+
+Cloudflare's own docs are explicit that quick/unnamed tunnels
+(`trycloudflare.com`, no Cloudflare account) are testing/development only
+
+- no SLA, a 200 concurrent-request cap, no guaranteed uptime. This plugin
+  should stay scoped to that intended use ("let a teammate reach my local
+  build") and not grow into a production tunnel manager - a **named**
+  tunnel (tied to a Cloudflare account/zone) is the correct path for
+  anything long-running, and is out of scope here on purpose.
+
+The publish step matters for the same reason: a GitHub Pages site is
+publicly reachable regardless of whether the source repo is private,
+_unless_ the org is specifically on GitHub Enterprise Cloud (confirmed
+against GitHub's own docs). `--publish=pages` should be treated as
+public-by-default, and `--publish=private-remote` (rclone/webhook) should
+be the default recommendation for anything not meant to be public.
+
+## Remaining work before this is real
+
+1. Add `tunnel` to core's `CliCommands`.
+2. nginx/Caddy config generation for named local routes.
+3. Cloudflare quick-tunnel invocation (`cloudflared tunnel --url`) and
+   resolved-URL extraction from its output.
+4. Both publish modes, with `--publish=pages` requiring an explicit
+   confirmation flag given the public-by-default behavior above.
+5. Tests once the above is real.

--- a/plugins/dev-tunnel/package.json
+++ b/plugins/dev-tunnel/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@game-ci/dev-tunnel",
+  "version": "0.0.1",
+  "description": "Dev Tunnel and Service Directory plugin (draft). nginx/Caddy local routing plus a Cloudflare quick tunnel for ephemeral, testing-only public exposure, with an explicit public-vs-private publish mode for the resolved URL.",
+  "license": "MIT",
+  "repository": "git@github.com:game-ci/cli.git",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.23",
+    "typescript": "4.7.4",
+    "vitest": "^4"
+  },
+  "engines": {
+    "node": ">=18.x"
+  }
+}

--- a/plugins/dev-tunnel/src/index.ts
+++ b/plugins/dev-tunnel/src/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Dev Tunnel & Service Directory plugin - DRAFT.
+ *
+ * Plan: `game-ci tunnel --target <port>` sets up nginx/Caddy local named
+ * routing for whatever's running locally, exposes it via a Cloudflare
+ * *quick* tunnel (testing-only by Cloudflare's own documentation - no
+ * SLA, not for production/sustained use - see plugins/dev-tunnel/README.md),
+ * and publishes the resolved URL via one of two explicit modes:
+ * --publish=pages (GitHub Pages - public by default, even from a private
+ * repo, unless the org is on GitHub Enterprise Cloud) or
+ * --publish=private-remote (rclone/webhook, access-controlled). The two
+ * modes are explicit and separate on purpose, so a live dev endpoint is
+ * never silently made public.
+ *
+ * NOTE: `tunnel` is not yet registered as a core CLI command.
+ */
+
+export const devTunnelPlugin = {
+  name: "dev-tunnel",
+  version: "0.0.1",
+
+  commands: [
+    {
+      engine: "*",
+      createCommand(command: string, _subCommands: string[]) {
+        if (command === "tunnel") {
+          return {
+            name: "Dev tunnel",
+            async configureOptions() {
+              // TODO: register --target (port), --routes (nginx/Caddy named-route config),
+              // --publish (pages|private-remote), and the publish-target-specific options.
+            },
+            async execute(): Promise<boolean> {
+              throw new Error(
+                "Dev Tunnel & Service Directory is not implemented yet (draft plugin), and `tunnel` " +
+                  "is not yet registered as a core command either. See plugins/dev-tunnel/README.md.",
+              );
+            },
+          };
+        }
+        return null;
+      },
+    },
+  ],
+};
+
+export default devTunnelPlugin;

--- a/plugins/dev-tunnel/tsconfig.json
+++ b/plugins/dev-tunnel/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "dist"]
+}


### PR DESCRIPTION
Structural skeleton for a dev-tunnel/service-directory plugin: nginx/Caddy local named routing plus a Cloudflare *quick* tunnel (testing-only per Cloudflare's own docs - no SLA, not for sustained use) for ephemeral public exposure, with an explicit public-vs-private publish mode for the resolved URL (GitHub Pages is public by default even from a private repo, unless the org is on GitHub Enterprise Cloud - confirmed against GitHub's own docs). **Not functional yet**, and `tunnel` is not yet registered as a core CLI command.

See `plugins/dev-tunnel/README.md` for what's real vs. TODO and the scope boundary this should stay within.