### PR TITLE
draft: @game-ci/github-release-deploy plugin (structural skeleton)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,15 @@
         "typescript": "^5.3.3",
       },
     },
+    "plugins/github-release-deploy": {
+      "name": "@game-ci/github-release-deploy",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^17.0.23",
+        "typescript": "4.7.4",
+        "vitest": "^4",
+      },
+    },
     "plugins/orchestrator": {
       "name": "@game-ci/orchestrator",
       "version": "1.0.0",
@@ -346,6 +355,8 @@
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
 
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
+
+    "@game-ci/github-release-deploy": ["@game-ci/github-release-deploy@workspace:plugins/github-release-deploy"],
 
     "@game-ci/orchestrator": ["@game-ci/orchestrator@workspace:plugins/orchestrator"],
 
@@ -1576,6 +1587,8 @@
     "@deno/shim-deno/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@game-ci/github-release-deploy/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 
     "@game-ci/orchestrator/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 

--- a/plugins/github-release-deploy/README.md
+++ b/plugins/github-release-deploy/README.md
@@ -1,0 +1,32 @@
+# @game-ci/github-release-deploy (draft)
+
+GitHub/GitLab Release deploy plugin. **Not functional yet** - structural
+skeleton only. Mirrors `@game-ci/steam-deploy`'s `deploy <target>`
+dispatch shape, reusing core's existing `deploy` command registration.
+
+## Why this
+
+Fills a real gap: games not on Steam or itch (open-source games, internal
+builds, anything distributed straight from a repo) have no deploy target
+today. Flagged as the thinnest of the recent plugin-idea batch - closest
+in spirit to what a generic release-upload action already does - but
+still worth having as a first-party, game-artifact-aware option.
+
+## What's real vs. TODO
+
+- Plugin/command registration shape: real, mirrors `steam-deploy`.
+- `execute()`: throws immediately, pointing here.
+
+## Remaining work before this is real
+
+1. Decide GitHub vs. GitLab scope for the first version (likely GitHub
+   first, given this repo's own hosting) and the auth token convention
+   (env var only, matching `steam-deploy`'s credential handling - never
+   CLI args).
+2. Multi-platform artifact naming/packaging - if `buildPath` contains
+   builds for multiple `targetPlatform`s, decide whether this plugin
+   zips each separately with a platform-suffixed name, or expects to be
+   invoked once per platform.
+3. Release creation vs. update-existing-release handling (idempotent
+   re-runs on the same tag).
+4. Tests once the above is real.

--- a/plugins/github-release-deploy/package.json
+++ b/plugins/github-release-deploy/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@game-ci/github-release-deploy",
+  "version": "0.0.1",
+  "description": "GitHub/GitLab Release deploy plugin (draft). Attaches built artifacts to a GitHub or GitLab Release, for games distributed outside Steam/itch.",
+  "license": "MIT",
+  "repository": "git@github.com:game-ci/cli.git",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.23",
+    "typescript": "4.7.4",
+    "vitest": "^4"
+  },
+  "engines": {
+    "node": ">=18.x"
+  }
+}

--- a/plugins/github-release-deploy/src/index.ts
+++ b/plugins/github-release-deploy/src/index.ts
@@ -1,0 +1,43 @@
+/**
+ * GitHub/GitLab Release deploy plugin - DRAFT.
+ *
+ * Plan: `game-ci deploy github-release <buildPath> --repo --tag` attaches
+ * built artifacts to a GitHub or GitLab Release - a deploy target for
+ * games distributed outside Steam/itch (open-source games, internal
+ * builds, anything shipped straight from a repo). Handles multi-platform
+ * artifact naming/organization the way a game build specifically
+ * produces it, rather than being a bare file-upload wrapper.
+ *
+ * NOTE: mirrors steam-deploy's `deploy <target>` dispatch shape (already
+ * registered in core - see game-ci/cli#123).
+ */
+
+export const githubReleaseDeployPlugin = {
+  name: "github-release-deploy",
+  version: "0.0.1",
+
+  commands: [
+    {
+      engine: "*",
+      createCommand(command: string, subCommands: string[]) {
+        if (command === "deploy" && subCommands[0] === "github-release") {
+          return {
+            name: "Deploy github release",
+            async configureOptions() {
+              // TODO: register --repo, --tag, --releaseNotes, --draft, --prerelease.
+            },
+            async execute(): Promise<boolean> {
+              throw new Error(
+                "GitHub Release deploy is not implemented yet (draft plugin). " +
+                  "See plugins/github-release-deploy/README.md for the planned approach.",
+              );
+            },
+          };
+        }
+        return null;
+      },
+    },
+  ],
+};
+
+export default githubReleaseDeployPlugin;

--- a/plugins/github-release-deploy/tsconfig.json
+++ b/plugins/github-release-deploy/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "dist"]
+}


### PR DESCRIPTION
Structural skeleton for a GitHub/GitLab Release deploy plugin (`game-ci deploy github-release`), filling the gap for games distributed outside Steam/itch. **Not functional yet.** Mirrors `steam-deploy`'s `deploy <target>` dispatch shape, reusing core's existing `deploy` command registration.

See `plugins/github-release-deploy/README.md` for what's real vs. TODO.