### PR TITLE
draft: @game-ci/code-signing plugin (structural skeleton)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,15 @@
         "typescript": "^5.3.3",
       },
     },
+    "plugins/code-signing": {
+      "name": "@game-ci/code-signing",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^17.0.23",
+        "typescript": "4.7.4",
+        "vitest": "^4",
+      },
+    },
     "plugins/orchestrator": {
       "name": "@game-ci/orchestrator",
       "version": "1.0.0",
@@ -346,6 +355,8 @@
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
 
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
+
+    "@game-ci/code-signing": ["@game-ci/code-signing@workspace:plugins/code-signing"],
 
     "@game-ci/orchestrator": ["@game-ci/orchestrator@workspace:plugins/orchestrator"],
 
@@ -1576,6 +1587,8 @@
     "@deno/shim-deno/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@game-ci/code-signing/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 
     "@game-ci/orchestrator/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
 

--- a/plugins/code-signing/README.md
+++ b/plugins/code-signing/README.md
@@ -1,0 +1,30 @@
+# @game-ci/code-signing (draft)
+
+macOS notarization (`xcrun notarytool` + stapling) and Windows
+Authenticode signing for built players. **Not functional yet**, and
+`sign` is not yet registered anywhere in core's CLI.
+
+## Why this
+
+Real, common pain point currently entirely hand-rolled per studio: an
+unsigned macOS build gets blocked by Gatekeeper, an unsigned Windows
+build gets flagged by SmartScreen. Distribution outside Steam/console
+storefronts (direct download, itch.io) hits this immediately.
+
+## Remaining work before this is real
+
+1. Add `sign <buildPath>` to core's `CliCommands`.
+2. macOS path: codesign the `.app` bundle with a Developer ID
+   certificate, submit to `xcrun notarytool submit --wait`, staple the
+   ticket on success. Certificate/App-Store-Connect-API-key handling via
+   environment variables only, matching `steam-deploy`'s credential
+   convention.
+3. Windows path: Authenticode signing via `signtool.exe` (or an HSM/cloud
+   signing service like Azure Trusted Signing, increasingly required
+   since traditional EV cert issuance has gotten harder for indies) -
+   needs real research into which signing backends are actually
+   accessible to indie/small studios today before picking one to
+   implement first.
+4. Tests once the above is real - likely needs to mock the actual
+   signing tool invocations, since real certificates can't be part of a
+   test fixture.

--- a/plugins/code-signing/package.json
+++ b/plugins/code-signing/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@game-ci/code-signing",
+  "version": "0.0.1",
+  "description": "Code-signing and notarization plugin (draft). macOS notarization (xcrun notarytool + stapling) and Windows Authenticode signing for built players.",
+  "license": "MIT",
+  "repository": "git@github.com:game-ci/cli.git",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.23",
+    "typescript": "4.7.4",
+    "vitest": "^4"
+  },
+  "engines": {
+    "node": ">=18.x"
+  }
+}

--- a/plugins/code-signing/src/index.ts
+++ b/plugins/code-signing/src/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Code-signing and notarization plugin - DRAFT.
+ *
+ * Plan: `game-ci sign <buildPath> --platform macos|windows` signs (and,
+ * on macOS, notarizes and staples) a built player. Real, common pain
+ * point: an unsigned macOS build is blocked by Gatekeeper, an unsigned
+ * Windows build is flagged by SmartScreen. Genuinely complex enough
+ * (credential/certificate management, async notarization ticket polling
+ * on macOS) to deserve dedicated code rather than a shell snippet.
+ *
+ * NOTE: `sign` is not yet registered as a core CLI command.
+ */
+
+export const codeSigningPlugin = {
+  name: "code-signing",
+  version: "0.0.1",
+
+  commands: [
+    {
+      engine: "*",
+      createCommand(command: string, _subCommands: string[]) {
+        if (command === "sign") {
+          return {
+            name: "Sign build",
+            async configureOptions() {
+              // TODO: register --platform (macos|windows), --identity/--certificate,
+              // --notarize (macOS, default true when --platform=macos), --timeout.
+            },
+            async execute(): Promise<boolean> {
+              throw new Error(
+                "Code-signing / notarization is not implemented yet (draft plugin), and `sign` " +
+                  "is not yet registered as a core command either. See plugins/code-signing/README.md.",
+              );
+            },
+          };
+        }
+        return null;
+      },
+    },
+  ],
+};
+
+export default codeSigningPlugin;

--- a/plugins/code-signing/tsconfig.json
+++ b/plugins/code-signing/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "dist"]
+}


### PR DESCRIPTION
Structural skeleton for a code-signing/notarization plugin: macOS notarization (`xcrun notarytool` + stapling) and Windows Authenticode signing for built players. **Not functional yet**, and `sign` is not yet registered as a core CLI command.

See `plugins/code-signing/README.md` for what's real vs. TODO.