### PR TITLE
fix: use the working inline Unity license instead of the stale secret

### DIFF
--- a/.github/workflows/orchestrator-async-checks.yml
+++ b/.github/workflows/orchestrator-async-checks.yml
@@ -41,7 +41,36 @@ env:
   ORCHESTRATOR_DEBUG: true
   ORCHESTRATOR_DEBUG_TREE: true
   DEBUG: true
-  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+  # Shared GameCI public Unity Personal test license, inlined rather than
+  # read from secrets.UNITY_LICENSE: that org-level secret is stale -
+  # activate.sh writes it and reports "Activation complete", but the Editor
+  # then rejects it with "No valid Unity Editor license found". Same value
+  # game-ci/unity-builder's build-tests-ubuntu.yml and
+  # game-ci/unity-activate's main.yml use - both green today. Unity Personal,
+  # ValidTo="9999-12-31", already published in those public repos.
+  UNITY_LICENSE: "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root>\n    <License
+    id=\"Terms\">\n        <MachineBindings>\n            <Binding Key=\"1\"
+    Value=\"576562626572264761624c65526f7578\"/>\n            <Binding Key=\"2\"
+    Value=\"576562626572264761624c65526f7578\"/>\n        </MachineBindings>\n        <MachineID
+    Value=\"D7nTUnjNAmtsUMcnoyrqkgIbYdM=\"/>\n        <SerialHash
+    Value=\"2033b8ac3e6faa3742ca9f0bfae44d18f2a96b80\"/>\n        <Features>\n            <Feature
+    Value=\"33\"/>\n            <Feature Value=\"1\"/>\n            <Feature Value=\"12\"/>\n            <Feature
+    Value=\"2\"/>\n            <Feature Value=\"24\"/>\n            <Feature Value=\"3\"/>\n            <Feature
+    Value=\"36\"/>\n            <Feature Value=\"17\"/>\n            <Feature Value=\"19\"/>\n            <Feature
+    Value=\"62\"/>\n        </Features>\n        <DeveloperData
+    Value=\"AQAAAEY0LUJHUlgtWEQ0RS1aQ1dWLUM1SlctR0RIQg==\"/>\n        <SerialMasked
+    Value=\"F4-BGRX-XD4E-ZCWV-C5JW-XXXX\"/>\n        <StartDate Value=\"2021-02-08T00:00:00\"/>\n        <UpdateDate
+    Value=\"2021-02-09T00:34:57\"/>\n        <InitialActivationDate
+    Value=\"2021-02-08T00:34:56\"/>\n        <LicenseVersion Value=\"6.x\"/>\n        <ClientProvidedVersion
+    Value=\"2018.4.30f1\"/>\n        <AlwaysOnline Value=\"false\"/>\n        <Entitlements>\n            <Entitlement
+    Ns=\"unity_editor\" Tag=\"UnityPersonal\" Type=\"EDITOR\"
+    ValidTo=\"9999-12-31T00:00:00\"/>\n            <Entitlement Ns=\"unity_editor\" Tag=\"DarkSkin\"
+    Type=\"EDITOR_FEATURE\" ValidTo=\"9999-12-31T00:00:00\"/>\n        </Entitlements>\n    </License>\n<Signature
+    xmlns=\"http://www.w3.org/2000/09/xmldsig#\"><SignedInfo><CanonicalizationMethod
+    Algorithm=\"http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments\"/><SignatureMethod
+    Algorithm=\"http://www.w3.org/2000/09/xmldsig#rsa-sha1\"/><Reference URI=\"#Terms\"><Transforms><Transform
+    Algorithm=\"http://www.w3.org/2000/09/xmldsig#enveloped-signature\"/></Transforms><DigestMethod
+    Algorithm=\"http://www.w3.org/2000/09/xmldsig#sha1\"/><DigestValue>m0Db8UK+ktnOLJBtHybkfetpcKo=</DigestValue></Reference></SignedInfo><SignatureValue>o/pUbSQAukz7+ZYAWhnA0AJbIlyyCPL7bKVEM2lVqbrXt7cyey+umkCXamuOgsWPVUKBMkXtMH8L\n5etLmD0getWIhTGhzOnDCk+gtIPfL4jMo9tkEuOCROQAXCci23VFscKcrkB+3X6h4wEOtA2APhOY\nB+wvC794o8/82ffjP79aVAi57rp3Wmzx+9pe9yMwoJuljAy2sc2tIMgdQGWVmOGBpQm3JqsidyzI\nJWG2kjnc7pDXK9pwYzXoKiqUqqrut90d+kQqRyv7MSZXR50HFqD/LI69h68b7P8Bjo3bPXOhNXGR\n9YCoemH6EkfCJxp2gIjzjWW+l2Hj2EsFQi8YXw==</SignatureValue></Signature></root>"
   PROJECT_PATH: test-project
   UNITY_VERSION: 2019.3.15f1
   USE_IL2CPP: false
@@ -75,7 +104,9 @@ jobs:
             yarn-${{ runner.os }}-node-20-
       - timeout-minutes: 180
         env:
-          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          # UNITY_LICENSE deliberately omitted here - the step inherits the
+          # workflow-level value above. Re-declaring it from the stale secret
+          # would shadow the working inline license.
           PROJECT_PATH: test-project
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_PRIVATE_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Context

While diagnosing why every Unity job on [game-ci/unity-test-runner#310](https://github.com/game-ci/unity-test-runner/pull/310) failed, the root cause turned out to be the **org-level `UNITY_LICENSE` secret being stale**. `activate.sh` writes the ULF and reports `Activation complete`, but the Editor then rejects it:

```
No valid Unity Editor license found. Please activate your license.
[Licensing::Client] Error: Code 500 ... Unable to update licenses. Errors: No ULF license found.
```

`orchestrator-async-checks.yml` reads that same secret, so it has the same defect.

## Why this workflow can't fall back to a serial

It's manual-dispatch only, so the breakage is **latent** rather than visible in CI. But it has no `UNITY_SERIAL` fallback — and couldn't usefully have one, because `UNITY_LICENSE` **takes precedence** over `UNITY_SERIAL` in `activate.sh` (the serial branch is an `elif`). A bad ULF always wins over a good serial. A dispatch today would fail activation outright.

## Fix

Uses the same inline Unity Personal license that `game-ci/unity-builder`'s `build-tests-ubuntu.yml` and `game-ci/unity-activate`'s `main.yml` already use — **both green today**. Verified byte-identical to unity-builder's copy (parsed both YAMLs and compared the resolved string, not the source text).

It carries `ValidTo="9999-12-31"` and is already published in those two public repos, so it is not a credential to protect. It also restores fork-PR support, since secrets aren't exposed to pull requests from forks.

The step-level `UNITY_LICENSE` re-declaration is **dropped** rather than duplicated: steps inherit workflow-level `env`, and re-reading the stale secret there would have silently shadowed the working value set above.

## Scope — what was deliberately *not* changed

`unity-builder`'s `build-tests-mac.yml` / `build-tests-windows.yml` also read `secrets.UNITY_LICENSE`, but they additionally pass `UNITY_SERIAL`, and their licensing **already succeeds** via the professional path — confirmed in their logs (`Successfully returned ULF license with serial number "F4-R7MU-…"`). Because `UNITY_LICENSE` wins precedence, inlining a personal ULF there would *override working activation*. Their Windows failures are a genuine build error (`BuildFailedException: Incremental Player build failed! Errors: 4`), not licensing.

Companion change: [game-ci/unity-test-runner@da2aa81](https://github.com/game-ci/unity-test-runner/commit/da2aa81) on #310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)