### PR TITLE
chore: bump version to 0.1.15 for the Docker test-flow fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "GameCI CLI - automation for game engines",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Cuts a release for the fixes merged in #140. `game-ci/unity-test-runner` downloads the **published** binary (`cliVersion: latest`), so it is still running `v0.1.14` and cannot pick them up until a release exists.

## Verified against a real matrix

[unity-test-runner#310](https://github.com/game-ci/unity-test-runner/pull/310) now gets all the way through Unity licensing and **runs its tests successfully**:

```
Requesting activation (personal license)
Activation complete.
<test-run id="2" testcasecount="5" result="Passed" total="5" passed="5" ...>
```

…and then fails anyway, for exactly two reasons — both fixed in #140, neither released:

**Linux** — `validateBuild()` scrapes the container log for a `# Build results #` section that only a real *build* ever emits, so a fully passing suite was reported as a build failure:

```
[ERROR] Error: There was an error building the project.
    at validateBuild (/$bunfs/root/game-ci:14493:22)
```

**Windows** — rejected outright by the `hostPlatform` guard (correct at the time: the container `entrypoint.ps1` had no `RUN_TESTS` branch and would have silently run a *build*). It has one now, reusing the shared `steps/test.ps1`:

```
[ERROR] Error: --docker's classic batchmode test flow is currently only supported on Linux hosts...
    Downloading game-ci CLI v0.1.14
```

This release also carries the missing `/UnityTestRunnerAction` mount, without which `--testPlatforms=standalone` dies on `cp -R` — on **Linux too**, not just Windows.

## After merge

Publish the `v0.1.15` release to trigger `release-cli.yml`, which builds and attaches the per-platform binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)