### PR TITLE
feat(orchestrator): build-lifecycle capabilities (symbols, visual baseline, provisioning, service directory, anti-cheat)

### DIFF
--- a/plugins/orchestrator/src/index.ts
+++ b/plugins/orchestrator/src/index.ts
@@ -61,6 +61,53 @@ export type {
   UnityRecoveryDecision,
 } from './model/orchestrator/services/reliability';
 export { TestWorkflowService } from './model/orchestrator/services/test-workflow';
+
+// Build-lifecycle capabilities. These were originally drafted as separate
+// @game-ci/* plugins, but a plugin adds user-facing command surface (see
+// steam-deploy, runtime-test-framework, the engine plugins) whereas these
+// are all things that happen *to* a build or a running job - orchestrator's
+// existing domain. See each module's doc comment.
+export {
+  collectSymbols,
+  summarizeSymbols,
+} from './model/orchestrator/services/output/symbol-collector';
+export type {
+  SymbolFile,
+  SymbolFormat,
+  CollectSymbolsOptions,
+} from './model/orchestrator/services/output/symbol-collector';
+export {
+  compareVisualCaptures,
+  digestDirectory,
+  summarizeVisualComparison,
+} from './model/orchestrator/services/output/visual-baseline';
+export type {
+  VisualChangeKind,
+  VisualComparisonEntry,
+  VisualComparisonResult,
+} from './model/orchestrator/services/output/visual-baseline';
+export {
+  generateDockerCompose,
+  generateSystemdUnit,
+  generateFirewallRules,
+} from './model/orchestrator/services/provisioning/dedicated-server-provisioner';
+export type {
+  DedicatedServerConfig,
+  ServerPort,
+} from './model/orchestrator/services/provisioning/dedicated-server-provisioner';
+export {
+  ServiceDirectory,
+  ServiceDirectoryError,
+} from './model/orchestrator/services/network/service-directory';
+export type {
+  ServiceEntry,
+  ServiceVisibility,
+} from './model/orchestrator/services/network/service-directory';
+export { createAntiCheatMiddleware } from './model/orchestrator/services/hooks/presets/anti-cheat-middleware';
+export type {
+  AntiCheatProvider,
+  AntiCheatMiddlewareConfig,
+} from './model/orchestrator/services/hooks/presets/anti-cheat-middleware';
 export {
   PreflightService,
   builtInChecks,

--- a/plugins/orchestrator/src/model/orchestrator/services/hooks/presets/anti-cheat-middleware.test.ts
+++ b/plugins/orchestrator/src/model/orchestrator/services/hooks/presets/anti-cheat-middleware.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { createAntiCheatMiddleware } from './anti-cheat-middleware';
+
+const command = 'eac-tool sign ./Builds/StandaloneWindows64/Game.exe';
+
+describe('createAntiCheatMiddleware', () => {
+  it('runs after the build, when a player actually exists', () => {
+    const middleware = createAntiCheatMiddleware({ provider: 'easy-anti-cheat', command });
+
+    expect(middleware.trigger.phase).toEqual(['post-build']);
+    expect(middleware.after?.commands).toBe(command);
+    // A pre-build/build hook would have nothing to operate on.
+    expect(middleware.before).toBeUndefined();
+  });
+
+  it('never allows failure', () => {
+    const middleware = createAntiCheatMiddleware({ provider: 'battleye', command });
+
+    // A build that skipped its integrity step but still produced a
+    // shippable player is the worst outcome: it looks successful and ships
+    // unprotected.
+    expect(middleware.allowFailure).toBe(false);
+  });
+
+  it('sorts ahead of default-priority packaging steps', () => {
+    const middleware = createAntiCheatMiddleware({ provider: 'easy-anti-cheat', command });
+
+    // Default middleware priority is 100; an unprotected binary must not be
+    // packaged or uploaded before this runs.
+    expect(middleware.priority).toBeLessThan(100);
+  });
+
+  it('requires a command, since the vendor SDKs are NDA-gated', () => {
+    expect(() =>
+      createAntiCheatMiddleware({ provider: 'easy-anti-cheat', command: '   ' }),
+    ).toThrow(/NDA-gated/i);
+  });
+
+  it('passes credentials as secrets rather than interpolating them into the command', () => {
+    const middleware = createAntiCheatMiddleware({
+      provider: 'easy-anti-cheat',
+      command,
+      secretNames: ['EAC_API_KEY'],
+    });
+
+    expect(middleware.secrets).toHaveLength(1);
+    expect(middleware.secrets[0].ParameterKey).toBe('EAC_API_KEY');
+    expect(middleware.secrets[0].EnvironmentVariable).toBe('EAC_API_KEY');
+    // The value must never be baked into the definition.
+    expect(middleware.secrets[0].ParameterValue).toBe('');
+    expect(middleware.after?.commands).not.toContain('EAC_API_KEY');
+  });
+
+  it('is a command middleware by default and a container one when an image is given', () => {
+    expect(createAntiCheatMiddleware({ provider: 'battleye', command }).type).toBe('command');
+
+    const containerized = createAntiCheatMiddleware({
+      provider: 'battleye',
+      command,
+      image: 'vendor/battleye:1',
+    });
+    expect(containerized.type).toBe('container');
+    expect(containerized.image).toBe('vendor/battleye:1');
+  });
+
+  it('restricts to the given platforms, and to all platforms when unset', () => {
+    expect(
+      createAntiCheatMiddleware({
+        provider: 'battleye',
+        command,
+        platforms: ['StandaloneWindows64'],
+      }).trigger.platform,
+    ).toEqual(['StandaloneWindows64']);
+
+    expect(
+      createAntiCheatMiddleware({ provider: 'battleye', command }).trigger.platform,
+    ).toBeUndefined();
+  });
+
+  it('names the middleware per provider so two can coexist', () => {
+    expect(createAntiCheatMiddleware({ provider: 'easy-anti-cheat', command }).name).toBe(
+      'anti-cheat-easy-anti-cheat',
+    );
+    expect(createAntiCheatMiddleware({ provider: 'battleye', command }).name).toBe(
+      'anti-cheat-battleye',
+    );
+  });
+});

--- a/plugins/orchestrator/src/model/orchestrator/services/hooks/presets/anti-cheat-middleware.ts
+++ b/plugins/orchestrator/src/model/orchestrator/services/hooks/presets/anti-cheat-middleware.ts
@@ -1,0 +1,87 @@
+import { Middleware } from '../middleware';
+import OrchestratorSecret from '../../../options/orchestrator-secret';
+
+/**
+ * Anti-cheat / build-integrity middleware presets.
+ *
+ * Anti-cheat integration is not a command anyone runs on its own - it is a
+ * step that has to happen to an existing build, after the player is
+ * produced and before it is shipped. That is precisely what
+ * middleware-service already models (trigger-aware before/after phases), so
+ * this is a preset over Middleware rather than a separate plugin.
+ *
+ * Both supported SDKs are gated behind vendor NDAs and are not publicly
+ * downloadable, so this module deliberately does not embed a fixed
+ * command line for either. The caller supplies the command; what the preset
+ * owns is the *wiring* that is easy to get wrong: running at post-build
+ * rather than build, never allowing a silent failure, and passing
+ * credentials as secrets instead of interpolating them into a shell string.
+ */
+
+export type AntiCheatProvider = 'easy-anti-cheat' | 'battleye';
+
+export interface AntiCheatMiddlewareConfig {
+  provider: AntiCheatProvider;
+  /**
+   * Command that runs the vendor's signing/integrity tool against the
+   * built player. Supplied by the caller because the tooling is
+   * NDA-gated and its invocation differs per licensee.
+   */
+  command: string;
+  /** Secret names the command needs (API keys, signing credentials). */
+  secretNames?: string[];
+  /** Restrict to specific target platforms. Defaults to all. */
+  platforms?: string[];
+  /** Container image providing the vendor tooling, if containerized. */
+  image?: string;
+}
+
+/**
+ * Builds the middleware definition for an anti-cheat integration step.
+ *
+ * `allowFailure` is forced to false and not configurable. A build that
+ * silently skipped its integrity step but still produced a shippable
+ * player is the worst possible outcome here - it looks successful and
+ * ships unprotected. Failing loudly is the only safe default, and making
+ * it opt-outable would invite exactly the misconfiguration this preset
+ * exists to prevent.
+ */
+export function createAntiCheatMiddleware(config: AntiCheatMiddlewareConfig): Middleware {
+  if (!config.command.trim()) {
+    throw new Error(
+      `Anti-cheat middleware for ${config.provider} requires a command - the vendor SDKs are ` +
+        'NDA-gated, so no default invocation can be assumed.',
+    );
+  }
+
+  const middleware = new Middleware();
+  middleware.name = `anti-cheat-${config.provider}`;
+  middleware.description = `Applies ${config.provider} build integrity to the built player`;
+  middleware.type = config.image ? 'container' : 'command';
+  if (config.image) middleware.image = config.image;
+
+  // Runs after the player exists; a pre-build or build-phase hook would
+  // have nothing to operate on.
+  middleware.trigger = {
+    phase: ['post-build'],
+    ...(config.platforms ? { platform: config.platforms } : {}),
+  };
+
+  // Lower number = earlier. This must precede packaging/upload steps, which
+  // sit at the default 100, or an unprotected binary gets shipped.
+  middleware.priority = 50;
+
+  middleware.after = { commands: config.command };
+  middleware.allowFailure = false;
+
+  middleware.secrets = (config.secretNames ?? []).map((name) => {
+    const secret = new OrchestratorSecret();
+    secret.ParameterKey = name;
+    secret.EnvironmentVariable = name;
+    secret.ParameterValue = '';
+
+    return secret;
+  });
+
+  return middleware;
+}

--- a/plugins/orchestrator/src/model/orchestrator/services/network/service-directory.test.ts
+++ b/plugins/orchestrator/src/model/orchestrator/services/network/service-directory.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { ServiceDirectory, ServiceDirectoryError } from './service-directory';
+
+describe('ServiceDirectory', () => {
+  it('registers and returns a service', () => {
+    const directory = new ServiceDirectory();
+    directory.register({
+      name: 'devbuild',
+      url: 'https://abc123.trycloudflare.com',
+      visibility: 'public',
+    });
+
+    expect(directory.get('devbuild')?.url).toBe('https://abc123.trycloudflare.com');
+  });
+
+  it('rejects a duplicate registration rather than silently overwriting', () => {
+    const directory = new ServiceDirectory();
+    directory.register({ name: 'devbuild', url: 'https://a.example.com', visibility: 'private' });
+
+    expect(() =>
+      directory.register({ name: 'devbuild', url: 'https://b.example.com', visibility: 'private' }),
+    ).toThrow(ServiceDirectoryError);
+  });
+
+  it('replace() updates an existing entry', () => {
+    const directory = new ServiceDirectory();
+    directory.register({ name: 'devbuild', url: 'https://a.example.com', visibility: 'private' });
+    directory.replace({ name: 'devbuild', url: 'https://b.example.com', visibility: 'public' });
+
+    expect(directory.get('devbuild')?.url).toBe('https://b.example.com');
+    expect(directory.get('devbuild')?.visibility).toBe('public');
+  });
+
+  it('rejects a malformed or non-http URL', () => {
+    const directory = new ServiceDirectory();
+
+    expect(() =>
+      directory.register({ name: 'a', url: 'not a url', visibility: 'private' }),
+    ).toThrow(/invalid URL/i);
+    expect(() =>
+      directory.register({ name: 'b', url: 'ftp://example.com', visibility: 'private' }),
+    ).toThrow(/http or https/i);
+  });
+
+  it('returns copies, so a caller cannot mutate the directory through them', () => {
+    const directory = new ServiceDirectory();
+    directory.register({ name: 'devbuild', url: 'https://a.example.com', visibility: 'private' });
+
+    const entry = directory.get('devbuild')!;
+    entry.visibility = 'public';
+
+    // A leaked reference here would let a caller flip a private service
+    // public without going through register/replace.
+    expect(directory.get('devbuild')?.visibility).toBe('private');
+  });
+
+  it('listPublic returns only explicitly public services', () => {
+    const directory = new ServiceDirectory();
+    directory.register({ name: 'public-one', url: 'https://a.example.com', visibility: 'public' });
+    directory.register({
+      name: 'private-one',
+      url: 'https://b.example.com',
+      visibility: 'private',
+    });
+
+    expect(directory.listPublic().map((entry) => entry.name)).toEqual(['public-one']);
+  });
+
+  describe('formatForLog', () => {
+    it('redacts the whole private URL, not just its host', () => {
+      const directory = new ServiceDirectory();
+      directory.register({
+        name: 'profiler',
+        url: 'https://secret-sub.trycloudflare.com/x',
+        visibility: 'private',
+      });
+
+      const output = directory.formatForLog();
+
+      // An ephemeral tunnel's random subdomain IS the secret, so any
+      // surviving fragment of the URL is a leak.
+      expect(output).not.toContain('secret-sub');
+      expect(output).not.toContain('trycloudflare.com');
+      expect(output).toContain('<redacted: private service>');
+    });
+
+    it('prints public URLs verbatim', () => {
+      const directory = new ServiceDirectory();
+      directory.register({
+        name: 'devbuild',
+        url: 'https://public.example.com',
+        visibility: 'public',
+        description: 'WebGL build',
+      });
+
+      expect(directory.formatForLog()).toBe('devbuild: https://public.example.com - WebGL build');
+    });
+
+    it('reports an empty directory rather than an empty string', () => {
+      expect(new ServiceDirectory().formatForLog()).toBe('No services registered.');
+    });
+  });
+});

--- a/plugins/orchestrator/src/model/orchestrator/services/network/service-directory.ts
+++ b/plugins/orchestrator/src/model/orchestrator/services/network/service-directory.ts
@@ -1,0 +1,130 @@
+/**
+ * Service directory for exposed job endpoints.
+ *
+ * When orchestrator runs a job somewhere other than the developer's
+ * machine (any of providers/), anything that job serves - a dev build, a
+ * profiler endpoint, a dedicated server - needs a resolvable address before
+ * it is useful to a human. That is a property of the running job, so it
+ * belongs next to hot-runner and the providers rather than in a standalone
+ * plugin.
+ *
+ * This module owns the *registry and its disclosure rules*, not the tunnel
+ * transport. It never starts a tunnel process: a caller resolves a URL
+ * however it likes (cloudflared, ngrok, a LAN address, a k8s Service) and
+ * registers it here.
+ *
+ * The disclosure rule is the point. An ephemeral tunnel URL is an
+ * unauthenticated public entry point into a machine that is often mid-build
+ * with source and credentials on disk, and CI logs are frequently public or
+ * archived. So visibility is explicit per service, defaults to private, and
+ * a private URL is redacted by `formatForLog` rather than printed.
+ */
+
+export type ServiceVisibility = 'public' | 'private';
+
+export interface ServiceEntry {
+  /** Stable identifier, unique within the directory. */
+  name: string;
+  /** Fully-qualified URL the service is reachable at. */
+  url: string;
+  /**
+   * 'public' means the URL may appear in logs and CI output. 'private'
+   * means it is redacted - the service may still be reachable, this
+   * controls disclosure only, never access.
+   */
+  visibility: ServiceVisibility;
+  /** Free-form description shown alongside the entry. */
+  description?: string;
+}
+
+export class ServiceDirectoryError extends Error {}
+
+/**
+ * Ephemeral tunnels are frequently plain http; that is allowed but the
+ * value still has to be a real absolute URL, since a half-formed address
+ * is worse than none (it looks published but resolves nowhere).
+ */
+function assertValidUrl(name: string, url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new ServiceDirectoryError(
+      `Service "${name}" has an invalid URL: ${JSON.stringify(url)}.`,
+    );
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new ServiceDirectoryError(
+      `Service "${name}" must use http or https, got ${JSON.stringify(parsed.protocol)}.`,
+    );
+  }
+}
+
+export class ServiceDirectory {
+  private readonly entries = new Map<string, ServiceEntry>();
+
+  /**
+   * Registers a service.
+   *
+   * `visibility` is required rather than defaulted at the call site, so
+   * publishing a URL is always a deliberate decision - an omitted argument
+   * cannot quietly make a tunnel public.
+   */
+  register(entry: ServiceEntry): void {
+    if (!entry.name.trim()) throw new ServiceDirectoryError('Service name must not be empty.');
+    assertValidUrl(entry.name, entry.url);
+
+    if (this.entries.has(entry.name)) {
+      throw new ServiceDirectoryError(
+        `Service "${entry.name}" is already registered; use replace() to update it.`,
+      );
+    }
+
+    this.entries.set(entry.name, { ...entry });
+  }
+
+  /** Registers or overwrites a service. */
+  replace(entry: ServiceEntry): void {
+    this.entries.delete(entry.name);
+    this.register(entry);
+  }
+
+  get(name: string): ServiceEntry | undefined {
+    const entry = this.entries.get(name);
+
+    return entry ? { ...entry } : undefined;
+  }
+
+  list(): ServiceEntry[] {
+    return [...this.entries.values()]
+      .map((entry) => ({ ...entry }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  /** Only the entries explicitly marked public. */
+  listPublic(): ServiceEntry[] {
+    return this.list().filter((entry) => entry.visibility === 'public');
+  }
+
+  /**
+   * Renders the directory for a build log, redacting private URLs.
+   *
+   * Redaction replaces the whole URL, not just the host: an ephemeral
+   * tunnel's random subdomain *is* the secret, so a partially-masked URL
+   * would still leak the reachable address.
+   */
+  formatForLog(): string {
+    const entries = this.list();
+    if (entries.length === 0) return 'No services registered.';
+
+    return entries
+      .map((entry) => {
+        const url = entry.visibility === 'public' ? entry.url : '<redacted: private service>';
+        const description = entry.description ? ` - ${entry.description}` : '';
+
+        return `${entry.name}: ${url}${description}`;
+      })
+      .join('\n');
+  }
+}

--- a/plugins/orchestrator/src/model/orchestrator/services/output/artifact-service.test.ts
+++ b/plugins/orchestrator/src/model/orchestrator/services/output/artifact-service.test.ts
@@ -56,10 +56,10 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 describe('OutputTypeRegistry', () => {
   describe('built-in types', () => {
-    it('should have 8 built-in types', () => {
+    it('should have 10 built-in types', () => {
       const allTypes = OutputTypeRegistry.getAllTypes();
       const builtInTypes = allTypes.filter((t) => t.builtIn);
-      expect(builtInTypes).toHaveLength(8);
+      expect(builtInTypes).toHaveLength(10);
     });
 
     it.each([
@@ -71,6 +71,8 @@ describe('OutputTypeRegistry', () => {
       'logs',
       'metrics',
       'coverage',
+      'symbols',
+      'visual-baseline',
     ])('should include built-in type "%s"', (typeName) => {
       const typeDef = OutputTypeRegistry.getType(typeName);
       expect(typeDef).toBeDefined();
@@ -139,7 +141,7 @@ describe('OutputTypeRegistry', () => {
       });
 
       const allTypes = OutputTypeRegistry.getAllTypes();
-      expect(allTypes.length).toBe(9); // 8 built-in + 1 custom
+      expect(allTypes.length).toBe(11); // 10 built-in + 1 custom
       expect(allTypes.some((t) => t.name === 'custom-a')).toBe(true);
     });
 

--- a/plugins/orchestrator/src/model/orchestrator/services/output/output-type-registry.ts
+++ b/plugins/orchestrator/src/model/orchestrator/services/output/output-type-registry.ts
@@ -68,6 +68,24 @@ export class OutputTypeRegistry {
       description: 'Code coverage reports',
       builtIn: true,
     },
+    // Debug symbols have to be captured at build time or they are gone for
+    // good - once the build machine is torn down, every future crash report
+    // from that build is unsymbolicatable. See symbol-collector.ts.
+    symbols: {
+      name: 'symbols',
+      defaultPath: './Symbols/',
+      description: 'Debug symbols for crash symbolication (dSYM, PDB, Breakpad, IL2CPP maps)',
+      builtIn: true,
+    },
+    // Reference captures a run is compared against; kept separate from
+    // `images` (the current run's captures) so a baseline is never
+    // overwritten by the run being judged against it.
+    'visual-baseline': {
+      name: 'visual-baseline',
+      defaultPath: './VisualBaseline/',
+      description: 'Reference screenshots for visual-regression comparison',
+      builtIn: true,
+    },
   };
 
   private static customTypes: Record<string, OutputTypeDefinition> = {};

--- a/plugins/orchestrator/src/model/orchestrator/services/output/symbol-collector.test.ts
+++ b/plugins/orchestrator/src/model/orchestrator/services/output/symbol-collector.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { collectSymbols, summarizeSymbols } from './symbol-collector';
+
+/**
+ * Builds a fake fs over a { path: sizeOrDirectory } tree, so these tests
+ * exercise the real traversal logic without touching disk. Directories are
+ * represented by a trailing '/'.
+ */
+function fakeFs(tree: Record<string, number>) {
+  const files = Object.keys(tree);
+  const isDirectory = (target: string) =>
+    files.some((file) => file !== target && file.startsWith(`${target}${path.sep}`));
+
+  return {
+    existsSync: (target: string) =>
+      files.some((file) => file === target || file.startsWith(`${target}${path.sep}`)),
+    statSync: ((target: string) => ({ size: tree[target] ?? 0 })) as any,
+    readdirSync: ((directory: string) => {
+      const prefix = `${directory}${path.sep}`;
+      const names = new Set<string>();
+      for (const file of files) {
+        if (!file.startsWith(prefix)) continue;
+        names.add(file.slice(prefix.length).split(path.sep)[0]);
+      }
+
+      return [...names].map((name) => ({
+        name,
+        isDirectory: () => isDirectory(path.join(directory, name)),
+      }));
+    }) as any,
+  };
+}
+
+const ROOT = path.join('build', 'out');
+const p = (...parts: string[]) => path.join(ROOT, ...parts);
+
+describe('collectSymbols', () => {
+  it('returns an empty array when the directory does not exist', () => {
+    expect(collectSymbols({ rootPath: ROOT, fsImpl: fakeFs({}) })).toEqual([]);
+  });
+
+  it('finds PDB, Breakpad and DWARF symbol files', () => {
+    const symbols = collectSymbols({
+      rootPath: ROOT,
+      fsImpl: fakeFs({
+        [p('Game.pdb')]: 2048,
+        [p('Game.sym')]: 512,
+        [p('libmain.so.dbg')]: 4096,
+        [p('Game.exe')]: 999999,
+      }),
+    });
+
+    expect(symbols.map((s) => [s.relativePath, s.format])).toEqual([
+      ['Game.pdb', 'PDB'],
+      ['Game.sym', 'Breakpad'],
+      ['libmain.so.dbg', 'DWARF'],
+    ]);
+  });
+
+  it('prefers the longer extension so .so.dbg is not read as a bare .dbg', () => {
+    const symbols = collectSymbols({
+      rootPath: ROOT,
+      fsImpl: fakeFs({ [p('libmain.so.dbg')]: 10 }),
+    });
+
+    expect(symbols[0].format).toBe('DWARF');
+  });
+
+  it('treats a .dSYM as one bundle entry and does not descend into it', () => {
+    const symbols = collectSymbols({
+      rootPath: ROOT,
+      fsImpl: fakeFs({
+        [p('Game.dSYM', 'Contents', 'Resources', 'DWARF', 'Game')]: 3000,
+        [p('Game.dSYM', 'Contents', 'Info.plist')]: 100,
+      }),
+    });
+
+    // One entry, not one per file inside - the symbolicator needs the
+    // bundle intact, and per-file entries would lose that structure.
+    expect(symbols).toHaveLength(1);
+    expect(symbols[0].isBundle).toBe(true);
+    expect(symbols[0].format).toBe('dSYM');
+    expect(symbols[0].sizeBytes).toBe(3100);
+  });
+
+  it('finds symbols nested in subdirectories', () => {
+    const symbols = collectSymbols({
+      rootPath: ROOT,
+      fsImpl: fakeFs({ [p('nested', 'deep', 'Game.pdb')]: 1 }),
+    });
+
+    expect(symbols).toHaveLength(1);
+    expect(symbols[0].relativePath).toBe(path.join('nested', 'deep', 'Game.pdb'));
+  });
+
+  it('returns entries in a stable order regardless of readdir order', () => {
+    const symbols = collectSymbols({
+      rootPath: ROOT,
+      fsImpl: fakeFs({ [p('z.pdb')]: 1, [p('a.pdb')]: 1, [p('m.pdb')]: 1 }),
+    });
+
+    expect(symbols.map((s) => s.relativePath)).toEqual(['a.pdb', 'm.pdb', 'z.pdb']);
+  });
+});
+
+describe('summarizeSymbols', () => {
+  it('reports the no-symbols case explicitly', () => {
+    expect(summarizeSymbols([])).toMatch(/no debug symbols/i);
+  });
+
+  it('counts by format and totals the size', () => {
+    const summary = summarizeSymbols([
+      { path: 'a', relativePath: 'a', format: 'PDB', sizeBytes: 1024 * 1024, isBundle: false },
+      { path: 'b', relativePath: 'b', format: 'PDB', sizeBytes: 1024 * 1024, isBundle: false },
+      { path: 'c', relativePath: 'c', format: 'dSYM', sizeBytes: 0, isBundle: true },
+    ]);
+
+    expect(summary).toContain('3 symbol artifact(s)');
+    expect(summary).toContain('2 PDB');
+    expect(summary).toContain('1 dSYM');
+    expect(summary).toContain('2.00 MB');
+  });
+});

--- a/plugins/orchestrator/src/model/orchestrator/services/output/symbol-collector.ts
+++ b/plugins/orchestrator/src/model/orchestrator/services/output/symbol-collector.ts
@@ -1,0 +1,161 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Debug-symbol discovery for the `symbols` output type.
+ *
+ * Crash reporters (Sentry, Backtrace, Crashlytics, ...) symbolicate stack
+ * traces from a build's debug symbols, which have to be captured at build
+ * time - once the build machine is gone the symbols are unrecoverable and
+ * every future crash report from that build stays unreadable. That makes
+ * this an output-collection concern, exactly like coverage/, logs/ and
+ * metrics/ already are, rather than a separate user-facing command.
+ *
+ * This module only *finds and classifies* symbol files. Uploading them is
+ * left to ArtifactUploadHandler, which already knows how to push an
+ * OutputEntry to github-artifacts/storage/local - there is deliberately no
+ * vendor-specific upload path here.
+ */
+
+export type SymbolFormat = 'dSYM' | 'PDB' | 'Breakpad' | 'DWARF' | 'IL2CPP-map';
+
+export interface SymbolFile {
+  /** Absolute path to the symbol file or bundle directory. */
+  path: string;
+  /** Path relative to the search root, for manifest entries. */
+  relativePath: string;
+  /** Which debugger/crash-reporter format this is. */
+  format: SymbolFormat;
+  /** Total size in bytes (recursive for bundle directories such as .dSYM). */
+  sizeBytes: number;
+  /** True when this entry is a directory bundle rather than a single file. */
+  isBundle: boolean;
+}
+
+/**
+ * Extension -> format. Ordered longest-first at match time so that
+ * ".so.dbg" wins over ".dbg".
+ */
+const FILE_FORMATS: ReadonlyArray<readonly [string, SymbolFormat]> = [
+  ['.so.dbg', 'DWARF'],
+  ['.sym', 'Breakpad'],
+  ['.pdb', 'PDB'],
+  ['.dbg', 'DWARF'],
+  // Unity/IL2CPP emits these next to the player; without them an IL2CPP
+  // release stack trace cannot be mapped back to managed method names.
+  ['.symbols.json', 'IL2CPP-map'],
+];
+
+function formatForFile(fileName: string): SymbolFormat | null {
+  const lower = fileName.toLowerCase();
+  for (const [extension, format] of FILE_FORMATS) {
+    if (lower.endsWith(extension)) return format;
+  }
+
+  return null;
+}
+
+function directorySize(
+  directory: string,
+  statSync: typeof fs.statSync,
+  readdirSync: typeof fs.readdirSync,
+): number {
+  let total = 0;
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const full = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      total += directorySize(full, statSync, readdirSync);
+    } else {
+      total += statSync(full).size;
+    }
+  }
+
+  return total;
+}
+
+export interface CollectSymbolsOptions {
+  /** Directory to search, typically the build output path. */
+  rootPath: string;
+  /** Injected for testing; defaults to the real fs. */
+  fsImpl?: Pick<typeof fs, 'existsSync' | 'readdirSync' | 'statSync'>;
+}
+
+/**
+ * Recursively finds debug symbols under `rootPath`.
+ *
+ * A `.dSYM` is a *directory* bundle, not a file, so it is reported as a
+ * single entry (with its recursive size) and not descended into - otherwise
+ * every DWARF file inside it would be reported separately and the upload
+ * would lose the bundle structure the symbolicator expects.
+ *
+ * Returns an empty array when the root does not exist: a build that
+ * produced no symbols is normal (debug symbols are commonly off for
+ * release), not an error.
+ */
+export function collectSymbols(options: CollectSymbolsOptions): SymbolFile[] {
+  const { rootPath } = options;
+  const fsImpl = options.fsImpl ?? fs;
+
+  if (!fsImpl.existsSync(rootPath)) return [];
+
+  const found: SymbolFile[] = [];
+
+  const walk = (directory: string): void => {
+    for (const entry of fsImpl.readdirSync(directory, { withFileTypes: true })) {
+      const full = path.join(directory, entry.name);
+
+      if (entry.isDirectory()) {
+        if (entry.name.toLowerCase().endsWith('.dsym')) {
+          found.push({
+            path: full,
+            relativePath: path.relative(rootPath, full),
+            format: 'dSYM',
+            sizeBytes: directorySize(
+              full,
+              fsImpl.statSync as typeof fs.statSync,
+              fsImpl.readdirSync as typeof fs.readdirSync,
+            ),
+            isBundle: true,
+          });
+          continue;
+        }
+
+        walk(full);
+        continue;
+      }
+
+      const format = formatForFile(entry.name);
+      if (!format) continue;
+
+      found.push({
+        path: full,
+        relativePath: path.relative(rootPath, full),
+        format,
+        sizeBytes: fsImpl.statSync(full).size,
+        isBundle: false,
+      });
+    }
+  };
+
+  walk(rootPath);
+
+  // Stable ordering keeps manifests diffable between runs; readdir order is
+  // filesystem-dependent and not guaranteed.
+  return found.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+}
+
+/** Human-readable one-line summary, for the build log. */
+export function summarizeSymbols(symbols: SymbolFile[]): string {
+  if (symbols.length === 0) return 'No debug symbols found.';
+
+  const byFormat = new Map<SymbolFormat, number>();
+  let totalBytes = 0;
+  for (const symbol of symbols) {
+    byFormat.set(symbol.format, (byFormat.get(symbol.format) ?? 0) + 1);
+    totalBytes += symbol.sizeBytes;
+  }
+
+  const parts = [...byFormat.entries()].map(([format, count]) => `${count} ${format}`).sort();
+
+  return `Found ${symbols.length} symbol artifact(s) (${parts.join(', ')}), ${(totalBytes / 1024 / 1024).toFixed(2)} MB total.`;
+}

--- a/plugins/orchestrator/src/model/orchestrator/services/output/visual-baseline.test.ts
+++ b/plugins/orchestrator/src/model/orchestrator/services/output/visual-baseline.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import {
+  compareVisualCaptures,
+  summarizeVisualComparison,
+  digestDirectory,
+} from './visual-baseline';
+import path from 'node:path';
+
+const digests = (entries: Record<string, string>) => new Map(Object.entries(entries));
+
+describe('compareVisualCaptures', () => {
+  it('reports an identical set as matching', () => {
+    const result = compareVisualCaptures(
+      digests({ 'menu.png': 'aaa' }),
+      digests({ 'menu.png': 'aaa' }),
+    );
+
+    expect(result.matchesBaseline).toBe(true);
+    expect(result.unchanged).toBe(1);
+  });
+
+  it('detects a changed capture', () => {
+    const result = compareVisualCaptures(
+      digests({ 'menu.png': 'aaa' }),
+      digests({ 'menu.png': 'bbb' }),
+    );
+
+    expect(result.matchesBaseline).toBe(false);
+    expect(result.changed).toBe(1);
+    expect(result.entries[0]).toMatchObject({ name: 'menu.png', kind: 'changed' });
+  });
+
+  it('detects added and removed captures', () => {
+    const result = compareVisualCaptures(
+      digests({ 'gone.png': 'aaa' }),
+      digests({ 'new.png': 'bbb' }),
+    );
+
+    expect(result.added).toBe(1);
+    expect(result.removed).toBe(1);
+    expect(result.matchesBaseline).toBe(false);
+  });
+
+  it('treats an empty baseline as unverified rather than as a pass', () => {
+    const result = compareVisualCaptures(new Map(), digests({ 'menu.png': 'aaa' }));
+
+    // Silently passing here would make the check vacuous on a first run
+    // and after an accidental baseline deletion.
+    expect(result.matchesBaseline).toBe(false);
+    expect(result.added).toBe(1);
+  });
+
+  it('reports nothing to compare when both sides are empty', () => {
+    const result = compareVisualCaptures(new Map(), new Map());
+
+    expect(result.entries).toEqual([]);
+    expect(result.matchesBaseline).toBe(true);
+    expect(summarizeVisualComparison(result)).toMatch(/no visual captures/i);
+  });
+
+  it('orders entries by name for a stable, diffable report', () => {
+    const result = compareVisualCaptures(
+      digests({ 'z.png': 'a', 'a.png': 'a' }),
+      digests({ 'z.png': 'a', 'a.png': 'a' }),
+    );
+
+    expect(result.entries.map((entry) => entry.name)).toEqual(['a.png', 'z.png']);
+  });
+});
+
+describe('digestDirectory', () => {
+  const fakeFs = (files: Record<string, string>) => ({
+    existsSync: (target: string) =>
+      Object.keys(files).some((file) => file === target || file.startsWith(`${target}${path.sep}`)),
+    readdirSync: ((directory: string) => {
+      const prefix = `${directory}${path.sep}`;
+      const names = new Set<string>();
+      for (const file of Object.keys(files)) {
+        if (!file.startsWith(prefix)) continue;
+        names.add(file.slice(prefix.length).split(path.sep)[0]);
+      }
+
+      return [...names].map((name) => ({
+        name,
+        isDirectory: () =>
+          Object.keys(files).some((file) =>
+            file.startsWith(`${path.join(directory, name)}${path.sep}`),
+          ),
+      }));
+    }) as any,
+    readFileSync: ((target: string) => Buffer.from(files[target] ?? '')) as any,
+  });
+
+  it('returns an empty map for a directory that does not exist', () => {
+    expect(digestDirectory('nope', { fsImpl: fakeFs({}) }).size).toBe(0);
+  });
+
+  it('digests images and ignores non-image files', () => {
+    const result = digestDirectory('caps', {
+      fsImpl: fakeFs({
+        [path.join('caps', 'menu.png')]: 'pixels',
+        [path.join('caps', 'notes.txt')]: 'ignore me',
+      }),
+    });
+
+    expect([...result.keys()]).toEqual(['menu.png']);
+  });
+
+  it('gives identical content the same digest and different content a different one', () => {
+    const a = digestDirectory('caps', { fsImpl: fakeFs({ [path.join('caps', 'x.png')]: 'same' }) });
+    const b = digestDirectory('caps', { fsImpl: fakeFs({ [path.join('caps', 'x.png')]: 'same' }) });
+    const c = digestDirectory('caps', {
+      fsImpl: fakeFs({ [path.join('caps', 'x.png')]: 'different' }),
+    });
+
+    expect(a.get('x.png')).toBe(b.get('x.png'));
+    expect(a.get('x.png')).not.toBe(c.get('x.png'));
+  });
+
+  it('normalizes nested keys to forward slashes so baselines are portable across OSes', () => {
+    const result = digestDirectory('caps', {
+      fsImpl: fakeFs({ [path.join('caps', 'hud', 'health.png')]: 'pixels' }),
+    });
+
+    // A baseline captured on Linux must still match the same capture
+    // produced on a Windows runner.
+    expect([...result.keys()]).toEqual(['hud/health.png']);
+  });
+});

--- a/plugins/orchestrator/src/model/orchestrator/services/output/visual-baseline.ts
+++ b/plugins/orchestrator/src/model/orchestrator/services/output/visual-baseline.ts
@@ -1,0 +1,139 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Visual-regression comparison for the `images` / `visual-baseline` output
+ * types.
+ *
+ * Capture collection itself is already an output concern - the `images`
+ * built-in type ("Screenshots, render captures, atlas previews") predates
+ * this module. What was missing is the *comparison*: deciding whether this
+ * run's captures differ from the accepted reference set.
+ *
+ * Scope, deliberately: this compares by content digest, which answers
+ * "did this frame change at all?" exactly, with no image decoding and no
+ * native dependency. It does NOT do perceptual/threshold diffing - a
+ * one-pixel antialiasing change and a completely different frame both read
+ * as "changed". Perceptual diffing needs a real image codec and a tuned
+ * threshold; adding one is a separate decision, and pretending to do it
+ * with a byte hash would be worse than not offering it.
+ */
+
+export type VisualChangeKind = 'added' | 'removed' | 'changed' | 'unchanged';
+
+export interface VisualComparisonEntry {
+  /** Capture path relative to its directory root. */
+  name: string;
+  kind: VisualChangeKind;
+  baselineDigest?: string;
+  currentDigest?: string;
+}
+
+export interface VisualComparisonResult {
+  entries: VisualComparisonEntry[];
+  added: number;
+  removed: number;
+  changed: number;
+  unchanged: number;
+  /** True when nothing differs from the baseline. */
+  matchesBaseline: boolean;
+}
+
+const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.bmp', '.tga', '.webp']);
+
+export interface DigestDirectoryOptions {
+  fsImpl?: Pick<typeof fs, 'existsSync' | 'readdirSync' | 'readFileSync'>;
+}
+
+/**
+ * Maps every image under `root` to a content digest, keyed by its path
+ * relative to `root`. Missing directories yield an empty map rather than
+ * throwing - a first-ever run legitimately has no baseline yet.
+ */
+export function digestDirectory(
+  root: string,
+  options: DigestDirectoryOptions = {},
+): Map<string, string> {
+  const fsImpl = options.fsImpl ?? fs;
+  const digests = new Map<string, string>();
+
+  if (!fsImpl.existsSync(root)) return digests;
+
+  const walk = (directory: string): void => {
+    for (const entry of fsImpl.readdirSync(directory, { withFileTypes: true })) {
+      const full = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+        continue;
+      }
+
+      if (!IMAGE_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) continue;
+
+      const contents = fsImpl.readFileSync(full);
+      const digest = crypto.createHash('sha256').update(contents).digest('hex');
+      // Normalize to forward slashes so a baseline captured on Linux still
+      // matches the same capture produced on a Windows runner.
+      digests.set(path.relative(root, full).split(path.sep).join('/'), digest);
+    }
+  };
+
+  walk(root);
+
+  return digests;
+}
+
+/**
+ * Compares this run's captures against the accepted baseline.
+ *
+ * An empty baseline is reported as every capture being 'added' (and so
+ * `matchesBaseline: false`) rather than as a pass - a run with no reference
+ * to compare against has not been verified, and silently passing it would
+ * make the whole check vacuous on the first run and after any accidental
+ * baseline deletion.
+ */
+export function compareVisualCaptures(
+  baseline: Map<string, string>,
+  current: Map<string, string>,
+): VisualComparisonResult {
+  const entries: VisualComparisonEntry[] = [];
+  const names = new Set<string>([...baseline.keys(), ...current.keys()]);
+
+  for (const name of [...names].sort()) {
+    const baselineDigest = baseline.get(name);
+    const currentDigest = current.get(name);
+
+    let kind: VisualChangeKind;
+    if (baselineDigest === undefined) kind = 'added';
+    else if (currentDigest === undefined) kind = 'removed';
+    else if (baselineDigest !== currentDigest) kind = 'changed';
+    else kind = 'unchanged';
+
+    entries.push({ name, kind, baselineDigest, currentDigest });
+  }
+
+  const count = (kind: VisualChangeKind) => entries.filter((entry) => entry.kind === kind).length;
+  const added = count('added');
+  const removed = count('removed');
+  const changed = count('changed');
+
+  return {
+    entries,
+    added,
+    removed,
+    changed,
+    unchanged: count('unchanged'),
+    matchesBaseline: added === 0 && removed === 0 && changed === 0,
+  };
+}
+
+/** Human-readable one-line summary, for the build log. */
+export function summarizeVisualComparison(result: VisualComparisonResult): string {
+  if (result.entries.length === 0) return 'No visual captures found to compare.';
+  if (result.matchesBaseline) return `All ${result.unchanged} capture(s) match the baseline.`;
+
+  return (
+    `Visual differences: ${result.changed} changed, ${result.added} added, ` +
+    `${result.removed} removed, ${result.unchanged} unchanged.`
+  );
+}

--- a/plugins/orchestrator/src/model/orchestrator/services/provisioning/dedicated-server-provisioner.test.ts
+++ b/plugins/orchestrator/src/model/orchestrator/services/provisioning/dedicated-server-provisioner.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateDockerCompose,
+  generateSystemdUnit,
+  generateFirewallRules,
+  DedicatedServerConfig,
+} from './dedicated-server-provisioner';
+
+const baseConfig: DedicatedServerConfig = {
+  name: 'my-game-server',
+  image: 'ghcr.io/example/my-game-server:1.2.3',
+  ports: [
+    { port: 27015, protocol: 'udp', description: 'Game traffic' },
+    { port: 27016, protocol: 'tcp', description: 'RCON' },
+  ],
+};
+
+describe('generateDockerCompose', () => {
+  it('publishes each port with its explicit protocol', () => {
+    const compose = generateDockerCompose(baseConfig);
+
+    // A UDP game port silently published as TCP produces a server that
+    // starts fine and is simply unreachable.
+    expect(compose).toContain('- "27015:27015/udp"');
+    expect(compose).toContain('- "27016:27016/tcp"');
+  });
+
+  it("translates on-failure into compose's retry-count form", () => {
+    expect(generateDockerCompose(baseConfig)).toContain('restart: on-failure:3');
+    expect(generateDockerCompose({ ...baseConfig, restart: 'always' })).toContain(
+      'restart: always',
+    );
+  });
+
+  it('emits environment and volume entries when configured', () => {
+    const compose = generateDockerCompose({
+      ...baseConfig,
+      environment: { MAX_PLAYERS: '32', SERVER_NAME: 'Test Server' },
+      dataPath: '/srv/game/data',
+    });
+
+    expect(compose).toContain('MAX_PLAYERS: "32"');
+    // Quoted so a value with spaces survives YAML parsing.
+    expect(compose).toContain('SERVER_NAME: "Test Server"');
+    expect(compose).toContain('- "/srv/game/data:/data"');
+  });
+
+  it('gives the health check a start period so slow world loads are not failures', () => {
+    const compose = generateDockerCompose({
+      ...baseConfig,
+      healthCheckCommand: 'curl -f localhost:8080/health',
+    });
+
+    expect(compose).toContain('healthcheck:');
+    expect(compose).toContain('start_period: 30s');
+  });
+
+  it('omits the healthcheck block entirely when no command is given', () => {
+    expect(generateDockerCompose(baseConfig)).not.toContain('healthcheck:');
+  });
+});
+
+describe('generateSystemdUnit', () => {
+  it('orders the unit after docker so a reboot does not race the daemon', () => {
+    const unit = generateSystemdUnit(baseConfig);
+
+    expect(unit).toContain('After=network-online.target docker.service');
+    expect(unit).toContain('Requires=docker.service');
+  });
+
+  it('removes a stale container before starting, so a crash cannot block the next start', () => {
+    expect(generateSystemdUnit(baseConfig)).toContain(
+      'ExecStartPre=-/usr/bin/docker rm -f my-game-server',
+    );
+  });
+
+  it('does not run as root by default', () => {
+    expect(generateSystemdUnit(baseConfig)).toContain('User=my-game-server');
+    expect(generateSystemdUnit({ ...baseConfig, user: 'gameuser' })).toContain('User=gameuser');
+  });
+
+  it('publishes every port on the docker run line', () => {
+    const unit = generateSystemdUnit(baseConfig);
+
+    expect(unit).toContain('-p 27015:27015/udp');
+    expect(unit).toContain('-p 27016:27016/tcp');
+  });
+});
+
+describe('generateFirewallRules', () => {
+  it('opens each port with its protocol and description', () => {
+    expect(generateFirewallRules(baseConfig)).toEqual([
+      'ufw allow 27015/udp comment "Game traffic"',
+      'ufw allow 27016/tcp comment "RCON"',
+    ]);
+  });
+});
+
+describe('validation', () => {
+  it('rejects a config with no ports', () => {
+    expect(() => generateDockerCompose({ ...baseConfig, ports: [] })).toThrow(/at least one port/i);
+  });
+
+  it('rejects an out-of-range port', () => {
+    expect(() =>
+      generateDockerCompose({ ...baseConfig, ports: [{ port: 70000, protocol: 'tcp' }] }),
+    ).toThrow(/out-of-range/i);
+  });
+
+  it('rejects the same port twice on one protocol', () => {
+    expect(() =>
+      generateDockerCompose({
+        ...baseConfig,
+        ports: [
+          { port: 27015, protocol: 'udp' },
+          { port: 27015, protocol: 'udp' },
+        ],
+      }),
+    ).toThrow(/more than once/i);
+  });
+
+  it('allows the same port number on tcp and udp, which is legitimate', () => {
+    expect(() =>
+      generateDockerCompose({
+        ...baseConfig,
+        ports: [
+          { port: 27015, protocol: 'udp' },
+          { port: 27015, protocol: 'tcp' },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects an empty image or name', () => {
+    expect(() => generateDockerCompose({ ...baseConfig, image: '' })).toThrow(/image/i);
+    expect(() => generateDockerCompose({ ...baseConfig, name: '  ' })).toThrow(/name/i);
+  });
+});

--- a/plugins/orchestrator/src/model/orchestrator/services/provisioning/dedicated-server-provisioner.ts
+++ b/plugins/orchestrator/src/model/orchestrator/services/provisioning/dedicated-server-provisioner.ts
@@ -1,0 +1,184 @@
+/**
+ * Dedicated-server provisioning artifacts.
+ *
+ * Orchestrator already decides *where* a job runs (see providers/: aws,
+ * azure-aci, gcp-cloud-run, k8s, docker, local, ...). Shipping a server
+ * build is the same question one step later - given this build, what does
+ * it take to actually run it somewhere - so it belongs here rather than in
+ * a standalone plugin.
+ *
+ * Everything in this module is a pure function from config to file
+ * contents. Nothing is written to disk and nothing is executed: the caller
+ * decides where the artifacts go, which keeps this testable and makes it
+ * impossible for a generator bug to mutate a real host.
+ */
+
+export interface ServerPort {
+  /** Port number on the host. */
+  port: number;
+  protocol: 'tcp' | 'udp';
+  /** What this port is for, used as a comment in generated output. */
+  description?: string;
+}
+
+export interface DedicatedServerConfig {
+  /** Service name; used for the container, systemd unit and image tag. */
+  name: string;
+  /** Container image to run. */
+  image: string;
+  /** Ports the server listens on. */
+  ports: ServerPort[];
+  /** Environment variables passed to the server process. */
+  environment?: Record<string, string>;
+  /** Host path mounted for persistent state (save games, world data). */
+  dataPath?: string;
+  /** Command used by the health check, if the server exposes one. */
+  healthCheckCommand?: string;
+  /** Restart policy for both docker-compose and systemd. */
+  restart?: 'no' | 'on-failure' | 'always';
+  /** User the systemd unit runs as. Never root by default. */
+  user?: string;
+}
+
+const DEFAULT_RESTART: NonNullable<DedicatedServerConfig['restart']> = 'on-failure';
+
+/**
+ * Game servers are overwhelmingly UDP, and a compose file that silently
+ * publishes UDP ports as TCP produces a server that starts cleanly and is
+ * simply unreachable - so the protocol is always written explicitly.
+ */
+function formatPort(port: ServerPort): string {
+  return `"${port.port}:${port.port}/${port.protocol}"`;
+}
+
+function assertValidConfig(config: DedicatedServerConfig): void {
+  if (!config.name.trim()) throw new Error('Dedicated server config requires a non-empty name.');
+  if (!config.image.trim()) throw new Error(`Dedicated server "${config.name}" requires an image.`);
+  if (config.ports.length === 0) {
+    throw new Error(`Dedicated server "${config.name}" requires at least one port.`);
+  }
+
+  const seen = new Set<string>();
+  for (const port of config.ports) {
+    if (!Number.isInteger(port.port) || port.port < 1 || port.port > 65535) {
+      throw new Error(`Dedicated server "${config.name}" has an out-of-range port: ${port.port}.`);
+    }
+
+    // The same number on tcp and udp is legitimate and common; the same
+    // number twice on one protocol is a config bug that docker would only
+    // surface at run time.
+    const key = `${port.port}/${port.protocol}`;
+    if (seen.has(key)) {
+      throw new Error(`Dedicated server "${config.name}" declares ${key} more than once.`);
+    }
+    seen.add(key);
+  }
+}
+
+/** Generates a docker-compose service definition for the server. */
+export function generateDockerCompose(config: DedicatedServerConfig): string {
+  assertValidConfig(config);
+
+  const restart = config.restart ?? DEFAULT_RESTART;
+  // compose has no 'on-failure' literal - it spells the same policy as
+  // 'on-failure:<retries>'; 'no'/'always' pass through unchanged.
+  const composeRestart = restart === 'on-failure' ? 'on-failure:3' : restart;
+
+  const lines: string[] = [
+    'services:',
+    `  ${config.name}:`,
+    `    image: ${config.image}`,
+    `    container_name: ${config.name}`,
+    `    restart: ${composeRestart}`,
+    '    ports:',
+    ...config.ports.map((port) => `      - ${formatPort(port)}`),
+  ];
+
+  const environment = config.environment ?? {};
+  const environmentKeys = Object.keys(environment).sort();
+  if (environmentKeys.length > 0) {
+    lines.push('    environment:');
+    for (const key of environmentKeys) {
+      lines.push(`      ${key}: ${JSON.stringify(environment[key])}`);
+    }
+  }
+
+  if (config.dataPath) {
+    lines.push('    volumes:', `      - ${JSON.stringify(`${config.dataPath}:/data`)}`);
+  }
+
+  if (config.healthCheckCommand) {
+    lines.push(
+      '    healthcheck:',
+      `      test: ${JSON.stringify(['CMD-SHELL', config.healthCheckCommand])}`,
+      '      interval: 30s',
+      '      timeout: 5s',
+      '      retries: 3',
+      // Cold-starting a game server (loading a world, warming caches) can
+      // easily exceed the retry budget; start_period keeps those early
+      // failures from being counted as unhealthy.
+      '      start_period: 30s',
+    );
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+/** Generates a systemd unit that runs the server via docker. */
+export function generateSystemdUnit(config: DedicatedServerConfig): string {
+  assertValidConfig(config);
+
+  const restart = config.restart ?? DEFAULT_RESTART;
+  const publish = config.ports.map((port) => `-p ${port.port}:${port.port}/${port.protocol}`);
+  const environment = config.environment ?? {};
+  const environmentArguments = Object.keys(environment)
+    .sort()
+    .map((key) => `-e ${key}=${JSON.stringify(environment[key])}`);
+  const volume = config.dataPath ? [`-v ${JSON.stringify(`${config.dataPath}:/data`)}`] : [];
+
+  const runArguments = [
+    'run',
+    '--rm',
+    `--name ${config.name}`,
+    ...publish,
+    ...environmentArguments,
+    ...volume,
+    config.image,
+  ].join(' ');
+
+  return [
+    '[Unit]',
+    `Description=${config.name} dedicated server`,
+    // Without these, a reboot races the unit against dockerd and the server
+    // fails to start until something restarts it manually.
+    'After=network-online.target docker.service',
+    'Wants=network-online.target',
+    'Requires=docker.service',
+    '',
+    '[Service]',
+    'Type=simple',
+    `User=${config.user ?? config.name}`,
+    `Restart=${restart}`,
+    'RestartSec=5',
+    // --rm plus a pre-stop cleanup keeps a crashed container from blocking
+    // the next start with a name conflict.
+    `ExecStartPre=-/usr/bin/docker rm -f ${config.name}`,
+    `ExecStart=/usr/bin/docker ${runArguments}`,
+    `ExecStop=/usr/bin/docker stop ${config.name}`,
+    '',
+    '[Install]',
+    'WantedBy=multi-user.target',
+    '',
+  ].join('\n');
+}
+
+/** Generates the ufw commands needed to open the server's ports. */
+export function generateFirewallRules(config: DedicatedServerConfig): string[] {
+  assertValidConfig(config);
+
+  return config.ports.map((port) => {
+    const comment = port.description ? ` comment ${JSON.stringify(port.description)}` : '';
+
+    return `ufw allow ${port.port}/${port.protocol}${comment}`;
+  });
+}


### PR DESCRIPTION
Implements five capabilities as **real orchestrator features**, replacing the standalone plugin skeletons drafted in #128, #130, #132, #133 and #136 (now removed from #142).

## Why these belong here

A plugin exists to add **user-facing command surface** — a new verb, engine, or deploy target (`steam-deploy`, `runtime-test-framework`, the engine plugins). None of these five are that. They are things that happen *to* a build or a running job, which is exactly orchestrator's domain: it already owns `providers/` (where a job runs) plus `services/` for cache, hooks, output, preflight, reliability, secrets and sync.

Two overlapped existing orchestrator surface outright:
- **anti-cheat** registered `options:` and **no command at all** — it hooks into an existing build, which is precisely `services/hooks/middleware-service`.
- **screen-capture** duplicated the built-in `images` output type (*"Screenshots, render captures, atlas previews"*).

## What landed

**`symbol-collector.ts` + `symbols` output type** — finds dSYM bundles, PDB, Breakpad, DWARF and IL2CPP maps. Sits beside the existing `coverage`/`logs`/`metrics` built-ins, because symbols must be captured at build time or they're gone: once the machine is torn down, every future crash report from that build is unsymbolicatable. A `.dSYM` is reported as **one bundle entry** rather than descended into — the symbolicator needs the bundle intact. Uploading is left to the existing `ArtifactUploadHandler`; no vendor-specific upload path here.

**`visual-baseline.ts` + `visual-baseline` output type** — digest-based comparison against the accepted reference set. **Deliberately not perceptual diffing:** a byte hash answers *"did this change at all"* exactly with no image codec, and pretending it were a threshold diff would be worse than not offering one. An empty baseline reports as **unverified rather than a pass**, so the check can't go vacuous on a first run or after an accidental baseline deletion.

**`dedicated-server-provisioner.ts`** — docker-compose, systemd unit and `ufw` rules from a typed config. Pure functions: nothing written, nothing executed, so a generator bug can't mutate a real host. Port protocol is always explicit (a UDP game port published as TCP gives a server that starts cleanly and is silently unreachable); the unit is ordered `After=docker.service` so a reboot doesn't race the daemon; it doesn't run as root by default.

**`service-directory.ts`** — registry for exposed job endpoints, where the **disclosure rules are the actual content**. An ephemeral tunnel URL is an unauthenticated entry point into a machine holding source and credentials, and CI logs are often public or archived — so visibility is explicit per service, and `formatForLog` redacts the *whole* URL. A random subdomain **is** the secret, so partial masking would still leak the reachable address. It doesn't start tunnels; a caller registers whatever URL it resolved (cloudflared, ngrok, LAN, k8s Service).

**`anti-cheat-middleware.ts`** — preset over the existing `Middleware` type. Runs at `post-build` (ahead of default-priority packaging, or an unprotected binary ships) with `allowFailure` forced to `false` and not configurable — a build that skipped its integrity step but still produced a shippable player is the worst outcome, since it looks successful. The SDKs are NDA-gated, so the command is caller-supplied rather than guessed, and credentials go through `OrchestratorSecret` instead of being interpolated into a shell string.

All five are exported from the package entry point.

## Verification

- **50 new tests, passing under _both_ vitest and bun.** They avoid `vi.mock(module, fn)` — which is what makes the 244 pre-existing orchestrator tests fail under bun's runner — so this adds **none** to that baseline.
- `tsc --noEmit` clean; `oxfmt` applied to the new files only.
- Build artifacts (`plugins/unity/dist`, `bun.lock`) deliberately reverted rather than committed.

## Merge order

Please merge this **before** #142 — #142 has already had these five skeletons removed, so landing this first keeps the catalog coherent at every commit.