### PR TITLE
chore: mark all 12 non-core plugins as experimental

### DIFF
--- a/plugins/code-signing/README.md
+++ b/plugins/code-signing/README.md
@@ -1,3 +1,8 @@
+> **EXPERIMENTAL — NOT IMPLEMENTED.** This is a structural draft only: the plugin
+> shape is real, but its domain logic is not written. Any command it claims will
+> throw. It is not published to npm and is never loaded unless you pass
+> `--plugin @game-ci/code-signing` explicitly.
+
 # @game-ci/code-signing (draft)
 
 macOS notarization (`xcrun notarytool` + stapling) and Windows

--- a/plugins/code-signing/package.json
+++ b/plugins/code-signing/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@game-ci/code-signing",
   "version": "0.0.1",
-  "description": "Code-signing and notarization plugin (draft). macOS notarization (xcrun notarytool + stapling) and Windows Authenticode signing for built players.",
+  "private": true,
+  "description": "EXPERIMENTAL (draft, not implemented): Code-signing and notarization plugin (draft). macOS notarization (xcrun notarytool + stapling) and Windows Authenticode signing for built players.",
   "license": "MIT",
   "repository": "git@github.com:game-ci/cli.git",
   "files": [

--- a/plugins/code-signing/src/index.ts
+++ b/plugins/code-signing/src/index.ts
@@ -15,6 +15,19 @@ export const codeSigningPlugin = {
   name: "code-signing",
   version: "0.0.1",
 
+  /**
+   * Loaded only via an explicit --plugin flag, never by default, so
+   * reaching this point is deliberate - warn rather than fail, but make
+   * it impossible to mistake for a working integration.
+   */
+  onLoad() {
+    console.warn(
+      "[game-ci] WARNING: @game-ci/code-signing is an EXPERIMENTAL draft plugin. " +
+        "Its structure is real but its domain logic is not implemented - any command it " +
+        "claims will throw. Do not depend on it. See plugins/code-signing/README.md.",
+    );
+  },
+
   commands: [
     {
       engine: "*",

--- a/plugins/gamemaker/README.md
+++ b/plugins/gamemaker/README.md
@@ -1,3 +1,8 @@
+> **EXPERIMENTAL — NOT IMPLEMENTED.** This is a structural draft only: the plugin
+> shape is real, but its domain logic is not written. Any command it claims will
+> throw. It is not published to npm and is never loaded unless you pass
+> `--plugin @game-ci/gamemaker` explicitly.
+
 # @game-ci/gamemaker (draft)
 
 GameMaker Studio engine plugin. **Not functional yet** - this is a structural

--- a/plugins/gamemaker/package.json
+++ b/plugins/gamemaker/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@game-ci/gamemaker",
   "version": "0.0.1",
-  "description": "GameMaker Studio engine plugin (draft). Wraps GameMaker's official Igor CLI for project builds.",
+  "private": true,
+  "description": "EXPERIMENTAL (draft, not implemented): GameMaker Studio engine plugin (draft). Wraps GameMaker's official Igor CLI for project builds.",
   "license": "MIT",
   "repository": "git@github.com:game-ci/cli.git",
   "files": [

--- a/plugins/gamemaker/src/index.ts
+++ b/plugins/gamemaker/src/index.ts
@@ -23,6 +23,19 @@ export const gamemakerPlugin = {
   name: "gamemaker",
   version: "0.0.1",
 
+  /**
+   * Loaded only via an explicit --plugin flag, never by default, so
+   * reaching this point is deliberate - warn rather than fail, but make
+   * it impossible to mistake for a working integration.
+   */
+  onLoad() {
+    console.warn(
+      "[game-ci] WARNING: @game-ci/gamemaker is an EXPERIMENTAL draft plugin. " +
+        "Its structure is real but its domain logic is not implemented - any command it " +
+        "claims will throw. Do not depend on it. See plugins/gamemaker/README.md.",
+    );
+  },
+
   engineDetectors: [
     {
       name: "gamemaker",

--- a/plugins/github-release-deploy/README.md
+++ b/plugins/github-release-deploy/README.md
@@ -1,3 +1,8 @@
+> **EXPERIMENTAL — NOT IMPLEMENTED.** This is a structural draft only: the plugin
+> shape is real, but its domain logic is not written. Any command it claims will
+> throw. It is not published to npm and is never loaded unless you pass
+> `--plugin @game-ci/github-release-deploy` explicitly.
+
 # @game-ci/github-release-deploy (draft)
 
 GitHub/GitLab Release deploy plugin. **Not functional yet** - structural

--- a/plugins/github-release-deploy/package.json
+++ b/plugins/github-release-deploy/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@game-ci/github-release-deploy",
   "version": "0.0.1",
-  "description": "GitHub/GitLab Release deploy plugin (draft). Attaches built artifacts to a GitHub or GitLab Release, for games distributed outside Steam/itch.",
+  "private": true,
+  "description": "EXPERIMENTAL (draft, not implemented): GitHub/GitLab Release deploy plugin (draft). Attaches built artifacts to a GitHub or GitLab Release, for games distributed outside Steam/itch.",
   "license": "MIT",
   "repository": "git@github.com:game-ci/cli.git",
   "files": [

--- a/plugins/github-release-deploy/src/index.ts
+++ b/plugins/github-release-deploy/src/index.ts
@@ -16,6 +16,19 @@ export const githubReleaseDeployPlugin = {
   name: "github-release-deploy",
   version: "0.0.1",
 
+  /**
+   * Loaded only via an explicit --plugin flag, never by default, so
+   * reaching this point is deliberate - warn rather than fail, but make
+   * it impossible to mistake for a working integration.
+   */
+  onLoad() {
+    console.warn(
+      "[game-ci] WARNING: @game-ci/github-release-deploy is an EXPERIMENTAL draft plugin. " +
+        "Its structure is real but its domain logic is not implemented - any command it " +
+        "claims will throw. Do not depend on it. See plugins/github-release-deploy/README.md.",
+    );
+  },
+
   commands: [
     {
       engine: "*",

--- a/plugins/itch-deploy/README.md
+++ b/plugins/itch-deploy/README.md
@@ -1,3 +1,8 @@
+> **EXPERIMENTAL — NOT IMPLEMENTED.** This is a structural draft only: the plugin
+> shape is real, but its domain logic is not written. Any command it claims will
+> throw. It is not published to npm and is never loaded unless you pass
+> `--plugin @game-ci/itch-deploy` explicitly.
+
 # @game-ci/itch-deploy (draft)
 
 itch.io deploy plugin. **Not functional yet** - structural skeleton only.

--- a/plugins/itch-deploy/package.json
+++ b/plugins/itch-deploy/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@game-ci/itch-deploy",
   "version": "0.0.1",
-  "description": "itch.io deploy plugin (draft). Wraps butler push for itch.io channel deploys.",
+  "private": true,
+  "description": "EXPERIMENTAL (draft, not implemented): itch.io deploy plugin (draft). Wraps butler push for itch.io channel deploys.",
   "license": "MIT",
   "repository": "git@github.com:game-ci/cli.git",
   "files": [

--- a/plugins/itch-deploy/src/index.ts
+++ b/plugins/itch-deploy/src/index.ts
@@ -13,6 +13,19 @@ export const itchDeployPlugin = {
   name: "itch-deploy",
   version: "0.0.1",
 
+  /**
+   * Loaded only via an explicit --plugin flag, never by default, so
+   * reaching this point is deliberate - warn rather than fail, but make
+   * it impossible to mistake for a working integration.
+   */
+  onLoad() {
+    console.warn(
+      "[game-ci] WARNING: @game-ci/itch-deploy is an EXPERIMENTAL draft plugin. " +
+        "Its structure is real but its domain logic is not implemented - any command it " +
+        "claims will throw. Do not depend on it. See plugins/itch-deploy/README.md.",
+    );
+  },
+
   commands: [
     {
       engine: "*",

--- a/plugins/live-show/README.md
+++ b/plugins/live-show/README.md
@@ -1,3 +1,8 @@
+> **EXPERIMENTAL — NOT IMPLEMENTED.** This is a structural draft only: the plugin
+> shape is real, but its domain logic is not written. Any command it claims will
+> throw. It is not published to npm and is never loaded unless you pass
+> `--plugin @game-ci/live-show` explicitly.
+
 # @game-ci/live-show (draft)
 
 Scripted/AI-driven attract-mode playthrough that auto-restarts on crash

--- a/plugins/live-show/package.json
+++ b/plugins/live-show/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@game-ci/live-show",
   "version": "0.0.1",
-  "description": "Live Show / Automated Demo plugin (draft). Scripted or AI-driven attract-mode playthrough that auto-restarts on crash and can stream output; doubles as an unattended soak test.",
+  "private": true,
+  "description": "EXPERIMENTAL (draft, not implemented): Live Show / Automated Demo plugin (draft). Scripted or AI-driven attract-mode playthrough that auto-restarts on crash and can stream output; doubles as an unattended soak test.",
   "license": "MIT",
   "repository": "git@github.com:game-ci/cli.git",
   "files": [

--- a/plugins/live-show/src/index.ts
+++ b/plugins/live-show/src/index.ts
@@ -14,6 +14,19 @@ export const liveShowPlugin = {
   name: "live-show",
   version: "0.0.1",
 
+  /**
+   * Loaded only via an explicit --plugin flag, never by default, so
+   * reaching this point is deliberate - warn rather than fail, but make
+   * it impossible to mistake for a working integration.
+   */
+  onLoad() {
+    console.warn(
+      "[game-ci] WARNING: @game-ci/live-show is an EXPERIMENTAL draft plugin. " +
+        "Its structure is real but its domain logic is not implemented - any command it " +
+        "claims will throw. Do not depend on it. See plugins/live-show/README.md.",
+    );
+  },
+
   commands: [
     {
       engine: "*",

--- a/plugins/pseudo-localization/README.md
+++ b/plugins/pseudo-localization/README.md
@@ -1,3 +1,8 @@
+> **EXPERIMENTAL — NOT IMPLEMENTED.** This is a structural draft only: the plugin
+> shape is real, but its domain logic is not written. Any command it claims will
+> throw. It is not published to npm and is never loaded unless you pass
+> `--plugin @game-ci/pseudo-localization` explicitly.
+
 # @game-ci/pseudo-localization (draft)
 
 Injects pseudo-loc strings pre-translation to catch UI overflow/

--- a/plugins/pseudo-localization/package.json
+++ b/plugins/pseudo-localization/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@game-ci/pseudo-localization",
   "version": "0.0.1",
-  "description": "Pseudo-localization QA plugin (draft). Injects pseudo-loc strings pre-translation to catch UI overflow/truncation bugs.",
+  "private": true,
+  "description": "EXPERIMENTAL (draft, not implemented): Pseudo-localization QA plugin (draft). Injects pseudo-loc strings pre-translation to catch UI overflow/truncation bugs.",
   "license": "MIT",
   "repository": "git@github.com:game-ci/cli.git",
   "files": [

--- a/plugins/pseudo-localization/src/index.ts
+++ b/plugins/pseudo-localization/src/index.ts
@@ -15,6 +15,19 @@ export const pseudoLocalizationPlugin = {
   name: "pseudo-localization",
   version: "0.0.1",
 
+  /**
+   * Loaded only via an explicit --plugin flag, never by default, so
+   * reaching this point is deliberate - warn rather than fail, but make
+   * it impossible to mistake for a working integration.
+   */
+  onLoad() {
+    console.warn(
+      "[game-ci] WARNING: @game-ci/pseudo-localization is an EXPERIMENTAL draft plugin. " +
+        "Its structure is real but its domain logic is not implemented - any command it " +
+        "claims will throw. Do not depend on it. See plugins/pseudo-localization/README.md.",
+    );
+  },
+
   commands: [
     {
       engine: "*",

--- a/plugins/renpy/README.md
+++ b/plugins/renpy/README.md
@@ -1,3 +1,8 @@
+> **EXPERIMENTAL — NOT IMPLEMENTED.** This is a structural draft only: the plugin
+> shape is real, but its domain logic is not written. Any command it claims will
+> throw. It is not published to npm and is never loaded unless you pass
+> `--plugin @game-ci/renpy` explicitly.
+
 # @game-ci/renpy (draft)
 
 Ren'Py engine plugin. **Not functional yet** - structural skeleton only.

--- a/plugins/renpy/package.json
+++ b/plugins/renpy/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@game-ci/renpy",
   "version": "0.0.1",
-  "description": "Ren'Py engine plugin (draft). Wraps Ren'Py's distribute command for cross-platform archive builds.",
+  "private": true,
+  "description": "EXPERIMENTAL (draft, not implemented): Ren'Py engine plugin (draft). Wraps Ren'Py's distribute command for cross-platform archive builds.",
   "license": "MIT",
   "repository": "git@github.com:game-ci/cli.git",
   "files": [

--- a/plugins/renpy/src/index.ts
+++ b/plugins/renpy/src/index.ts
@@ -17,6 +17,19 @@ export const renpyPlugin = {
   name: "renpy",
   version: "0.0.1",
 
+  /**
+   * Loaded only via an explicit --plugin flag, never by default, so
+   * reaching this point is deliberate - warn rather than fail, but make
+   * it impossible to mistake for a working integration.
+   */
+  onLoad() {
+    console.warn(
+      "[game-ci] WARNING: @game-ci/renpy is an EXPERIMENTAL draft plugin. " +
+        "Its structure is real but its domain logic is not implemented - any command it " +
+        "claims will throw. Do not depend on it. See plugins/renpy/README.md.",
+    );
+  },
+
   engineDetectors: [
     {
       name: "renpy",

--- a/plugins/rpg-maker/README.md
+++ b/plugins/rpg-maker/README.md
@@ -1,3 +1,8 @@
+> **EXPERIMENTAL — NOT IMPLEMENTED.** This is a structural draft only: the plugin
+> shape is real, but its domain logic is not written. Any command it claims will
+> throw. It is not published to npm and is never loaded unless you pass
+> `--plugin @game-ci/rpg-maker` explicitly.
+
 # @game-ci/rpg-maker (draft)
 
 RPG Maker (MV/MZ) engine plugin. **Not functional yet** - structural skeleton

--- a/plugins/rpg-maker/package.json
+++ b/plugins/rpg-maker/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@game-ci/rpg-maker",
   "version": "0.0.1",
-  "description": "RPG Maker engine plugin (draft). Wraps RPG Maker MV/MZ's NW.js export packaging.",
+  "private": true,
+  "description": "EXPERIMENTAL (draft, not implemented): RPG Maker engine plugin (draft). Wraps RPG Maker MV/MZ's NW.js export packaging.",
   "license": "MIT",
   "repository": "git@github.com:game-ci/cli.git",
   "files": [

--- a/plugins/rpg-maker/src/index.ts
+++ b/plugins/rpg-maker/src/index.ts
@@ -19,6 +19,19 @@ export const rpgMakerPlugin = {
   name: "rpg-maker",
   version: "0.0.1",
 
+  /**
+   * Loaded only via an explicit --plugin flag, never by default, so
+   * reaching this point is deliberate - warn rather than fail, but make
+   * it impossible to mistake for a working integration.
+   */
+  onLoad() {
+    console.warn(
+      "[game-ci] WARNING: @game-ci/rpg-maker is an EXPERIMENTAL draft plugin. " +
+        "Its structure is real but its domain logic is not implemented - any command it " +
+        "claims will throw. Do not depend on it. See plugins/rpg-maker/README.md.",
+    );
+  },
+
   engineDetectors: [
     {
       name: "rpg-maker",

--- a/plugins/runtime-test-framework/README.md
+++ b/plugins/runtime-test-framework/README.md
@@ -1,3 +1,7 @@
+> **EXPERIMENTAL.** This plugin is implemented and loaded by default, but its
+> behaviour and options may still change without a major version bump.
+> Do not depend on it in a production pipeline yet.
+
 # @game-ci/runtime-test-framework
 
 GPU-free, assertion-based tests run against the actual _built player_, not

--- a/plugins/runtime-test-framework/package.json
+++ b/plugins/runtime-test-framework/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@game-ci/runtime-test-framework",
   "version": "0.1.0",
-  "description": "Runtime Test Framework plugin. `game-ci test-runtime <buildPath>` runs GPU-free, assertion-based tests against the actual built player, not the editor.",
+  "private": true,
+  "description": "EXPERIMENTAL: Runtime Test Framework plugin. `game-ci test-runtime <buildPath>` runs GPU-free, assertion-based tests against the actual built player, not the editor.",
   "license": "MIT",
   "repository": "git@github.com:game-ci/cli.git",
   "files": [

--- a/plugins/runtime-test-framework/src/index.ts
+++ b/plugins/runtime-test-framework/src/index.ts
@@ -21,6 +21,15 @@ export const runtimeTestFrameworkPlugin = {
       engine: "*",
       createCommand(command: string, _subCommands: string[]) {
         if (command === "test-runtime") {
+          // Warned here rather than in onLoad: this plugin is in cli.ts's
+          // default load list, so an onLoad warning would fire on every
+          // single game-ci invocation and train people to ignore warnings.
+          // This fires exactly when the experimental feature is used.
+          console.warn(
+            "[game-ci] WARNING: `test-runtime` is EXPERIMENTAL. It is implemented, but the " +
+              "results-file contract it relies on may still change. Do not depend on it in " +
+              "production pipelines yet.",
+          );
           return new RuntimeTestCommand();
         }
         return null;

--- a/plugins/save-data-compat/README.md
+++ b/plugins/save-data-compat/README.md
@@ -1,3 +1,8 @@
+> **EXPERIMENTAL — NOT IMPLEMENTED.** This is a structural draft only: the plugin
+> shape is real, but its domain logic is not written. Any command it claims will
+> throw. It is not published to npm and is never loaded unless you pass
+> `--plugin @game-ci/save-data-compat` explicitly.
+
 # @game-ci/save-data-compat (draft)
 
 Verifies new builds can still load a maintained corpus of historical save

--- a/plugins/save-data-compat/package.json
+++ b/plugins/save-data-compat/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@game-ci/save-data-compat",
   "version": "0.0.1",
-  "description": "Save-Data Cross-Version Compatibility plugin (draft). Verifies new builds can still load a maintained corpus of historical save files.",
+  "private": true,
+  "description": "EXPERIMENTAL (draft, not implemented): Save-Data Cross-Version Compatibility plugin (draft). Verifies new builds can still load a maintained corpus of historical save files.",
   "license": "MIT",
   "repository": "git@github.com:game-ci/cli.git",
   "files": [

--- a/plugins/save-data-compat/src/index.ts
+++ b/plugins/save-data-compat/src/index.ts
@@ -14,6 +14,19 @@ export const saveDataCompatPlugin = {
   name: "save-data-compat",
   version: "0.0.1",
 
+  /**
+   * Loaded only via an explicit --plugin flag, never by default, so
+   * reaching this point is deliberate - warn rather than fail, but make
+   * it impossible to mistake for a working integration.
+   */
+  onLoad() {
+    console.warn(
+      "[game-ci] WARNING: @game-ci/save-data-compat is an EXPERIMENTAL draft plugin. " +
+        "Its structure is real but its domain logic is not implemented - any command it " +
+        "claims will throw. Do not depend on it. See plugins/save-data-compat/README.md.",
+    );
+  },
+
   commands: [
     {
       engine: "*",

--- a/plugins/steam-deploy/README.md
+++ b/plugins/steam-deploy/README.md
@@ -1,0 +1,11 @@
+# @game-ci/steam-deploy
+
+> **EXPERIMENTAL.** Implemented and loaded by default, but its behaviour and options
+> may still change without a major version bump. A Steam upload cannot be undone, so
+> verify against a test branch before pointing it at a live one.
+
+`game-ci deploy steam <buildPath>` - generates the app/depot VDFs and runs SteamCMD,
+either locally or in Docker.
+
+Credentials are read from the environment (never passed as CLI arguments, since argv
+can leak through process listings and command logging).

--- a/plugins/steam-deploy/package.json
+++ b/plugins/steam-deploy/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@game-ci/steam-deploy",
   "version": "0.1.0",
-  "description": "Deploy a pre-built game output to Steam via SteamCMD. Engine-agnostic - works on any built output folder, regardless of what built it.",
+  "private": true,
+  "description": "EXPERIMENTAL: Deploy a pre-built game output to Steam via SteamCMD. Engine-agnostic - works on any built output folder, regardless of what built it.",
   "license": "MIT",
   "repository": "git@github.com:game-ci/cli.git",
   "files": [

--- a/plugins/steam-deploy/src/index.ts
+++ b/plugins/steam-deploy/src/index.ts
@@ -17,6 +17,15 @@ export const steamDeployPlugin = {
       engine: "*",
       createCommand(command: string, subCommands: string[]) {
         if (command === "deploy" && subCommands[0] === "steam") {
+          // Warned here rather than in onLoad: this plugin is in cli.ts's
+          // default load list, so an onLoad warning would fire on every
+          // single game-ci invocation and train people to ignore warnings.
+          // This fires exactly when the experimental feature is used - and
+          // a Steam upload is irreversible once it reaches a live branch.
+          console.warn(
+            "[game-ci] WARNING: `deploy steam` is EXPERIMENTAL. Verify against a test branch " +
+              "before pointing it at a live one - a Steam upload cannot be undone.",
+          );
           return new SteamDeployCommand();
         }
         return null;

--- a/plugins/steam-workshop/README.md
+++ b/plugins/steam-workshop/README.md
@@ -1,3 +1,8 @@
+> **EXPERIMENTAL — NOT IMPLEMENTED.** A structural draft only: the plugin shape
+> is real, but its domain logic is not written, so any command it claims will
+> throw. Not published to npm, and never loaded unless you pass
+> `--plugin @game-ci/steam-workshop` explicitly.
+
 # @game-ci/steam-workshop (draft)
 
 Steam Workshop / mod-publishing plugin. **Not functional yet** - structural

--- a/plugins/steam-workshop/package.json
+++ b/plugins/steam-workshop/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@game-ci/steam-workshop",
   "version": "0.0.1",
-  "description": "Steam Workshop / mod-publishing plugin (draft). Wraps SteamCMD's workshop_build_item.vdf upload path for mods/maps/asset packs - a distinct target and VDF schema from a full game build (see @game-ci/steam-deploy).",
+  "private": true,
+  "description": "EXPERIMENTAL (draft, not implemented): Steam Workshop / mod-publishing plugin (draft). Wraps SteamCMD's workshop_build_item.vdf upload path for mods/maps/asset packs - a distinct target and VDF schema from a full game build (see @game-ci/steam-deploy).",
   "license": "MIT",
   "repository": "git@github.com:game-ci/cli.git",
   "files": [

--- a/plugins/steam-workshop/src/index.ts
+++ b/plugins/steam-workshop/src/index.ts
@@ -16,6 +16,19 @@ export const steamWorkshopPlugin = {
   name: "steam-workshop",
   version: "0.0.1",
 
+  /**
+   * Loaded only via an explicit --plugin flag, never by default, so
+   * reaching this point is deliberate - warn rather than fail, but make
+   * it impossible to mistake for a working integration.
+   */
+  onLoad() {
+    console.warn(
+      "[game-ci] WARNING: @game-ci/steam-workshop is an EXPERIMENTAL draft plugin. " +
+        "Its structure is real but its domain logic is not implemented - any command it " +
+        "claims will throw. Do not depend on it. See plugins/steam-workshop/README.md.",
+    );
+  },
+
   commands: [
     {
       engine: "*",


### PR DESCRIPTION
Marks every plugin except `orchestrator` and `unity` as experimental, in three layers.

## 1. `"private": true` — the actual safety measure

npm refuses to publish a private package. **None of these names exist on the registry yet** (all 404), so without this a stray `npm publish -w`, or a future workflow less careful than `orchestrator-release.yml` (which is scoped to `working-directory: plugins/orchestrator`), would put non-functional packages on the public `@game-ci` scope — where `npm i @game-ci/gamemaker` installs something that only throws.

**Worth knowing:** root `@game-ci/cli` is *not* private and depends on `steam-deploy` + `runtime-test-framework` via `workspace:*`. Marking those private means a future `npm publish` of the CLI would now fail rather than silently publish experimental deps. That is currently a no-op — `@game-ci/cli` isn't on npm either, and ships as compiled binaries via `release-cli.yml` — but it's a deliberate trade, not an oversight.

## 2. A runtime warning, placed by how the plugin loads

This distinction is the part that matters:

- **The ten drafts warn from `onLoad()`.** They're only ever loaded via an explicit `--plugin @game-ci/<name>`, so reaching that point is deliberate.
- **`steam-deploy` and `runtime-test-framework` warn from `createCommand` instead.** They're in `cli.ts`'s default load list, so an `onLoad` warning would fire on *every* `game-ci` invocation — which trains people to ignore warnings and makes the marking worthless. Warning at command use fires exactly when the experimental feature is used, and never for an unrelated command.

## 3. Banners and descriptions

An `EXPERIMENTAL` banner atop each README and an `EXPERIMENTAL` prefix on each package description. The wording separates the two cases honestly: the drafts say **NOT IMPLEMENTED** and that any command they claim will throw; the two implemented ones say they work but may still change.

`steam-deploy` had **no README at all** — the only default-loaded deploy path was the single piece with no written warning anywhere — so one was added, noting that a Steam upload cannot be undone.

## Verification

Driven directly against the plugin objects rather than inferred:

| Scenario | Warnings | Expected |
|---|---|---|
| `onLoad()` on the two default-loaded plugins | 0 | 0 |
| `test-runtime` + `deploy steam` invoked | 2 | 2 |
| unrelated commands (`build`, `deploy itch`) | 0 | 0 |
| a draft's `onLoad()` | 1 | 1 |

`bun install --frozen-lockfile` passes; suite unchanged at the 244 pre-existing failures (orchestrator's vitest `vi.mock` under bun). Lockfile and `plugins/unity/dist` churn reverted rather than committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)