### PR TITLE
fix: restore remote-cli-pre-build/log-stream/post-build after the -m CliFunction dispatcher was retired

### DIFF
--- a/plugins/orchestrator/src/cli.ts
+++ b/plugins/orchestrator/src/cli.ts
@@ -11,6 +11,9 @@ import versionCommand from './cli/commands/version';
 import updateCommand from './cli/commands/update';
 import initCommand from './cli/commands/init';
 import preflightCommand from './cli/commands/preflight';
+import remoteCliPreBuildCommand from './cli/commands/remote-cli-pre-build';
+import remoteCliLogStreamCommand from './cli/commands/remote-cli-log-stream';
+import remoteCliPostBuildCommand from './cli/commands/remote-cli-post-build';
 import * as core from '@actions/core';
 
 const cli = yargs(hideBin(process.argv))
@@ -25,6 +28,13 @@ const cli = yargs(hideBin(process.argv))
   .command(updateCommand)
   .command(initCommand)
   .command(preflightCommand)
+  // Internal commands, invoked by build-automation-workflow.ts's generated
+  // shell scripts from *inside* the remote build container (AWS/K8s) -
+  // never by a user directly. Not hidden from --help since that would make
+  // them harder to find while debugging a broken remote build.
+  .command(remoteCliPreBuildCommand)
+  .command(remoteCliLogStreamCommand)
+  .command(remoteCliPostBuildCommand)
   .demandCommand(1, 'You must specify a command. Run game-ci --help for available commands.')
   .strict()
   .alias('h', 'help')

--- a/plugins/orchestrator/src/cli/__tests__/cli-integration.test.ts
+++ b/plugins/orchestrator/src/cli/__tests__/cli-integration.test.ts
@@ -23,9 +23,18 @@ function runCli(
   });
 }
 
-// Per-test timeout configured via vitest options at the file/describe level.
-
-describe('CLI integration', () => {
+// Each test spawns a real `node --require ts-node/register/transpile-only`
+// process, which has to transpile and load this package's full CLI
+// dependency graph before it can even start parsing argv - genuinely slow,
+// and slower still under CI's parallel test-shard contention. runCli's own
+// execFile already allows up to 60s for that, but vitest's default per-test
+// timeout is 5000ms regardless, so the wrapping `it()` was timing out (and
+// failing the whole run under `set -e`-equivalent CI gating) long before the
+// child process's own generous budget was ever exhausted - not a real
+// failure, just a mismatched timeout. A 30s per-test timeout here comfortably
+// covers real CI contention without masking a genuine hang (which would
+// still exceed even that).
+describe('CLI integration', { timeout: 30_000 }, () => {
   it('exits 0 and shows all commands for --help', async () => {
     const result = await runCli(['--help']);
 

--- a/plugins/orchestrator/src/cli/__tests__/commands.test.ts
+++ b/plugins/orchestrator/src/cli/__tests__/commands.test.ts
@@ -5,6 +5,9 @@ import orchestrateCommand from '../commands/orchestrate';
 import statusCommand from '../commands/status';
 import versionCommand from '../commands/version';
 import updateCommand from '../commands/update';
+import remoteCliPreBuildCommand from '../commands/remote-cli-pre-build';
+import remoteCliLogStreamCommand from '../commands/remote-cli-log-stream';
+import remoteCliPostBuildCommand from '../commands/remote-cli-post-build';
 
 function createFakeYargs(): { yargs: any; options: Record<string, any> } {
   const options: Record<string, any> = {};
@@ -243,6 +246,77 @@ describe('CLI commands', () => {
       expect(options['force'].default).toStrictEqual(false);
       expect(options['version']).toBeDefined();
       expect(options['version'].type).toStrictEqual('string');
+    });
+  });
+
+  // These three run inside the remote build container (AWS/K8s), dispatched
+  // by build-automation-workflow.ts's generated shell scripts. They used to
+  // be reached via a bespoke `-m <name>` flag from when this package had its
+  // own argv-based CliFunction dispatcher; that dispatcher no longer exists
+  // in either this package's yargs-based src/cli.ts or game-ci/cli's, so
+  // `-m` was rejected by strict-mode yargs as an unknown argument -
+  // silently breaking every remote build's pre-build, log-streaming and
+  // post-build steps. These commands restore real yargs entry points for
+  // them; regression tests exist so this cannot silently regress again by,
+  // say, a rename in build-automation-workflow.ts drifting out of sync with
+  // the command name registered here.
+  describe('remote-cli-pre-build command', () => {
+    it('exports the correct command name', () => {
+      expect(remoteCliPreBuildCommand.command).toStrictEqual('remote-cli-pre-build');
+    });
+
+    it('has a description', () => {
+      expect(remoteCliPreBuildCommand.describe).toBeTruthy();
+    });
+
+    it('has a handler function', () => {
+      expect(typeof remoteCliPreBuildCommand.handler).toStrictEqual('function');
+    });
+
+    it('takes no required options - the original bare invocation took none', () => {
+      expect(remoteCliPreBuildCommand.builder).toBeUndefined();
+    });
+  });
+
+  describe('remote-cli-log-stream command', () => {
+    it('exports the correct command name', () => {
+      expect(remoteCliLogStreamCommand.command).toStrictEqual('remote-cli-log-stream');
+    });
+
+    it('has a description', () => {
+      expect(remoteCliLogStreamCommand.describe).toBeTruthy();
+    });
+
+    it('has a handler function', () => {
+      expect(typeof remoteCliLogStreamCommand.handler).toStrictEqual('function');
+    });
+
+    it('requires --log-file, aliased to logFile to match the shell scripts that invoke it', () => {
+      const { yargs, options } = createFakeYargs();
+
+      (remoteCliLogStreamCommand.builder as Function)(yargs);
+
+      expect(options['log-file']).toBeDefined();
+      expect(options['log-file'].alias).toStrictEqual('logFile');
+      expect(options['log-file'].demandOption).toStrictEqual(true);
+    });
+  });
+
+  describe('remote-cli-post-build command', () => {
+    it('exports the correct command name', () => {
+      expect(remoteCliPostBuildCommand.command).toStrictEqual('remote-cli-post-build');
+    });
+
+    it('has a description', () => {
+      expect(remoteCliPostBuildCommand.describe).toBeTruthy();
+    });
+
+    it('has a handler function', () => {
+      expect(typeof remoteCliPostBuildCommand.handler).toStrictEqual('function');
+    });
+
+    it('takes no required options - the original bare invocation took none', () => {
+      expect(remoteCliPostBuildCommand.builder).toBeUndefined();
     });
   });
 });

--- a/plugins/orchestrator/src/cli/commands/remote-cli-log-stream.ts
+++ b/plugins/orchestrator/src/cli/commands/remote-cli-log-stream.ts
@@ -1,0 +1,41 @@
+import type { CommandModule } from 'yargs';
+import { RemoteClient } from '../../model/orchestrator/remote-client';
+import { mapCliArgumentsToInput, CliArguments } from '../input-mapper';
+
+interface RemoteCliLogStreamArguments extends CliArguments {
+  logFile: string;
+}
+
+/**
+ * Runs inside the remote build container - reads the piped build/setup
+ * output from stdin and writes it to a log file (and, for K8s, echoes it to
+ * stdout so `kubectl logs` captures it too). See remote-cli-pre-build.ts's
+ * doc comment for why this needs to be a real yargs command.
+ *
+ * RemoteClient.remoteClientLogStream reads Cli.options['logFile'] directly
+ * rather than taking it as a parameter, so mapCliArgumentsToInput has to run
+ * first to populate that.
+ *
+ * Deliberately does not await stream completion: attaching the stdin
+ * listeners is enough to keep the process alive until the pipe closes, the
+ * same way the process stayed alive under the old dispatch protocol.
+ */
+const remoteCliLogStreamCommand: CommandModule<object, RemoteCliLogStreamArguments> = {
+  command: 'remote-cli-log-stream',
+  describe:
+    'Streams piped build output to a log file (internal - runs inside the remote build container)',
+  builder: (yargs) => {
+    return yargs.option('log-file', {
+      alias: 'logFile',
+      type: 'string',
+      description: 'Path to write the streamed log output to',
+      demandOption: true,
+    }) as any;
+  },
+  handler: async (cliArguments) => {
+    mapCliArgumentsToInput(cliArguments);
+    await RemoteClient.remoteClientLogStream();
+  },
+};
+
+export default remoteCliLogStreamCommand;

--- a/plugins/orchestrator/src/cli/commands/remote-cli-post-build.ts
+++ b/plugins/orchestrator/src/cli/commands/remote-cli-post-build.ts
@@ -1,0 +1,22 @@
+import type { CommandModule } from 'yargs';
+import { BuildParameters, Orchestrator } from '../../model';
+import { RemoteClient } from '../../model/orchestrator/remote-client';
+import { mapCliArgumentsToInput, CliArguments } from '../input-mapper';
+
+/**
+ * Runs inside the remote build container (AWS/K8s), after the build -
+ * pushes the Library/Build caches. See remote-cli-pre-build.ts's doc
+ * comment for why this needs to be a real yargs command: the `-m` protocol
+ * it used to be dispatched through no longer has a live dispatcher.
+ */
+const remoteCliPostBuildCommand: CommandModule<object, CliArguments> = {
+  command: 'remote-cli-post-build',
+  describe: 'Runs post-build cache push tasks (internal - runs inside the remote build container)',
+  handler: async (cliArguments) => {
+    mapCliArgumentsToInput(cliArguments);
+    Orchestrator.buildParameters = await BuildParameters.create();
+    await RemoteClient.remoteClientPostBuild();
+  },
+};
+
+export default remoteCliPostBuildCommand;

--- a/plugins/orchestrator/src/cli/commands/remote-cli-pre-build.ts
+++ b/plugins/orchestrator/src/cli/commands/remote-cli-pre-build.ts
@@ -1,0 +1,36 @@
+import type { CommandModule } from 'yargs';
+import { BuildParameters, Orchestrator } from '../../model';
+import { RemoteClient } from '../../model/orchestrator/remote-client';
+import { mapCliArgumentsToInput, CliArguments } from '../input-mapper';
+
+/**
+ * Runs inside the remote build container (AWS/K8s), before the actual
+ * Unity/engine build - bootstraps the git workspace (full clone, incremental
+ * sync, or retained-workspace reuse) and runs `before-build` hooks.
+ *
+ * This used to be dispatched via a bespoke `-m remote-cli-pre-build` flag,
+ * a protocol from when this package was a standalone repo with its own
+ * argv-based CliFunction dispatcher. That dispatcher does not exist in
+ * either this package's own yargs-based src/cli.ts or game-ci/cli's -
+ * `Unknown argument: m` in a strict-mode yargs parser is a hard failure,
+ * not a warning it recovers from, so every remote build's pre-build step
+ * has been broken since the CliFunction/-m protocol was retired. A real
+ * yargs command is the fix.
+ *
+ * Reads entirely from the environment (INPUT_* vars already present in the
+ * container via the images this build ran with) - the original bare
+ * `-m remote-cli-pre-build` invocation took no CLI flags at all, so this
+ * command intentionally accepts none either.
+ */
+const remoteCliPreBuildCommand: CommandModule<object, CliArguments> = {
+  command: 'remote-cli-pre-build',
+  describe:
+    'Sets up a repository, usually before a game-ci build (internal - runs inside the remote build container)',
+  handler: async (cliArguments) => {
+    mapCliArgumentsToInput(cliArguments);
+    Orchestrator.buildParameters = await BuildParameters.create();
+    await RemoteClient.setupRemoteClient();
+  },
+};
+
+export default remoteCliPreBuildCommand;

--- a/plugins/orchestrator/src/model/orchestrator/providers/local/index.ts
+++ b/plugins/orchestrator/src/model/orchestrator/providers/local/index.ts
@@ -131,7 +131,7 @@ class LocalOrchestrator implements ProviderInterface {
    * wrapper's captured stdout/stderr: dist/platforms/ubuntu/steps/runsteps.sh
    * (via build.sh/activate.sh) invokes `unity-editor -logfile /dev/stdout`,
    * and BuildAutomationWorkflow.BuildWorkflow pipes that whole pipeline
-   * through `node <builder> -m remote-cli-log-stream --logFile "$LOG_FILE"`,
+   * through `node <builder> remote-cli-log-stream --logFile "$LOG_FILE"`,
    * which appends every line to $LOG_FILE. For the bare-local provider,
    * $LOG_FILE is exported as `$(pwd)/temp/job-log.txt` (see
    * BuildAutomationWorkflow.BuildWorkflow), so that file accumulates the

--- a/plugins/orchestrator/src/model/orchestrator/remote-client/index.ts
+++ b/plugins/orchestrator/src/model/orchestrator/remote-client/index.ts
@@ -16,7 +16,7 @@ import { Cli } from '../../cli/cli';
 import OrchestratorOptions from '../options/orchestrator-options';
 import ResourceTracking from '../services/core/resource-tracking';
 import { IncrementalSyncService } from '../services/sync';
-import { SyncStrategy } from '../services/sync/sync-state';
+import type { SyncStrategy } from '../services/sync/sync-state';
 
 export class RemoteClient {
   @CliFunction(`remote-cli-pre-build`, `sets up a repository, usually before a game-ci build`)

--- a/plugins/orchestrator/src/model/orchestrator/services/sync/incremental-sync-service.ts
+++ b/plugins/orchestrator/src/model/orchestrator/services/sync/incremental-sync-service.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { OrchestratorSystem } from '../core/orchestrator-system';
 import OrchestratorLogger from '../core/orchestrator-logger';
-import { SyncState, SyncStrategy } from './sync-state';
+import type { SyncState, SyncStrategy } from './sync-state';
 import { SyncStateManager } from './sync-state-manager';
 
 /**

--- a/plugins/orchestrator/src/model/orchestrator/services/sync/index.ts
+++ b/plugins/orchestrator/src/model/orchestrator/services/sync/index.ts
@@ -1,3 +1,3 @@
-export { SyncState, SyncStrategy } from './sync-state';
+export type { SyncState, SyncStrategy } from './sync-state';
 export { IncrementalSyncService } from './incremental-sync-service';
 export { SyncStateManager } from './sync-state-manager';

--- a/plugins/orchestrator/src/model/orchestrator/services/sync/sync-state-manager.ts
+++ b/plugins/orchestrator/src/model/orchestrator/services/sync/sync-state-manager.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import OrchestratorLogger from '../core/orchestrator-logger';
-import { SyncState } from './sync-state';
+import type { SyncState } from './sync-state';
 
 /**
  * Manages persistent sync state for incremental workspace updates.

--- a/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.ts
+++ b/plugins/orchestrator/src/model/orchestrator/workflows/build-automation-workflow.ts
@@ -559,7 +559,7 @@ echo "log start" >> /home/job-log.txt
 echo "CACHE_KEY=$CACHE_KEY"
 ${
   Orchestrator.buildParameters.providerStrategy !== 'local-docker'
-    ? `node ${builderPath} -m remote-cli-pre-build`
+    ? `node ${builderPath} remote-cli-pre-build`
     : `# skipping remote-cli-pre-build in local-docker`
 }`;
     }
@@ -623,7 +623,7 @@ echo "CACHE_KEY=$CACHE_KEY"`;
     if ! command -v yarn > /dev/null 2>&1; then printf '#!/bin/sh\nexit 0\n' > /usr/local/bin/yarn && chmod +x /usr/local/bin/yarn; fi
     ${Orchestrator.buildParameters.cacheSaveOnFailure ? CacheCheckpointService.generateFailureTrapScript('/data/cache/$CACHE_KEY', Orchestrator.buildParameters.cacheSaveOnFailureFilter) : ''}
     # Pipe entrypoint.sh output through log stream to capture Unity build output (including "Build succeeded")
-    { echo "game ci start"; echo "game ci start" >> /home/job-log.txt; echo "CACHE_KEY=$CACHE_KEY"; echo "$CACHE_KEY"; if [ -n "$LOCKED_WORKSPACE" ]; then echo "Retained Workspace: true"; fi; if [ -n "$LOCKED_WORKSPACE" ] && [ -d "$GITHUB_WORKSPACE/.git" ]; then echo "Retained Workspace Already Exists!"; fi; /entrypoint.sh; } | node ${builderPath} -m remote-cli-log-stream --logFile /home/job-log.txt
+    { echo "game ci start"; echo "game ci start" >> /home/job-log.txt; echo "CACHE_KEY=$CACHE_KEY"; echo "$CACHE_KEY"; if [ -n "$LOCKED_WORKSPACE" ]; then echo "Retained Workspace: true"; fi; if [ -n "$LOCKED_WORKSPACE" ] && [ -d "$GITHUB_WORKSPACE/.git" ]; then echo "Retained Workspace Already Exists!"; fi; /entrypoint.sh; } | node ${builderPath} remote-cli-log-stream --logFile /home/job-log.txt
     ${BuildAutomationWorkflow.engineCacheCommands()}
     # Ensure cache directories exist for post-build and S3 upload hooks.
     # Do NOT create empty placeholder tars — they waste S3 storage and on next
@@ -640,7 +640,7 @@ echo "CACHE_KEY=$CACHE_KEY"`;
       # Use tee to write to both stdout and log file, ensuring output is captured
       # For K8s, kubectl logs reads from stdout, so we need stdout
       # For local-docker, the log file is read directly
-      node ${builderPath} -m remote-cli-post-build 2>&1 | tee -a /home/job-log.txt || echo "Post-build command completed with warnings" | tee -a /home/job-log.txt
+      node ${builderPath} remote-cli-post-build 2>&1 | tee -a /home/job-log.txt || echo "Post-build command completed with warnings" | tee -a /home/job-log.txt
     else
       # Builder doesn't exist, skip post-build (shouldn't happen, but handle gracefully)
       echo "Builder path not found, skipping post-build" | tee -a /home/job-log.txt
@@ -670,13 +670,13 @@ echo "CACHE_KEY=$CACHE_KEY"`;
     cp -r "${OrchestratorFolders.ToLinuxFolder(path.join(ubuntuPlatformsFolder, 'steps'))}" "/steps"
     chmod -R +x "/entrypoint.sh"
     chmod -R +x "/steps"
-    { echo "game ci start"; echo "game ci start" >> /home/job-log.txt; echo "CACHE_KEY=$CACHE_KEY"; echo "$CACHE_KEY"; if [ -n "$LOCKED_WORKSPACE" ]; then echo "Retained Workspace: true"; fi; if [ -n "$LOCKED_WORKSPACE" ] && [ -d "$GITHUB_WORKSPACE/.git" ]; then echo "Retained Workspace Already Exists!"; fi; /entrypoint.sh; } | node ${builderPath} -m remote-cli-log-stream --logFile /home/job-log.txt
+    { echo "game ci start"; echo "game ci start" >> /home/job-log.txt; echo "CACHE_KEY=$CACHE_KEY"; echo "$CACHE_KEY"; if [ -n "$LOCKED_WORKSPACE" ]; then echo "Retained Workspace: true"; fi; if [ -n "$LOCKED_WORKSPACE" ] && [ -d "$GITHUB_WORKSPACE/.git" ]; then echo "Retained Workspace Already Exists!"; fi; /entrypoint.sh; } | node ${builderPath} remote-cli-log-stream --logFile /home/job-log.txt
     # Run post-build and capture output to both stdout (for kubectl logs) and log file
     # Note: Post-build may clean up the builder directory, so write output directly
     set +e
     if [ -f "${builderPath}" ]; then
       # Use tee to write to both stdout and log file for K8s kubectl logs
-      node ${builderPath} -m remote-cli-post-build 2>&1 | tee -a /home/job-log.txt || echo "Post-build command completed with warnings" | tee -a /home/job-log.txt
+      node ${builderPath} remote-cli-post-build 2>&1 | tee -a /home/job-log.txt || echo "Post-build command completed with warnings" | tee -a /home/job-log.txt
     else
       echo "Builder path not found, skipping post-build" | tee -a /home/job-log.txt
     fi
@@ -731,16 +731,16 @@ echo "CACHE_KEY=$CACHE_KEY"`;
     mkdir -p "$ACTIVATE_LICENSE_PATH"
     mkdir -p "$GITHUB_WORKSPACE/$BUILD_PATH"
     # Pipe runsteps.sh output through log stream to capture Unity build/activation output
-    { bash "$STEPS_DIR/runsteps.sh"; echo "RUNSTEPS_EXIT_CODE:$?" >> "$LOG_FILE"; } | node ${builderPath} -m remote-cli-log-stream --logFile "$LOG_FILE"
-    node ${builderPath} -m remote-cli-post-build`;
+    { bash "$STEPS_DIR/runsteps.sh"; echo "RUNSTEPS_EXIT_CODE:$?" >> "$LOG_FILE"; } | node ${builderPath} remote-cli-log-stream --logFile "$LOG_FILE"
+    node ${builderPath} remote-cli-post-build`;
     }
 
     // prettier-ignore
     return `
     echo "game ci start"
     echo "game ci start" >> "$LOG_FILE"
-    timeout 3s node ${builderPath} -m remote-cli-log-stream --logFile "$LOG_FILE" || true
-    node ${builderPath} -m remote-cli-post-build`;
+    timeout 3s node ${builderPath} remote-cli-log-stream --logFile "$LOG_FILE" || true
+    node ${builderPath} remote-cli-post-build`;
   }
 
   /**


### PR DESCRIPTION
## The bug

Every remote (AWS/K8s) orchestrator build has been broken on `main` for at least 2+ days (confirmed back to Aug 22). `Integration Tests` fails identically across the last 6+ runs, and only on `AWS Provider Tests`/`K8s Provider Tests`/`Local Docker Provider Tests` — not the `MockAWS`/`Rclone` jobs. I traced this independently, and a fresh audit agent (no shared context) converged on the exact same root cause from a different angle.

It is **not** a MiniStack flake — MiniStack starts and the S3 bucket creates successfully in every failing run (`make_bucket: game-ci-team-pipelines`). The real failure:

```
[WARN] Unknown argument: m
Build failed with exit code 1
```

`[WARN]` is `game-ci/cli`'s own logger format (`src/core/logger/index.ts`), and `Cli.handleFailure` does exactly `log.warning(message); process.exit(1)` on any yargs failure — this is that failure, not some unrelated tool.

## Root cause

`build-automation-workflow.ts` invokes `node ${builderPath} -m remote-cli-pre-build` (and 7 more call sites for `-m remote-cli-log-stream` / `-m remote-cli-post-build`) for every non-local-docker provider. `-m <name>` is a **legacy dispatch protocol**: a `@CliFunction(name, ...)` decorator registers a static method with `CliFunctionsRepository`, which some other file used to read `process.argv`'s `-m` value and invoke the matching one.

That dispatcher is gone. `CliFunctionsRepository` is explicitly a *"Bridge file — stub"* that only stores registrations — nothing calls `GetCliFunctions()` against `-m` anywhere. This package's own bin entry (`src/cli.ts`) was independently rewritten to yargs subcommands too, with no `-m` support either.

`start.sh` runs under `set -e`, so this isn't a swallowed warning — it kills the entire remote build.

## Why this needed real commands, not a deletion

`remote-cli-pre-build` isn't diagnostic-only: `RemoteClient.setupRemoteClient()` bootstraps the actual git workspace (full clone, incremental sync, or retained-workspace reuse) and runs `before-build` hooks — build-critical. `remote-cli-post-build` pushes the Library/Build caches. `remote-cli-log-stream` pipes build output into a log file (and, on K8s, echoes it to stdout for `kubectl logs`).

## Fix

Three real yargs commands, matching this package's own existing command-per-file convention under `cli/commands/`, registered in `src/cli.ts`. All 9 call sites in `build-automation-workflow.ts` updated from `-m <name>` to the plain positional command. Each handler reads entirely from the environment via `mapCliArgumentsToInput` + `BuildParameters.create()` — the original bare invocations took no CLI flags at all (`remote-cli-log-stream`'s one exception, `--logFile`, is preserved as a real yargs option).

## A second bug found while verifying this under bun (not just tsc)

Three files imported `SyncState`/`SyncStrategy` (type-only exports) as regular values instead of `import type`: `services/sync/index.ts`, `services/sync/sync-state-manager.ts`, `services/sync/incremental-sync-service.ts`, and `remote-client/index.ts` itself. tsc erases type-only imports at compile time and never catches this; bun's isolated-module transpiler does not, and threw `SyntaxError: export 'SyncStrategy' not found` the moment these modules first actually loaded. This was a real, pre-existing latent bug — nothing in the old CLI's dependency graph ever loaded `remote-client/index.ts`, so it never surfaced until this fix made these modules load for the first time.

## Verification

- `game-ci --help` lists all three commands.
- Invoking `remote-cli-pre-build` directly no longer hits `Unknown argument: m` and proceeds into real setup logic — reaches a genuine `mkdir -p /data`, which only fails here because this is a Windows dev sandbox, not the Linux container the code assumes (expected, not a bug).
- `tsc --noEmit` clean.
- **144 tests passing** across the touched areas: 12 new command tests, plus the existing `build-automation-workflow`, `sync`, and `mock-aws` suites — the closest thing to the AWS integration path this environment can exercise without real AWS/Docker.
- Full suite: same 2 pre-existing, unrelated flakes as before this change (`cli-integration` timing out under parallel load — passes 9/9 in isolation — and `orchestrator-rclone-steps`, which fails identically on a clean `main` checkout).

I don't have Docker/real AWS/K8s access in this environment, so I could not run the actual `Integration Tests` workflow end-to-end. Everything short of that has been verified directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commands to initialize remote builds, stream build logs, and complete post-build processing.
  * Remote log streaming now requires a log-file path for reliable output collection.

* **Improvements**
  * Updated build workflows to use the streamlined command format across supported execution environments.
  * Remote build initialization and post-build cache processing now run through dedicated commands.

* **Documentation**
  * Updated command usage guidance to reflect the new invocation format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->