### PR TITLE
fix: pin bun version in release-cli.yml to unblock v0.1.15's binary build

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -45,8 +45,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Pinned, unlike this repo's other bun-version: latest workflows:
+      # v0.1.15's release build failed on all three "Verify binary
+      # (native only)" runners (windows-x64, linux-x64, macos-arm64) with
+      # `error: Cannot find module './src/cat' from '.../game-ci[.exe]'`
+      # under Bun v1.4.0's --compile bundler - a transitive dependency's
+      # dynamic-require pattern that v1.4.0 no longer resolves correctly
+      # inside a standalone binary (no `./src/cat` exists anywhere in this
+      # repo's own source, so this isn't a game-ci/cli bug to fix here).
+      # 1.3.13 is the last version confirmed to compile cleanly. Bump this
+      # deliberately once a Bun release is confirmed to build clean again,
+      # not by drifting back to `latest` and re-breaking every release.
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
## The bug

`v0.1.15`'s release build failed on 3 of 5 targets — `windows-x64`, `linux-x64`, `macos-arm64` — each hitting:

```
error: Cannot find module './src/cat' from '.../game-ci[.exe]'
Bun v1.4.0
```

`./src/cat` does not exist anywhere in this repo's own source — checked directly, no file and no import. This is a transitive dependency's dynamic-require pattern that Bun **1.4.0**'s `--compile` bundler no longer resolves correctly inside a standalone binary.

`oven-sh/setup-bun@v2` was unpinned in this workflow (unlike this repo's other workflows, which explicitly set `bun-version: latest`), so the release build silently rode a Bun version bump straight into this regression. Because "Generate checksums and upload" only runs after all 5 build jobs succeed, the release ended up with **zero binary assets attached at all** — not just the 3 broken ones, all 5, including the 2 that actually compiled fine.

## Fix

Pins to `1.3.13` — the version this entire session's local builds (across every plugin worktree touched today) have compiled clean under.

## Next step

Once merged, re-running the release build for `v0.1.15` should attach real binaries — currently it has none, which is why `unity-builder`'s Windows Docker builds are 404ing trying to download it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)