### PR TITLE
fix: default plugins fail to load in compiled --compile binary (Cannot find module @game-ci/orchestrator/cli-plugin)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,16 +62,28 @@ export class Cli {
 
     // Orchestrator is a genuinely separate package (plugins/orchestrator),
     // not core-internal like unity/godot/unreal above (which live inside
-    // src/plugin/builtin/ itself). It's loaded the same way any other
-    // plugin is - through PluginLoader's dynamic import - so core has no
-    // compile-time dependency on a plugin's internals. "Built-in" here
-    // just means "always in the default load list", not "statically
-    // imported": the package is still resolved by its public name/exports
-    // (@game-ci/orchestrator/cli-plugin), never a relative path into its
-    // src/ tree.
-    await PluginLoader.load("@game-ci/orchestrator/cli-plugin");
-    await PluginLoader.load("@game-ci/steam-deploy");
-    await PluginLoader.load("@game-ci/runtime-test-framework");
+    // src/plugin/builtin/ itself). "Built-in" here just means "always in
+    // the default load list", not "statically imported": the package is
+    // still resolved by its public name/exports (@game-ci/orchestrator/cli-plugin),
+    // never a relative path into its src/ tree.
+    //
+    // These use literal `import()` expressions (not PluginLoader.load's
+    // string-parameter path) because Bun's --compile bundler can only trace
+    // a dynamic import whose specifier is a source-level string literal at
+    // the call site - `import(variable)` inside a shared helper resolves
+    // fine under `bun run`/`bun test` but throws "Cannot find module" in
+    // the compiled standalone binary the moment a real command needs a
+    // plugin (never during --help, which doesn't reach this code path).
+    // See game-ci/cli#151.
+    await PluginLoader.loadModule(
+      await import("@game-ci/orchestrator/cli-plugin"),
+      "@game-ci/orchestrator/cli-plugin",
+    );
+    await PluginLoader.loadModule(await import("@game-ci/steam-deploy"), "@game-ci/steam-deploy");
+    await PluginLoader.loadModule(
+      await import("@game-ci/runtime-test-framework"),
+      "@game-ci/runtime-test-framework",
+    );
 
     const options = await this.getPreCommandOptions();
     const pluginSources = this.getPluginSources(options);

--- a/src/plugin/plugin-loader.ts
+++ b/src/plugin/plugin-loader.ts
@@ -37,6 +37,26 @@ export class PluginLoader {
   }
 
   /**
+   * Register an already-imported plugin module. Use this for npm packages
+   * whose specifier is a source-level string literal (e.g. a default plugin
+   * imported via `await import("@game-ci/orchestrator/cli-plugin")`).
+   *
+   * `loadFromNpm` below resolves `import(packageName)` where `packageName`
+   * is a variable - Bun's `--compile` bundler can't statically trace that
+   * and the standalone binary fails at runtime with "Cannot find module"
+   * for every npm-sourced plugin (see game-ci/cli#151). A literal `import()`
+   * expression at the call site *is* traceable, so callers that know their
+   * specifier at compile time should import it themselves and pass the
+   * resolved module here instead of going through `load()`.
+   */
+  static async loadModule(mod: any, source: string): Promise<GameCIPlugin> {
+    const plugin: GameCIPlugin = mod.default || mod;
+    PluginLoader.validate(plugin, source);
+    await PluginRegistry.registerOnce(plugin);
+    return plugin;
+  }
+
+  /**
    * Load multiple plugins from an array of sources.
    */
   static async loadAll(sources: string[]): Promise<GameCIPlugin[]> {


### PR DESCRIPTION
## What broke

Every real command (`build`, `test`, `orchestrate`, `deploy steam`, ...) on
the `v0.1.15` compiled standalone binary fails immediately with:

```
[ERROR] {
  "name": "ResolveMessage",
  "message": "Cannot find module '@game-ci/orchestrator/cli-plugin' from '.../game-ci[.exe]'",
  "specifier": "@game-ci/orchestrator/cli-plugin",
  ...
}
```

`--help` works fine, which is why `release-cli.yml`'s "Verify binary" step
(and my own local verification for #150) never caught this.

## Root cause

`Cli.loadPlugins()` calls `PluginLoader.load("@game-ci/orchestrator/cli-plugin")`
etc. with literal strings, but `PluginLoader.load` forwards that string as a
**parameter** into `loadFromNpm(packageName)`, which does `await import(packageName)`.

Bun's `--compile` bundler can only statically trace a dynamic `import()` whose
specifier is a source-level string literal *at the call site*. Once the
literal passes through a variable in a shared helper, the bundler can't
follow it, and the module isn't embedded in the standalone binary - so it's
"not found" at runtime, exactly like `game-ci/cli#150`'s `shelljs` bug, but
this time in `game-ci/cli`'s own plugin-loading code rather than a
transitive dependency.

## Fix

Add `PluginLoader.loadModule(mod, source)` which validates + registers an
**already-imported** module, and have `loadPlugins()` import the three
default plugins with literal `await import("...")` expressions directly at
the call site, passing the resolved module into `loadModule` instead of
routing the string through `PluginLoader.load`/`loadFromNpm`.

User-supplied plugin sources (`--plugin=<pkg>`, config-file plugins) still go
through the original string-based `PluginLoader.load` path and are
unaffected by this fix - those are inherently runtime-determined strings and
can't be statically traced under `--compile` regardless; this only fixes the
plugins shipped and always loaded by default.

## Verification

Reproduced locally against a clean checkout of the exact commit that
produced `v0.1.15` (`cc48cb7`, this branch's parent):

```
$ bun build src/index.ts --compile --outfile /tmp/gameci-test
$ /tmp/gameci-test build /tmp/nonexistent-project --targetPlatform=StandaloneLinux64
[ERROR] { "message": "Cannot find module '@game-ci/orchestrator/cli-plugin' ..." }
```

Same repro with this branch's fix applied - the plugin-loading error is
gone, the binary progresses past plugin loading into real command logic
(fails on the placeholder nonexistent path instead, as expected):

```
$ bun build src/index.ts --compile --outfile /tmp/gameci-fixed
$ /tmp/gameci-fixed build /tmp/nonexistent-project --targetPlatform=StandaloneLinux64
[ERROR] Error: fatal: cannot change to '.../nonexistent-project': No such file or directory
```

`bun test src/cli.ts src/plugin` - 8/8 pass.

## Test plan

- [x] Local `--compile` binary repro before/after fix, confirmed root cause and fix empirically (not just via `bun test`, which doesn't exercise the compiled-binary code path at all)
- [x] Existing plugin-loader/cli unit tests pass unchanged
- [ ] CI: release-cli.yml build + verify-binary steps green
- [ ] Once merged, re-verify against unity-builder #844 and unity-test-runner #310, which are both currently blocked on this exact error against v0.1.15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin loading reliability when running the compiled CLI.
  - Ensured supported deployment and testing plugins are discovered and registered consistently.
  - Prevented duplicate plugin registration during startup.

- **Improvements**
  - Enhanced compatibility with statically compiled application builds.
  - Added clearer handling for plugins loaded through the CLI’s startup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->