### PR TITLE
chore: bump version to 0.1.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "GameCI CLI - automation for game engines",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump to cut a release with #151's fix (plugin loading under the compiled --compile binary). No other changes.