### PR TITLE
fix: drop --changeset from macOS Unity Hub install (fixes unity-builder#844's macOS build failures)

### DIFF
--- a/plugins/unity/dist/unity-builder/model/platform-setup/setup-mac.js
+++ b/plugins/unity/dist/unity-builder/model/platform-setup/setup-mac.js
@@ -3,7 +3,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-const unity_changeset_1 = require("unity-changeset");
 const exec_1 = require("@actions/exec");
 const cache_1 = require("@actions/cache");
 const node_fs_1 = __importDefault(require("node:fs"));
@@ -114,7 +113,10 @@ class SetupMac {
                 return;
             }
         }
-        const unityChangeset = await (0, unity_changeset_1.getUnityChangeset)(buildParameters.editorVersion);
+        // No --changeset: passing it here has previously caused Unity Hub CLI to
+        // reject known-good versions with "Provided editor version does not
+        // match to any known Unity Editor versions" (see game-ci/cli#153).
+        // --version alone is what the legacy setup-mac.ts relied on for years.
         const moduleArguments = SetupMac.getModuleParametersForTargetPlatform(buildParameters.targetPlatform);
         const architectureArguments = SetupMac.getArchitectureParameters();
         const execArguments = [
@@ -122,7 +124,6 @@ class SetupMac {
             '--headless',
             'install',
             ...['--version', buildParameters.editorVersion],
-            ...['--changeset', unityChangeset.changeset],
             ...moduleArguments,
             ...architectureArguments,
             '--childModules',

--- a/plugins/unity/src/unity-builder/model/platform-setup/setup-mac.ts
+++ b/plugins/unity/src/unity-builder/model/platform-setup/setup-mac.ts
@@ -1,5 +1,4 @@
 import { BuildParameters } from '..';
-import { getUnityChangeset } from 'unity-changeset';
 import { exec, getExecOutput } from '@actions/exec';
 import { restoreCache, saveCache } from '@actions/cache';
 
@@ -137,7 +136,10 @@ class SetupMac {
       }
     }
 
-    const unityChangeset = await getUnityChangeset(buildParameters.editorVersion);
+    // No --changeset: passing it here has previously caused Unity Hub CLI to
+    // reject known-good versions with "Provided editor version does not
+    // match to any known Unity Editor versions" (see game-ci/cli#153).
+    // --version alone is what the legacy setup-mac.ts relied on for years.
     const moduleArguments = SetupMac.getModuleParametersForTargetPlatform(
       buildParameters.targetPlatform,
     );
@@ -148,7 +150,6 @@ class SetupMac {
       '--headless',
       'install',
       ...['--version', buildParameters.editorVersion],
-      ...['--changeset', unityChangeset.changeset],
       ...moduleArguments,
       ...architectureArguments,
       '--childModules',


### PR DESCRIPTION
## What broke

Every macOS job (StandaloneOSX + iOS, all Unity versions) in unity-builder
PR #844's \"Builds - MacOS\" workflow fails during Unity install with:

\`\`\`
Error while installing an editor or a module. Error: Provided editor version does not match to any known Unity Editor versions.
[ERROR] Error: There was an error installing the Unity Editor.
    at installUnity (/$bunfs/root/game-ci:...)
\`\`\`

Confirmed this is a real regression, not environmental: re-ran the same
\"Builds - MacOS\" workflow on unity-builder's \`main\` branch and it's
7/8 green. But \`main\`'s macOS build never goes through this plugin's
\`installUnity\` at all - it still uses the legacy bash-based
\`dist/platforms/mac/entrypoint.sh\`. \`main\` was never exercising this
code path, so this bug was never previously caught.

## Root cause

\`plugins/unity/src/unity-builder/model/platform-setup/setup-mac.ts\`'s
\`installUnity\` resolves a changeset via \`getUnityChangeset()\` (the
\`unity-changeset\` npm package) and passes it to Unity Hub CLI as
\`--changeset <hash>\`. Verified locally that \`getUnityChangeset('2021.3.45f1')\`
resolves correctly (changeset \`0da89fac8e79\`, matching what the CI log
shows) - so the rejection is coming from Unity Hub CLI itself, not a
lookup failure on our side.

The older, still-in-production \`src/logic/unity/platform-setup/setup-mac.ts\`
(used by \`main\`'s bash entrypoint) has carried this comment since 2023
(a80ecbc, \"Latest unity builder changes (Non Cloud Runner) (#37)\"):

> // Note: getUnityChangeset was removed as a dependency - install by version only

i.e. this exact \`--changeset\` argument was already tried and removed
from this codebase once before. The plugin migration reintroduced it.

## Fix

Drop \`--changeset\` from the plugin's \`installUnity\` exec arguments,
matching the long-proven \`--version\`-only pattern. \`--architecture\` is
kept (needed for correct installs on arm64 runners, which the legacy
code predates).

## Verification

- Reproduced the failure's root logic locally: \`getUnityChangeset('2021.3.45f1')\`
  resolves fine, so the failure is Unity Hub CLI rejecting the changeset
  argument itself, not a lookup issue - consistent with dropping it as
  the fix rather than trying to "fix" the lookup.
- No other call sites reference \`getUnityChangeset\`/\`unity-changeset\`
  in this plugin.
- Full mac hardware CI verification pending - this needs to run on the
  actual macOS runners to confirm; will re-trigger unity-builder#844's
  "Builds - MacOS" workflow once this merges and a release ships.

## Test plan

- [ ] CI green on this PR
- [ ] Once merged + released, re-trigger unity-builder#844's "Builds - MacOS" workflow and confirm StandaloneOSX/iOS jobs pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unity installation reliability by using the specified Unity version directly.
  * Removed reliance on changeset resolution during Unity Hub installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->