### PR TITLE
fix: respect an explicit --engineVersion/--engine instead of always auto-detecting

### DIFF
--- a/src/middleware/engine-detection/index.test.ts
+++ b/src/middleware/engine-detection/index.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+mock.module('./engine-detector.ts', () => ({
+  EngineDetector: class {
+    detect() {
+      return { engine: 'unity', engineVersion: '2021.3.45f1' };
+    }
+  },
+}));
+
+const { engineDetection } = await import('./index.ts');
+
+describe('engineDetection', () => {
+  it('auto-detects engine and engineVersion when neither is set', async () => {
+    const argv: any = { projectPath: '/some/project' };
+    await engineDetection(argv);
+
+    expect(argv.engine).toBe('unity');
+    expect(argv.engineVersion).toBe('2021.3.45f1');
+  });
+
+  it('respects an explicit --engineVersion instead of overwriting it', async () => {
+    const argv: any = { projectPath: '/some/project', engineVersion: '6000.0.36f1' };
+    await engineDetection(argv);
+
+    expect(argv.engineVersion).toBe('6000.0.36f1');
+    expect(argv.engine).toBe('unity');
+  });
+
+  it('respects an explicit --engine instead of overwriting it', async () => {
+    const argv: any = { projectPath: '/some/project', engine: 'godot' };
+    await engineDetection(argv);
+
+    expect(argv.engine).toBe('godot');
+    expect(argv.engineVersion).toBe('2021.3.45f1');
+  });
+
+  it('does not call the detector at all when both are already set', async () => {
+    const argv: any = { projectPath: '/some/project', engine: 'godot', engineVersion: '4.3' };
+    await engineDetection(argv);
+
+    expect(argv.engine).toBe('godot');
+    expect(argv.engineVersion).toBe('4.3');
+  });
+});

--- a/src/middleware/engine-detection/index.ts
+++ b/src/middleware/engine-detection/index.ts
@@ -6,8 +6,18 @@ export const engineDetection = async (argv: Options) => {
 
   if (!projectPath) projectPath = process.cwd();
 
-  const { engine, engineVersion } = new EngineDetector(projectPath).detect();
+  // Respect an explicit --engine/--engineVersion instead of clobbering it:
+  // both are already registered options (see project-options.ts,
+  // default ''), so a caller that knows better than ProjectVersion.txt -
+  // e.g. unity-builder's "via Build Profile" test matrix cell, which needs
+  // Unity 6 even though its checked-out test-project's ProjectVersion.txt
+  // says 2021.3.45f1 - can override auto-detection. See game-ci/cli#154.
+  const needsEngine = !argv.engine;
+  const needsEngineVersion = !argv.engineVersion;
+  if (!needsEngine && !needsEngineVersion) return;
 
-  argv.engine = engine;
-  argv.engineVersion = engineVersion;
+  const detected = new EngineDetector(projectPath).detect();
+
+  if (needsEngine) argv.engine = detected.engine;
+  if (needsEngineVersion) argv.engineVersion = detected.engineVersion;
 };


### PR DESCRIPTION
## What broke

unity-builder#844's \`build-tests-ubuntu.yml\` has a matrix cell testing Unity
6's Build Profiles feature (\`WebGL on 6000.0.36f1 (via Build Profile)\`).
It fails every run with:

\`\`\`
Missing argument -buildTarget
[ERROR] Error: Command exited with code 120
\`\`\`

This is a documented, disclosed known gap in that workflow
(\`continue-on-error: true\` + \`knownGap: true\` on that cell, with a comment
explaining it - see unity-builder#844).

## Root cause

Traced end-to-end:

1. \`ArgumentsParser.cs\` requires \`-buildTarget\` unless the Editor supports
   Build Profiles (\`#if UNITY_6000_0_OR_NEWER\`), which is a real Unity SDK
   compile-time gate - Build Profiles don't exist before Unity 6.
2. The CLI passes \`--buildProfile=...\` but omits \`--targetPlatform\`'s
   \`-buildTarget\` translation when a build profile is set (correct for
   Unity 6, since \`BuildPlayerWithProfileOptions\` doesn't need it).
3. But \`engineVersion\` - which decides *which* Unity Editor the container
   actually runs - is always auto-detected from the checked-out project's
   \`ProjectSettings/ProjectVersion.txt\` (\`2021.3.45f1\` for this test
   project), regardless of what the workflow's matrix says
   (\`6000.0.36f1\`). So the container runs Unity 2021.3, which doesn't
   support Build Profiles, doesn't get a \`-buildTarget\` either (since the
   CLI thought Unity 6 was in play), and \`ArgumentsParser.cs\` correctly -
   if unhelpfully - exits 120.

\`engineVersion\`/\`engine\` are already registered CLI options (default \`''\`,
see \`project-options.ts\`), but \`engineDetection\` (the yargs middleware that
runs auto-detection) unconditionally overwrote them regardless of whether a
caller had already passed \`--engineVersion\` explicitly.

## Fix

\`engineDetection\` now only fills in whichever of \`engine\`/\`engineVersion\`
wasn't already explicitly provided, skipping the detector entirely once
both are set. This lets a caller (e.g. unity-builder's workflow) pass
\`--engineVersion=6000.0.36f1\` to override auto-detection for cases like
this one, where the checked-out project's own \`ProjectVersion.txt\` doesn't
match what the test actually needs to exercise.

## Verification

- New test file (\`src/middleware/engine-detection/index.test.ts\`, 4 tests):
  auto-detect-when-unset (existing behavior, unchanged), respects explicit
  \`--engineVersion\`, respects explicit \`--engine\`, skips detection
  entirely when both are set.
- \`bun test src/middleware/engine-detection src/command-options\` - 26/26 pass.
- This alone doesn't fix unity-builder#844's Build Profile cell - that also
  needs unity-builder's \`build-tests-ubuntu.yml\`/\`build-args.ts\` to actually
  pass \`--engineVersion\` from its matrix's \`unityVersion\` (companion PR to
  follow in game-ci/unity-builder once this merges + releases).

## Test plan

- [ ] CI green
- [ ] Once merged + released, wire unity-builder's Build Profile matrix cell to pass \`--engineVersion\` and remove its \`knownGap\`/\`continue-on-error\` exception