### PR TITLE
fix: repair plugin.test.ts's @game-ci/orchestrator mocking (blocks any PR touching plugins/unity)

### DIFF
--- a/plugins/unity/dist/unity-builder/model/__fixtures__/fake-orchestrator-plugin.d.ts
+++ b/plugins/unity/dist/unity-builder/model/__fixtures__/fake-orchestrator-plugin.d.ts
@@ -1,0 +1,1 @@
+export declare function createPlugin(): void;

--- a/plugins/unity/dist/unity-builder/model/__fixtures__/fake-orchestrator-plugin.js
+++ b/plugins/unity/dist/unity-builder/model/__fixtures__/fake-orchestrator-plugin.js
@@ -1,0 +1,14 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.createPlugin = createPlugin;
+// Resolvable stand-in for @game-ci/orchestrator in plugin.test.ts's
+// "package installed" tests. @game-ci/orchestrator itself is intentionally
+// not a real dependency of this package (see plugin.ts's DEFAULT_PLUGIN_MODULE
+// comment) and has no built dist/ in this CI job, so vi.doMock'ing that bare
+// specifier directly fails at real module resolution before the mock factory
+// ever runs. Mocking this real, on-disk file instead sidesteps that: the
+// module identity resolves normally, and the mock factory replaces its
+// (otherwise-unused) content.
+function createPlugin() {
+    throw new Error('createPlugin() from the fixture stub was called unmocked - the test should have overridden it');
+}

--- a/plugins/unity/dist/unity-builder/model/plugin.js
+++ b/plugins/unity/dist/unity-builder/model/plugin.js
@@ -68,5 +68,10 @@ function isModuleNotFoundError(error) {
         }
     }
     return (typeof error?.message === 'string' &&
-        /cannot find module/i.test(error.message));
+        // Node/Bun's own resolver throws "Cannot find module"; Vite's (used by
+        // vitest, including this file's own tests when @game-ci/orchestrator's
+        // dist/ isn't built) throws a differently-worded "Failed to resolve
+        // entry for package" for the same "package genuinely isn't there"
+        // situation - both mean the same thing to this optional-plugin loader.
+        /cannot find module|failed to resolve entry for package/i.test(error.message));
 }

--- a/plugins/unity/src/unity-builder/model/__fixtures__/fake-orchestrator-plugin.ts
+++ b/plugins/unity/src/unity-builder/model/__fixtures__/fake-orchestrator-plugin.ts
@@ -1,0 +1,11 @@
+// Resolvable stand-in for @game-ci/orchestrator in plugin.test.ts's
+// "package installed" tests. @game-ci/orchestrator itself is intentionally
+// not a real dependency of this package (see plugin.ts's DEFAULT_PLUGIN_MODULE
+// comment) and has no built dist/ in this CI job, so vi.doMock'ing that bare
+// specifier directly fails at real module resolution before the mock factory
+// ever runs. Mocking this real, on-disk file instead sidesteps that: the
+// module identity resolves normally, and the mock factory replaces its
+// (otherwise-unused) content.
+export function createPlugin() {
+  throw new Error('createPlugin() from the fixture stub was called unmocked - the test should have overridden it');
+}

--- a/plugins/unity/src/unity-builder/model/plugin.test.ts
+++ b/plugins/unity/src/unity-builder/model/plugin.test.ts
@@ -43,11 +43,16 @@ describe('plugin (default package installed)', () => {
 
   const mockCreatePlugin = vi.fn().mockReturnValue(fakePlugin);
 
+  const FIXTURE_MODULE = './__fixtures__/fake-orchestrator-plugin';
+
   function installDefaultPluginMock(overrides: Record<string, unknown> = {}) {
-    // The `@game-ci/orchestrator` module is intentionally optional and may not
-    // be installed. `vi.doMock` lets the dynamic import in the loader resolve
-    // through this factory before vite tries to load a real package.
-    vi.doMock('@game-ci/orchestrator', () => ({
+    // `@game-ci/orchestrator` is intentionally optional and, in this CI job,
+    // genuinely unbuilt/unresolvable (no dist/, not a real dependency here) -
+    // vi.doMock'ing that bare specifier directly fails at real module
+    // resolution before the mock factory ever runs. Mock a real, on-disk
+    // fixture file instead (its own content is irrelevant, only its
+    // resolvability matters) and pass it to loadPlugin() explicitly.
+    vi.doMock(FIXTURE_MODULE, () => ({
       createPlugin: mockCreatePlugin,
       ...overrides,
     }));
@@ -67,7 +72,7 @@ describe('plugin (default package installed)', () => {
     installDefaultPluginMock();
     const { loadPlugin } = await import('./plugin');
 
-    const plugin = await loadPlugin();
+    const plugin = await loadPlugin(FIXTURE_MODULE);
 
     expect(plugin).toBeDefined();
     expect(mockCreatePlugin).toHaveBeenCalledTimes(1);
@@ -78,7 +83,7 @@ describe('plugin (default package installed)', () => {
     installDefaultPluginMock();
     const { loadPlugin } = await import('./plugin');
 
-    const plugin = await loadPlugin();
+    const plugin = await loadPlugin(FIXTURE_MODULE);
 
     expect(typeof plugin!.initialize).toBe('function');
     expect(typeof plugin!.canHandleBuild).toBe('function');
@@ -92,7 +97,7 @@ describe('plugin (default package installed)', () => {
     installDefaultPluginMock({ createPlugin: undefined });
     const { loadPlugin } = await import('./plugin');
 
-    const plugin = await loadPlugin();
+    const plugin = await loadPlugin(FIXTURE_MODULE);
 
     expect(plugin).toBeUndefined();
     expect(mockWarning).toHaveBeenCalledWith(
@@ -111,6 +116,6 @@ describe('plugin (default package installed)', () => {
     });
     const { loadPlugin } = await import('./plugin');
 
-    await expect(loadPlugin()).rejects.toThrow('Syntax error in module');
+    await expect(loadPlugin(FIXTURE_MODULE)).rejects.toThrow('Syntax error in module');
   });
 });

--- a/plugins/unity/src/unity-builder/model/plugin.ts
+++ b/plugins/unity/src/unity-builder/model/plugin.ts
@@ -71,6 +71,11 @@ function isModuleNotFoundError(error: unknown): boolean {
 
   return (
     typeof (error as Error)?.message === 'string' &&
-    /cannot find module/i.test((error as Error).message)
+    // Node/Bun's own resolver throws "Cannot find module"; Vite's (used by
+    // vitest, including this file's own tests when @game-ci/orchestrator's
+    // dist/ isn't built) throws a differently-worded "Failed to resolve
+    // entry for package" for the same "package genuinely isn't there"
+    // situation - both mean the same thing to this optional-plugin loader.
+    /cannot find module|failed to resolve entry for package/i.test((error as Error).message)
   );
 }


### PR DESCRIPTION
## What this is

While getting #153 and #154 through CI, both hit an identical, pre-existing
\`Unity engine core tests\` failure unrelated to either change:

\`\`\`
FAIL src/unity-builder/model/plugin.test.ts > ...
Error: Failed to resolve entry for package "@game-ci/orchestrator". The
package may have incorrect main/module/exports specified in its package.json.
```

This job is gated by \`if: needs.changes.outputs.unity == 'true'\` and CI
never builds \`@game-ci/orchestrator\`'s \`dist/\` before running it (confirmed:
no such step in \`tests.yml\`). \`main\`'s own most recent \`Tests\` run shows
this job as **skipped**, not passing - nothing recently touched
\`plugins/unity\` until #153/#154, so this was never actually exercised.

## Two separate real bugs

1. \`plugin.ts\`'s \`isModuleNotFoundError()\` only recognized Node/Bun's
   \"Cannot find module\" error shape. Vite's (which is what \`bun run test\`
   actually runs under here - the script is \`vitest run\`) unresolvable-
   package error is worded differently (\"Failed to resolve entry for
   package ...\") and wasn't recognized, so the \"not installed\" test's
   genuine resolution failure propagated as an uncaught error instead of
   the intended graceful \`undefined\`.
2. \`plugin.test.ts\`'s \"installed\" tests \`vi.doMock\`'d the bare specifier
   \`@game-ci/orchestrator\` directly. That only works if Vite can resolve a
   module identity to attach the mock to - with no built \`dist/\` and no
   declared dependency, it can't, so mocking a genuinely-absent bare
   specifier fails outright before the factory ever runs.

## Fix

- Broadened \`isModuleNotFoundError()\`'s message match to also catch Vite's
  wording (both mean the same thing: the package genuinely isn't there).
- Changed the \"installed\" tests to mock a real, trivial, always-resolvable
  fixture file (\`__fixtures__/fake-orchestrator-plugin.ts\`) instead of the
  bare specifier, passing its path to \`loadPlugin()\` explicitly (which
  already accepted a \`moduleName\` override for exactly this).

## Verification

\`bun run test\` in \`plugins/unity\`: 454/454 pass, 0 failures (previously
4-5 failures depending on whether \`@game-ci/orchestrator/dist\` happened to
already be built in the working tree).

## Test plan

- [ ] CI green
- [ ] Rebase #153 and #154 onto this (or merge this first) so their own CI goes green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved optional plugin loading when a plugin is unavailable.
  * Prevented test environments from failing when optional dependencies cannot be resolved.
  * Preserved existing plugin lifecycle, warning, and error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->