### PR TITLE
chore: bump version to 0.1.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "GameCI CLI - automation for game engines",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump to cut a release with #153 (macOS Unity Hub --changeset fix), #154 (--engineVersion override), and #155's (plugin.test.ts CI fix) changes. No other changes.