### PR TITLE
fix: RunnerImageTag.versionPattern rejects Unity 6's "6000.x" version scheme

### DIFF
--- a/src/model/unity/runner/runner-image-tag.test.ts
+++ b/src/model/unity/runner/runner-image-tag.test.ts
@@ -30,7 +30,7 @@ describe('RunnerImageTag', () => {
       expect(image.builderPlatform).toStrictEqual(some.builderPlatform);
     });
 
-    test.each(['2000.0.0f0', '2011.1.11f1'])('accepts %p version format', (version) => {
+    test.each(['2000.0.0f0', '2011.1.11f1', '6000.0.36f1'])('accepts %p version format', (version) => {
       expect(() => new RunnerImageTag({ engineVersion: version, targetPlatform: some.targetPlatform })).not.toThrow();
     });
 

--- a/src/model/unity/runner/runner-image-tag.ts
+++ b/src/model/unity/runner/runner-image-tag.ts
@@ -49,7 +49,16 @@ class RunnerImageTag {
   }
 
   static get versionPattern() {
-    return /^20\d{2}\.\d\.\w{3,4}|3$/;
+    // Matches both the legacy YYYY.M.PPl# scheme (e.g. "2021.3.45f1") and
+    // Unity 6's "6000.M.PPl#" scheme (e.g. "6000.0.36f1") - previously only
+    // the former was accepted, which silently never mattered while
+    // engineVersion could only ever come from auto-detected
+    // ProjectVersion.txt (itself always a real installed version), but
+    // surfaced as "Invalid version" once an explicit --engineVersion
+    // override became possible (see game-ci/cli#154) and unity-builder's
+    // Unity 6 Build Profile matrix cell (game-ci/unity-builder#847) tried
+    // to pass "6000.0.36f1" through.
+    return /^\d{4}\.\d+\.\w{1,6}$/;
   }
 
   static get targetPlatformSuffixes() {


### PR DESCRIPTION
## What broke

Once #154 made an explicit \`--engineVersion\` override actually take effect, unity-builder#847's Build Profile matrix cell (which passes \`unityVersion: 6000.0.36f1\`) started failing on **every** WebGL job for that Unity version - not just the Build Profile cell, but the plain \`WebGL on 6000.0.36f1\` job that had been passing fine before:

\`\`\`
[ERROR] Error: Invalid version "6000.0.36f1".
\`\`\`

## Root cause

\`RunnerImageTag.versionPattern\` was \`/^20\d{2}\.\d\.\w{3,4}|3$/\` - hardcoded to only accept the legacy \`20xx.x.xxxx\` scheme. This was latent: \`engineVersion\` could previously only ever come from auto-detected \`ProjectVersion.txt\` (always a real, already-legacy-formatted installed version), so the pattern never actually had to handle anything else - until an explicit override became possible and unity-builder passed Unity 6's real \`6000.M.PPl#\`-style version string through.

## Fix

Generalized the leading component from a hardcoded \`20\d{2}\` to any 4 digits (\`/^\d{4}\.\d+\.\w{1,6}$/\`), covering both the legacy scheme and Unity 6's, while staying exactly as permissive otherwise - existing tests use synthetic non-real versions like \`"2099.1.1111"\` (no letter suffix), which still pass.

## Verification

- New test case \`'6000.0.36f1'\` added to the existing accepted-format table - 15/15 pass (was 14).
- \`bun test src/model/unity src/command/build\` - 41/41 pass.
- Traced end-to-end against unity-builder#844's actual failing CI run to find the exact error and confirm the fix addresses it (not yet re-verified against a real release - needs this merged + released first).

## Test plan

- [ ] CI green
- [ ] Once merged + released, re-verify unity-builder#844's Ubuntu Build Profile cell and the plain WebGL on 6000.0.36f1 job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added support for Unity 6 engine versions, including versions such as `6000.0.36f1`.
  - Continued support for legacy Unity version formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->