### PR TITLE
fix: -activeBuildProfile path gets word-split into multiple argv entries on Linux/macOS

### DIFF
--- a/dist/platforms/mac/steps/build.sh
+++ b/dist/platforms/mac/steps/build.sh
@@ -138,13 +138,21 @@ fi
 
 # BUILD_PROFILE (Unity 6) determines the target itself, so -buildTarget is
 # omitted when one is set - matches real unity-builder's own handling.
-BUILD_TARGET_FLAG="-buildTarget $BUILD_TARGET"
+#
+# Arrays, not plain strings: BUILD_PROFILE is a path that can contain spaces
+# (e.g. "Assets/Settings/Build Profiles/Sample WebGL Build Profile.asset").
+# A plain string expanded unquoted ($BUILD_PROFILE_FLAGS) word-splits on
+# those spaces into separate argv entries, silently truncating the value
+# Unity actually receives for -activeBuildProfile to its first word - see
+# game-ci/cli#159. "${arr[@]}" preserves each element intact regardless of
+# internal whitespace, matching build.ps1's already-correct @(...) array.
+BUILD_TARGET_FLAG=(-buildTarget "$BUILD_TARGET")
 if [ -n "$BUILD_PROFILE" ]; then
-  BUILD_TARGET_FLAG=""
+  BUILD_TARGET_FLAG=()
 fi
-BUILD_PROFILE_FLAGS=""
+BUILD_PROFILE_FLAGS=()
 if [ -n "$BUILD_PROFILE" ]; then
-  BUILD_PROFILE_FLAGS="-activeBuildProfile $BUILD_PROFILE"
+  BUILD_PROFILE_FLAGS=(-activeBuildProfile "$BUILD_PROFILE")
 fi
 
 /Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS/Unity \
@@ -156,11 +164,11 @@ fi
   -password "$UNITY_PASSWORD" \
   -customBuildName "$BUILD_NAME" \
   -projectPath "$UNITY_PROJECT_PATH" \
-  $BUILD_TARGET_FLAG \
+  "${BUILD_TARGET_FLAG[@]}" \
   -customBuildTarget "$BUILD_TARGET" \
   -customBuildPath "$CUSTOM_BUILD_PATH" \
   -customBuildProfile "$BUILD_PROFILE" \
-  $BUILD_PROFILE_FLAGS \
+  "${BUILD_PROFILE_FLAGS[@]}" \
   -executeMethod "$BUILD_METHOD" \
   -buildVersion "$VERSION" \
   -androidVersionCode "$ANDROID_VERSION_CODE" \

--- a/dist/platforms/ubuntu/steps/build.sh
+++ b/dist/platforms/ubuntu/steps/build.sh
@@ -123,13 +123,21 @@ fi
 
 # BUILD_PROFILE (Unity 6) determines the target itself, so -buildTarget is
 # omitted when one is set - matches real unity-builder's own handling.
-BUILD_TARGET_FLAG=""
+#
+# Arrays, not plain strings: BUILD_PROFILE is a path that can contain spaces
+# (e.g. "Assets/Settings/Build Profiles/Sample WebGL Build Profile.asset").
+# A plain string expanded unquoted ($BUILD_PROFILE_FLAGS) word-splits on
+# those spaces into separate argv entries, silently truncating the value
+# Unity actually receives for -activeBuildProfile to its first word - see
+# game-ci/cli#159. "${arr[@]}" preserves each element intact regardless of
+# internal whitespace, matching build.ps1's already-correct @(...) array.
+BUILD_TARGET_FLAG=()
 if [ -z "$BUILD_PROFILE" ]; then
-  BUILD_TARGET_FLAG="-buildTarget $BUILD_TARGET"
+  BUILD_TARGET_FLAG=(-buildTarget "$BUILD_TARGET")
 fi
-BUILD_PROFILE_FLAGS=""
+BUILD_PROFILE_FLAGS=()
 if [ -n "$BUILD_PROFILE" ]; then
-  BUILD_PROFILE_FLAGS="-activeBuildProfile $BUILD_PROFILE"
+  BUILD_PROFILE_FLAGS=(-activeBuildProfile "$BUILD_PROFILE")
 fi
 
 ${ENGINE_LAUNCH_WRAPPER:-} unity-editor \
@@ -137,11 +145,11 @@ ${ENGINE_LAUNCH_WRAPPER:-} unity-editor \
   $QUIT_FLAG \
   -customBuildName "$BUILD_NAME" \
   -projectPath "$UNITY_PROJECT_PATH" \
-  $BUILD_TARGET_FLAG \
+  "${BUILD_TARGET_FLAG[@]}" \
   -customBuildTarget "$BUILD_TARGET" \
   -customBuildPath "$CUSTOM_BUILD_PATH" \
   -customBuildProfile "$BUILD_PROFILE" \
-  $BUILD_PROFILE_FLAGS \
+  "${BUILD_PROFILE_FLAGS[@]}" \
   -executeMethod "$BUILD_METHOD" \
   -buildVersion "$VERSION" \
   -androidVersionCode "$ANDROID_VERSION_CODE" \


### PR DESCRIPTION
## What broke

unity-builder#844's \"WebGL on 6000.0.36f1 (via Build Profile)\" job fails consistently. The invoked Unity Editor command line (visible in the run's own log) showed:

\`\`\`
-activeBuildProfile
Assets/Settings/Build
Profiles/Sample
WebGL
Build
Profile.asset
\`\`\`

Six separate argv entries instead of one intact path - while the adjacent \`-customBuildProfile\` flag, three lines earlier in the same invocation, got the full path correctly.

## Root cause

Both \`dist/platforms/ubuntu/steps/build.sh\` and \`dist/platforms/mac/steps/build.sh\` build \`BUILD_PROFILE_FLAGS\` as a plain string:

\`\`\`bash
BUILD_PROFILE_FLAGS="-activeBuildProfile $BUILD_PROFILE"
```
...and expand it **unquoted** (\`$BUILD_PROFILE_FLAGS\`) in the Unity invocation. Bash word-splits an unquoted expansion on whitespace - any build profile path containing a space (e.g. this repo's own test fixture, \`\"Assets/Settings/Build Profiles/Sample WebGL Build Profile.asset\"\`) silently truncates to \`-activeBuildProfile Assets/Settings/Build\` plus five now-misinterpreted bare positional arguments, which is exactly what broke the actual Unity build.

\`build.ps1\` (Windows) never had this bug - it already used a real PowerShell array (\`@('-activeBuildProfile', $Env:BUILD_PROFILE)\`), which preserves each element regardless of internal whitespace. This matches what's been observed all session: Windows has been green throughout; only the two bash platforms (Ubuntu, macOS) were affected.

## Fix

\`BUILD_TARGET_FLAG\` and \`BUILD_PROFILE_FLAGS\` are now bash arrays, expanded with \`\"${arr[@]}\"\` - the same word-splitting-safe pattern \`build.ps1\` already used.

## Verification

Manually verified via a standalone argv-dump script that the array form preserves the full spaced path as one token:

\`\`\`
argv[2] = [Assets/Settings/Build Profiles/Sample WebGL Build Profile.asset]
```
(previously would have been 5 separate entries). \`bash -n\` syntax-checked both files.

## Test plan

- [ ] CI green
- [ ] Once merged + released, re-trigger unity-builder#844's Ubuntu Build Profile cell and confirm it passes