### PR TITLE
fix: restore --changeset in macOS Unity Hub install (partial revert of #153)

### DIFF
--- a/plugins/unity/dist/unity-builder/model/platform-setup/setup-mac.js
+++ b/plugins/unity/dist/unity-builder/model/platform-setup/setup-mac.js
@@ -3,6 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+const unity_changeset_1 = require("unity-changeset");
 const exec_1 = require("@actions/exec");
 const cache_1 = require("@actions/cache");
 const node_fs_1 = __importDefault(require("node:fs"));
@@ -113,10 +114,14 @@ class SetupMac {
                 return;
             }
         }
-        // No --changeset: passing it here has previously caused Unity Hub CLI to
-        // reject known-good versions with "Provided editor version does not
-        // match to any known Unity Editor versions" (see game-ci/cli#153).
-        // --version alone is what the legacy setup-mac.ts relied on for years.
+        // #153 removed --changeset based on an untested hypothesis about
+        // unity-builder#844's macOS failures; empirically wrong - main's own
+        // successful runs invoke Unity Hub WITH --changeset
+        // (--version 2021.3.45f2 --changeset 88f88f591b2e ...), confirmed via
+        // a real passing CI log. Restored. The actual #844 root cause was
+        // -activeBuildProfile's value getting word-split on the bash side
+        // (see game-ci/cli#159), unrelated to this flag.
+        const unityChangeset = await (0, unity_changeset_1.getUnityChangeset)(buildParameters.editorVersion);
         const moduleArguments = SetupMac.getModuleParametersForTargetPlatform(buildParameters.targetPlatform);
         const architectureArguments = SetupMac.getArchitectureParameters();
         const execArguments = [
@@ -124,6 +129,7 @@ class SetupMac {
             '--headless',
             'install',
             ...['--version', buildParameters.editorVersion],
+            ...['--changeset', unityChangeset.changeset],
             ...moduleArguments,
             ...architectureArguments,
             '--childModules',

--- a/plugins/unity/src/unity-builder/model/platform-setup/setup-mac.ts
+++ b/plugins/unity/src/unity-builder/model/platform-setup/setup-mac.ts
@@ -1,4 +1,5 @@
 import { BuildParameters } from '..';
+import { getUnityChangeset } from 'unity-changeset';
 import { exec, getExecOutput } from '@actions/exec';
 import { restoreCache, saveCache } from '@actions/cache';
 
@@ -136,10 +137,14 @@ class SetupMac {
       }
     }
 
-    // No --changeset: passing it here has previously caused Unity Hub CLI to
-    // reject known-good versions with "Provided editor version does not
-    // match to any known Unity Editor versions" (see game-ci/cli#153).
-    // --version alone is what the legacy setup-mac.ts relied on for years.
+    // #153 removed --changeset based on an untested hypothesis about
+    // unity-builder#844's macOS failures; empirically wrong - main's own
+    // successful runs invoke Unity Hub WITH --changeset
+    // (--version 2021.3.45f2 --changeset 88f88f591b2e ...), confirmed via
+    // a real passing CI log. Restored. The actual #844 root cause was
+    // -activeBuildProfile's value getting word-split on the bash side
+    // (see game-ci/cli#159), unrelated to this flag.
+    const unityChangeset = await getUnityChangeset(buildParameters.editorVersion);
     const moduleArguments = SetupMac.getModuleParametersForTargetPlatform(
       buildParameters.targetPlatform,
     );
@@ -150,6 +155,7 @@ class SetupMac {
       '--headless',
       'install',
       ...['--version', buildParameters.editorVersion],
+      ...['--changeset', unityChangeset.changeset],
       ...moduleArguments,
       ...architectureArguments,
       '--childModules',


### PR DESCRIPTION
#153 removed \`--changeset\` from \`setup-mac.ts\`'s \`installUnity\` based on an untested hypothesis (I had no real macOS hardware to verify against at the time - only a 2023-era comment in an unrelated legacy file as circumstantial evidence).

Disproven empirically: fetched the log of a genuinely successful unity-builder \`main\`-branch macOS run (run 32851368275, job 97812836925). Its actual Unity Hub invocation:

\`\`\`
Unity Hub -- --headless install --version 2021.3.45f2 --changeset 88f88f591b2e --module mac-il2cpp --architecture arm64 --childModules
\`\`\`

\`--changeset\` is present there and it works. Removing it in #153 did not fix unity-builder#844's macOS failures either - still 0/8 after #153 shipped in v0.1.17/v0.1.18, with the exact same \"Provided editor version does not match to any known Unity Editor versions\" error.

The actual root cause of #844's Build Profile Ubuntu cell was \`-activeBuildProfile\`'s value getting silently word-split by two bash scripts (#159) - unrelated to \`--changeset\`. The plain macOS jobs' failure is still under investigation; this PR just removes a variable (\`--changeset\` removal) that was never actually the fix, restoring the empirically-proven-working invocation shape.

## Verification

454/454 tests pass in \`plugins/unity\` (\`bun run test\`), typecheck clean, dist rebuilt (only the expected file changed).

## Test plan

- [ ] CI green
- [ ] Continue investigating macOS's actual remaining failure once this + #159 are both live