### PR TITLE
chore: bump version to 0.1.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "GameCI CLI - automation for game engines",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump to cut a release with #159 (fix -activeBuildProfile argv word-splitting on Linux/macOS) and #160 (restore --changeset in macOS Unity Hub install). No other changes.