### PR TITLE
fix: root dist/default-build-script's C# entirely lacked Build Profile support

### DIFF
--- a/dist/default-build-script/Assets/Editor/UnityBuilderAction/Builder.cs
+++ b/dist/default-build-script/Assets/Editor/UnityBuilderAction/Builder.cs
@@ -6,6 +6,9 @@ using UnityBuilderAction.Reporting;
 using UnityBuilderAction.Versioning;
 using UnityEditor;
 using UnityEditor.Build.Reporting;
+#if UNITY_6000_0_OR_NEWER
+using UnityEditor.Build.Profile;
+#endif
 using UnityEngine;
 
 namespace UnityBuilderAction
@@ -17,9 +20,9 @@ namespace UnityBuilderAction
       // Gather values from args
       var options = ArgumentsParser.GetValidatedOptions();
 
-      // Gather values from project
-      var scenes = EditorBuildSettings.scenes.Where(scene => scene.enabled).Select(s => s.path).ToArray();
-      
+      // Set version for this build
+      VersionApplicator.SetVersion(options["buildVersion"]);
+
       // Get all buildOptions from options
       BuildOptions buildOptions = BuildOptions.None;
       foreach (string buildOptionString in Enum.GetNames(typeof(BuildOptions))) {
@@ -29,35 +32,65 @@ namespace UnityBuilderAction
         }
       }
 
+      // Depending on whether the build is using a build profile, buildPlayerOptions
+      // will be an instance of either BuildPlayerOptions or BuildPlayerWithProfileOptions.
+      dynamic buildPlayerOptions;
+
+      if (options.TryGetValue("activeBuildProfile", out var buildProfilePath)) {
+        if (string.IsNullOrEmpty(buildProfilePath)) {
+          throw new Exception("`-activeBuildProfile` is set but with an empty value; this shouldn't happen");
+        }
+
+#if UNITY_6000_0_OR_NEWER
+        // Load build profile from Assets folder
+        var buildProfile = AssetDatabase.LoadAssetAtPath<BuildProfile>(buildProfilePath)
+                           ?? throw new Exception("Build profile file not found at path: " + buildProfilePath);
+
+        // No need to set active profile, as already set by `-activeBuildProfile` CLI argument.
+        Debug.Log($"build profile: {buildProfile.name}");
+
+        buildPlayerOptions = new BuildPlayerWithProfileOptions {
+          buildProfile = buildProfile,
+          locationPathName = options["customBuildPath"],
+          options = buildOptions,
+        };
+#else // UNITY_6000_0_OR_NEWER
+        throw new Exception("Build profiles are not supported by this version of Unity (" + Application.unityVersion + ")");
+#endif // UNITY_6000_0_OR_NEWER
+
+      } else {
+        // Gather values from project
+        var scenes = EditorBuildSettings.scenes.Where(scene => scene.enabled).Select(s => s.path).ToArray();
+
 #if UNITY_2021_2_OR_NEWER
-      // Determine subtarget
-      StandaloneBuildSubtarget buildSubtarget;
-      if (!options.TryGetValue("standaloneBuildSubtarget", out var subtargetValue) || !Enum.TryParse(subtargetValue, out buildSubtarget)) {
-        buildSubtarget = default;
-      }
+        // Determine subtarget
+        StandaloneBuildSubtarget buildSubtarget;
+        if (!options.TryGetValue("standaloneBuildSubtarget", out var subtargetValue) || !Enum.TryParse(subtargetValue, out buildSubtarget)) {
+          buildSubtarget = default;
+        }
 #endif
 
-      // Define BuildPlayer Options
-      var buildPlayerOptions = new BuildPlayerOptions {
-        scenes = scenes,
-        locationPathName = options["customBuildPath"],
-        target = (BuildTarget) Enum.Parse(typeof(BuildTarget), options["buildTarget"]),
-        options = buildOptions,
-#if UNITY_2021_2_OR_NEWER
-        subtarget = (int) buildSubtarget
-#endif
-      };
+        var target = (BuildTarget) Enum.Parse(typeof(BuildTarget), options["buildTarget"]);
 
-      // Set version for this build
-      VersionApplicator.SetVersion(options["buildVersion"]);
-      
-      // Apply Android settings
-      if (buildPlayerOptions.target == BuildTarget.Android)
-      {
-        VersionApplicator.SetAndroidVersionCode(options["androidVersionCode"]);
-        AndroidSettings.Apply(options);
+        // Define BuildPlayer Options
+        buildPlayerOptions = new BuildPlayerOptions {
+          scenes = scenes,
+          locationPathName = options["customBuildPath"],
+          target = target,
+          options = buildOptions,
+#if UNITY_2021_2_OR_NEWER
+          subtarget = (int) buildSubtarget
+#endif
+        };
+
+        // Apply Android settings
+        if (target == BuildTarget.Android)
+        {
+          VersionApplicator.SetAndroidVersionCode(options["androidVersionCode"]);
+          AndroidSettings.Apply(options);
+        }
       }
-      
+
       // Execute default AddressableAsset content build, if the package is installed.
       // Version defines would be the best solution here, but Unity 2018 doesn't support that,
       // so we fall back to using reflection instead.

--- a/dist/default-build-script/Assets/Editor/UnityBuilderAction/Input/ArgumentsParser.cs
+++ b/dist/default-build-script/Assets/Editor/UnityBuilderAction/Input/ArgumentsParser.cs
@@ -21,15 +21,31 @@ namespace UnityBuilderAction.Input
         EditorApplication.Exit(110);
       }
 
-      string buildTarget;
-      if (!validatedOptions.TryGetValue("buildTarget", out buildTarget)) {
-        Console.WriteLine("Missing argument -buildTarget");
-        EditorApplication.Exit(120);
-      }
+      // Unity 6's Build Profiles (-activeBuildProfile) determine the target
+      // themselves, so -buildTarget is only required when one isn't given -
+      // see Builder.cs's matching branch.
+#if UNITY_6000_0_OR_NEWER
+      var buildProfileSupport = true;
+#else
+      var buildProfileSupport = false;
+#endif // UNITY_6000_0_OR_NEWER
 
-      if (!Enum.IsDefined(typeof(BuildTarget), buildTarget)) {
-        Console.WriteLine($"{buildTarget} is not a defined {nameof(BuildTarget)}");
-        EditorApplication.Exit(121);
+      string buildTarget;
+      if (buildProfileSupport && validatedOptions.TryGetValue("activeBuildProfile", out _)) {
+        if (validatedOptions.ContainsKey("buildTarget")) {
+          Console.WriteLine("Extra argument -buildTarget");
+          EditorApplication.Exit(122);
+        }
+      } else {
+        if (!validatedOptions.TryGetValue("buildTarget", out buildTarget)) {
+          Console.WriteLine("Missing argument -buildTarget");
+          EditorApplication.Exit(120);
+        }
+
+        if (!Enum.IsDefined(typeof(BuildTarget), buildTarget)) {
+          Console.WriteLine($"{buildTarget} is not a defined {nameof(BuildTarget)}");
+          EditorApplication.Exit(121);
+        }
       }
 
       string customBuildPath;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "GameCI CLI - automation for game engines",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What broke

After #159 fixed the argv word-splitting bug, unity-builder#844's Ubuntu \"WebGL on 6000.0.36f1 (via Build Profile)\" job progressed further - the Editor log confirms \`-activeBuildProfile\` now arrives with its full, intact path:

\`\`\`
Found flag "activeBuildProfile" with value "Assets/Settings/Build Profiles/Sample WebGL Build Profile.asset".
\`\`\`

But the build still exits 120 with \`Missing argument -buildTarget\`.

## Root cause

Same class of problem as #159's discovery process: \`root/dist/default-build-script\` (confirmed via \`release-cli.yml\`'s \`cp -r dist pkg/dist\` step - this exact tree ships in every release archive) is a **completely separate, independently-maintained copy** of \`Builder.cs\`/\`ArgumentsParser.cs\` from \`plugins/unity/src/unity-builder/dist\`'s version.

The two have drifted apart: root's copy uses a newer C# string-interpolation style throughout but has **zero** Build Profile support (no \`UNITY_6000_0_OR_NEWER\` guard, no \`activeBuildProfile\` handling at all - \`grep -c\` returns 0 matches). \`plugins/unity\`'s copy has Build Profile support but an older string-concatenation style. Neither copy was ever reconciled with the other, so root's \`ArgumentsParser.cs\` *always* required \`-buildTarget\` unconditionally, regardless of any \`-activeBuildProfile\` flag being present - hence the error.

## Fix

Ported just the missing Build Profile logic into root's files, preserving root's existing style/structure everywhere else (not a wholesale copy-over, to avoid regressing anything else in the more current root version):

- \`ArgumentsParser.cs\`: \`-buildTarget\` is now only required when \`-activeBuildProfile\` isn't set (mirrors Unity's own \`BuildPlayerOptions\` vs \`BuildPlayerWithProfileOptions\` distinction).
- \`Builder.cs\`: branches into \`BuildPlayerOptions\` (existing path, unchanged behavior) vs \`BuildPlayerWithProfileOptions\` (new, \`UNITY_6000_0_OR_NEWER\`-gated) based on whether \`-activeBuildProfile\` was given.

## Known follow-up (not fixed here)

\`default-build-script\`'s two copies have also diverged in several **other** files - \`AndroidSettings.cs\`, \`StdOutReporter.cs\`, \`Git.cs\` differ; \`plugins/unity\`'s copy has an extra \`Reporting/CompileListener.cs\` not present in root at all. A broader repo-hygiene gap worth its own investigation - out of scope here since I can't verify behavioral impact across all of them without real Unity/hardware access for each.

## Test plan

- [ ] CI green (this only touches static C# assets under \`dist/\`, no TS changed, so no automated test coverage exists for this specific change - manual review of the diff is the real gate here)
- [ ] Once merged + released, re-trigger unity-builder#844's Ubuntu Build Profile cell and confirm it passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.1.19.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->