### PR TITLE
chore: bump version to 0.1.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "GameCI CLI - automation for game engines",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump to cut a release with #162 (root dist's default-build-script C# now supports Build Profiles). No other changes.