### PR TITLE
debug: instrument macOS Unity Hub install to diagnose #844's mystery

### DIFF
--- a/plugins/unity/dist/unity-builder/model/platform-setup/setup-mac.js
+++ b/plugins/unity/dist/unity-builder/model/platform-setup/setup-mac.js
@@ -121,7 +121,16 @@ class SetupMac {
         // a real passing CI log. Restored. The actual #844 root cause was
         // -activeBuildProfile's value getting word-split on the bash side
         // (see game-ci/cli#159), unrelated to this flag.
-        const unityChangeset = await (0, unity_changeset_1.getUnityChangeset)(buildParameters.editorVersion);
+        let unityChangeset;
+        console.log(`[SetupMac] Resolving changeset for editorVersion="${buildParameters.editorVersion}"...`);
+        try {
+            unityChangeset = await (0, unity_changeset_1.getUnityChangeset)(buildParameters.editorVersion);
+            console.log(`[SetupMac] Resolved changeset: ${unityChangeset.changeset}`);
+        }
+        catch (changesetError) {
+            console.log(`[SetupMac] getUnityChangeset FAILED: ${changesetError}`);
+            throw changesetError;
+        }
         const moduleArguments = SetupMac.getModuleParametersForTargetPlatform(buildParameters.targetPlatform);
         const architectureArguments = SetupMac.getArchitectureParameters();
         const execArguments = [
@@ -134,13 +143,20 @@ class SetupMac {
             ...architectureArguments,
             '--childModules',
         ];
-        // Ignoring return code because the log seems to overflow the internal buffer which triggers
-        // a false error
-        const errorCode = await (0, exec_1.exec)(this.unityHubExecPath, execArguments, {
+        // Debug instrumentation (game-ci/cli#844 investigation): exec()'s normal
+        // [command] echo + live output has been mysteriously absent from CI logs
+        // for this exact call - switching to getExecOutput so we capture and
+        // print stdout/stderr ourselves, independent of whatever's suppressing
+        // exec()'s own listener-based echo in this compiled-binary context.
+        console.log(`[SetupMac] Running: ${this.unityHubExecPath} ${execArguments.map((a) => JSON.stringify(a)).join(' ')}`);
+        const result = await (0, exec_1.getExecOutput)(this.unityHubExecPath, execArguments, {
             silent,
             ignoreReturnCode: true,
         });
-        if (errorCode) {
+        console.log(`[SetupMac] Unity Hub install exit code: ${result.exitCode}`);
+        console.log(`[SetupMac] Unity Hub install stdout:\n${result.stdout}`);
+        console.log(`[SetupMac] Unity Hub install stderr:\n${result.stderr}`);
+        if (result.exitCode) {
             throw new Error(`There was an error installing the Unity Editor. See logs above for details.`);
         }
         if (buildParameters.cacheUnityInstallationOnMac) {

--- a/plugins/unity/src/unity-builder/model/platform-setup/setup-mac.ts
+++ b/plugins/unity/src/unity-builder/model/platform-setup/setup-mac.ts
@@ -144,7 +144,15 @@ class SetupMac {
     // a real passing CI log. Restored. The actual #844 root cause was
     // -activeBuildProfile's value getting word-split on the bash side
     // (see game-ci/cli#159), unrelated to this flag.
-    const unityChangeset = await getUnityChangeset(buildParameters.editorVersion);
+    let unityChangeset: { changeset: string };
+    console.log(`[SetupMac] Resolving changeset for editorVersion="${buildParameters.editorVersion}"...`);
+    try {
+      unityChangeset = await getUnityChangeset(buildParameters.editorVersion);
+      console.log(`[SetupMac] Resolved changeset: ${unityChangeset.changeset}`);
+    } catch (changesetError) {
+      console.log(`[SetupMac] getUnityChangeset FAILED: ${changesetError}`);
+      throw changesetError;
+    }
     const moduleArguments = SetupMac.getModuleParametersForTargetPlatform(
       buildParameters.targetPlatform,
     );
@@ -161,13 +169,22 @@ class SetupMac {
       '--childModules',
     ];
 
-    // Ignoring return code because the log seems to overflow the internal buffer which triggers
-    // a false error
-    const errorCode = await exec(this.unityHubExecPath, execArguments, {
+    // Debug instrumentation (game-ci/cli#844 investigation): exec()'s normal
+    // [command] echo + live output has been mysteriously absent from CI logs
+    // for this exact call - switching to getExecOutput so we capture and
+    // print stdout/stderr ourselves, independent of whatever's suppressing
+    // exec()'s own listener-based echo in this compiled-binary context.
+    console.log(
+      `[SetupMac] Running: ${this.unityHubExecPath} ${execArguments.map((a) => JSON.stringify(a)).join(' ')}`,
+    );
+    const result = await getExecOutput(this.unityHubExecPath, execArguments, {
       silent,
       ignoreReturnCode: true,
     });
-    if (errorCode) {
+    console.log(`[SetupMac] Unity Hub install exit code: ${result.exitCode}`);
+    console.log(`[SetupMac] Unity Hub install stdout:\n${result.stdout}`);
+    console.log(`[SetupMac] Unity Hub install stderr:\n${result.stderr}`);
+    if (result.exitCode) {
       throw new Error(
         `There was an error installing the Unity Editor. See logs above for details.`,
       );


### PR DESCRIPTION
Adds explicit logging (resolved changeset, exact command+args, full captured stdout/stderr via getExecOutput instead of exec) around the macOS Unity Hub install call, to see what's actually happening - the normal exec() command echo has been mysteriously absent from every CI log this session, across every version from v0.1.17 to v0.1.20, with and without --changeset. Purely additive, no behavior change. 454/454 tests pass. Will merge, release, re-run, then revert/quiet the logging once the mystery is solved.