### PR TITLE
chore: bump version to 0.1.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "GameCI CLI - automation for game engines",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump to cut a debug release with #164's macOS install logging instrumentation. No other changes.