### PR TITLE
chore: bump version to 0.1.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "GameCI CLI - automation for game engines",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump to cut a debug release with #166's logger fix (log.info instead of console.log for the mac install instrumentation).