### PR TITLE
chore: bump version to 0.1.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "GameCI CLI - automation for game engines",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump to cut a release with #168, the real fix for macOS build failures (options.editorVersion -> options.engineVersion typo).