### PR TITLE
debug: log the exact resolved installUnity command

### DIFF
--- a/src/logic/unity/platform-setup/setup-mac.ts
+++ b/src/logic/unity/platform-setup/setup-mac.ts
@@ -88,6 +88,8 @@ class SetupMac {
                                           ${moduleArgument} \
                                           --childModules `;
 
+    log.error(`[DEBUG-844] installUnity resolved command: ${command}`);
+
     try {
       await System.run(command, undefined, { silent });
     } catch (error) {


### PR DESCRIPTION
#168's fix is source-verified (unit test proves it) but unity-builder#844's macOS CI still shows the identical error after v0.1.23. Adds one log.error line printing the fully resolved command before System.run, to see definitively what's actually being sent to Unity Hub.