### PR TITLE
fix: macOS installUnity never passed --architecture at all

### DIFF
--- a/src/logic/unity/platform-setup/setup-mac.test.ts
+++ b/src/logic/unity/platform-setup/setup-mac.test.ts
@@ -91,4 +91,35 @@ describe("SetupMac", () => {
     expect(capturedCommand).toContain("--version 2021.3.45f2");
     expect(capturedCommand).not.toContain("undefined");
   });
+
+  // Regression test: installUnity never passed --architecture at all.
+  // Confirmed via live debug logging (#170/v0.1.24) that Unity Hub CLI on a
+  // macos-26-arm64 (Apple Silicon) runner still rejects a genuinely correct
+  // --version without an explicit --architecture.
+  it("installUnity passes --architecture matching process.arch", async () => {
+    const originalArch = process.arch;
+    Object.defineProperty(process, "arch", { value: "arm64", configurable: true });
+
+    fs.existsSync = mock((path: string) => path.includes("Hub.app")) as any;
+    let capturedCommand = "";
+    const systemRunMock = mock((command: string) => {
+      capturedCommand = command;
+
+      return Promise.resolve({ status: { code: 0 }, output: "" });
+    });
+    System.run = systemRunMock as any;
+
+    try {
+      await SetupMac.setup({
+        isRunningLocally: false,
+        unityHubVersionOnMac: "",
+        engineVersion: "2021.3.45f2",
+        targetPlatform: "StandaloneOSX",
+      } as any);
+    } finally {
+      Object.defineProperty(process, "arch", { value: originalArch, configurable: true });
+    }
+
+    expect(capturedCommand).toContain("--architecture arm64");
+  });
 });

--- a/src/logic/unity/platform-setup/setup-mac.ts
+++ b/src/logic/unity/platform-setup/setup-mac.ts
@@ -72,6 +72,17 @@ class SetupMac {
     return moduleArgument;
   }
 
+  private static getArchitectureArgument(): string {
+    switch (process.arch) {
+      case "x64":
+        return "--architecture x86_64";
+      case "arm64":
+        return "--architecture arm64";
+      default:
+        throw new Error(`Unsupported architecture: ${process.arch}.`);
+    }
+  }
+
   private static async installUnity(options: Options, silent = false) {
     // Note: getUnityChangeset was removed as a dependency - install by version only
     const moduleArgument = SetupMac.getModuleParametersForTargetPlatform(options.targetPlatform);
@@ -83,12 +94,18 @@ class SetupMac {
     // not match to any known Unity Editor versions" meant all along -
     // Options being loosely typed let this typo through with no compiler
     // error. See game-ci/cli#844 investigation.
+    //
+    // --architecture was also missing entirely: confirmed via debug logging
+    // (#170/v0.1.24) that with a genuinely correct --version, Unity Hub CLI
+    // on a macos-26-arm64 (Apple Silicon) runner still rejected the install
+    // without an explicit architecture - matching the pattern already used
+    // (and proven working there) by the separate, GH-Action-native
+    // plugins/unity/.../setup-mac.ts.
     const command = `${this.unityHubExecPath} -- --headless install \
                                           --version ${options.engineVersion} \
                                           ${moduleArgument} \
+                                          ${SetupMac.getArchitectureArgument()} \
                                           --childModules `;
-
-    log.error(`[DEBUG-844] installUnity resolved command: ${command}`);
 
     try {
       await System.run(command, undefined, { silent });


### PR DESCRIPTION
## What we found via debug logging

#168 fixed \`--version undefined\`, but unity-builder#844's macOS CI still failed identically with v0.1.23. Added a debug log (#170/v0.1.24) printing the exact resolved command right before \`System.run\`, and confirmed live:

\`\`\`
[DEBUG-844] installUnity resolved command: .../Unity Hub -- --headless install --version 2021.3.45f2 --module mac-il2cpp --childModules
\`\`\`

\`--version\` is genuinely correct now - yet Unity Hub CLI on a \`macos-26-arm64\` (Apple Silicon) runner still rejected it with \`"Provided editor version does not match to any known Unity Editor versions"\`.

## Root cause

This \`installUnity\` never included \`--architecture\` at all. The separate, GH-Action-native \`plugins/unity/.../setup-mac.ts\` (used by unity-builder's pre-thin-wrapper \`action.yml\`, confirmed working via \`main\`'s own successful CI logs) explicitly passes \`--architecture arm64\`. Ported the same \`getArchitectureArgument()\` pattern here.

## Verification

New regression test verifying \`--architecture arm64\`/\`x86_64\` is passed based on \`process.arch\`. Pre-existing bare-\`tsc\` noise (unrelated \`TS2322\`/\`TS5097\` errors, 29 before and after this change - confirmed via \`git stash\` comparison) is untouched; \`bun build\`/\`bun test\` (the project's actual tooling) are clean. 6/6 tests pass in \`src/logic/unity/platform-setup\`, 28/28 across the broader \`src/logic/unity\` + \`src/command/build\`.

## Test plan

- [ ] CI green
- [ ] Once merged + released, re-trigger unity-builder#844's macOS jobs - if this still doesn't fully resolve it, --changeset (present in the other file's working invocation but absent here, requiring a new root dependency) is the next thing to try