### PR TITLE
chore: bump version to 0.1.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "GameCI CLI - automation for game engines",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump to cut a release with #172's --architecture fix for macOS.