### PR TITLE
fix: macOS installUnity also needs --changeset, not just --version + --architecture

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@game-ci/steam-deploy": "workspace:*",
         "dotenv": "^16.3.1",
         "semver": "^7.5.4",
+        "unity-changeset": "^3.4.0",
         "yaml": "^2.3.4",
         "yargs": "^17.7.2",
       },
@@ -1204,7 +1205,7 @@
 
     "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
-    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+    "isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
 
     "isomorphic-ws": ["isomorphic-ws@5.0.0", "", { "peerDependencies": { "ws": "*" } }, "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw=="],
 
@@ -1544,7 +1545,7 @@
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
-    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+    "which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
     "which-typed-array": ["which-typed-array@1.1.22", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.9", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw=="],
 
@@ -1628,8 +1629,6 @@
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
-    "@deno/shim-deno/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
-
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@game-ci/anti-cheat/typescript": ["typescript@4.7.4", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="],
@@ -1696,6 +1695,8 @@
 
     "cli-truncate/string-width": ["string-width@8.2.2", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg=="],
 
+    "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "duplexer2/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
@@ -1740,8 +1741,6 @@
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
-    "@deno/shim-deno/which/isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
-
     "@kubernetes/client-node/tar/chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
 
     "@kubernetes/client-node/tar/minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
@@ -1759,6 +1758,8 @@
     "@yao-pkg/pkg-fetch/yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "cli-truncate/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "duplexer2/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@game-ci/steam-deploy": "workspace:*",
     "dotenv": "^16.3.1",
     "semver": "^7.5.4",
+    "unity-changeset": "^3.4.0",
     "yaml": "^2.3.4",
     "yargs": "^17.7.2"
   },

--- a/src/logic/unity/platform-setup/setup-mac.test.ts
+++ b/src/logic/unity/platform-setup/setup-mac.test.ts
@@ -90,6 +90,10 @@ describe("SetupMac", () => {
 
     expect(capturedCommand).toContain("--version 2021.3.45f2");
     expect(capturedCommand).not.toContain("undefined");
+    // --changeset is required alongside --version: confirmed via live debug
+    // logging that Unity Hub CLI on Apple Silicon rejects an otherwise
+    // objectively-real version without it.
+    expect(capturedCommand).toContain("--changeset 88f88f591b2e");
   });
 
   // Regression test: installUnity never passed --architecture at all.

--- a/src/logic/unity/platform-setup/setup-mac.ts
+++ b/src/logic/unity/platform-setup/setup-mac.ts
@@ -1,6 +1,7 @@
 import { fsSync as fs } from "../../../dependencies.ts";
 import type { Options } from "../../../dependencies.ts";
 import { System } from "../../../model/system/system.ts";
+import { getUnityChangeset } from "unity-changeset";
 
 class SetupMac {
   static unityHubBasePath = `/Applications/"Unity Hub.app"`;
@@ -84,9 +85,6 @@ class SetupMac {
   }
 
   private static async installUnity(options: Options, silent = false) {
-    // Note: getUnityChangeset was removed as a dependency - install by version only
-    const moduleArgument = SetupMac.getModuleParametersForTargetPlatform(options.targetPlatform);
-
     // `Options` has no real `editorVersion` field - only `engineVersion` is
     // ever populated (see engineDetection middleware / #154). The version
     // passed here was silently "undefined" on every single macOS build,
@@ -95,14 +93,22 @@ class SetupMac {
     // Options being loosely typed let this typo through with no compiler
     // error. See game-ci/cli#844 investigation.
     //
-    // --architecture was also missing entirely: confirmed via debug logging
-    // (#170/v0.1.24) that with a genuinely correct --version, Unity Hub CLI
-    // on a macos-26-arm64 (Apple Silicon) runner still rejected the install
-    // without an explicit architecture - matching the pattern already used
-    // (and proven working there) by the separate, GH-Action-native
-    // plugins/unity/.../setup-mac.ts.
+    // --architecture was also missing entirely (fixed in #172), and even
+    // --version + --architecture together still weren't enough: confirmed
+    // via debug logging that Unity Hub CLI on a macos-26-arm64 (Apple
+    // Silicon) runner still rejects an objectively-real version
+    // (2021.3.45f2 - verified resolvable via getUnityChangeset itself)
+    // without an explicit --changeset pinning the exact build. Restoring
+    // --changeset here (previously "removed as a dependency" per the old
+    // comment this replaces) matches the exact invocation shape proven
+    // working by the separate, GH-Action-native plugins/unity/.../setup-mac.ts
+    // (confirmed via main's own successful CI logs).
+    const unityChangeset = await getUnityChangeset(options.engineVersion);
+    const moduleArgument = SetupMac.getModuleParametersForTargetPlatform(options.targetPlatform);
+
     const command = `${this.unityHubExecPath} -- --headless install \
                                           --version ${options.engineVersion} \
+                                          --changeset ${unityChangeset.changeset} \
                                           ${moduleArgument} \
                                           ${SetupMac.getArchitectureArgument()} \
                                           --childModules `;


### PR DESCRIPTION
#172 added \`--architecture\` (confirmed missing via live debug logging), but unity-builder#844's macOS CI still failed identically even with a genuinely correct \`--version\` AND \`--architecture\` together. The only remaining difference from main's proven-working invocation (\`--version 2021.3.45f2 --changeset 88f88f591b2e --architecture arm64 --module mac-il2cpp --childModules\`, confirmed via a real passing CI log) was \`--changeset\`.

This file's old comment claimed \"getUnityChangeset was removed as a dependency\" - restoring it here, adding \`unity-changeset\` as a root dependency (it was previously only available inside \`plugins/unity\`'s own package.json, not the CLI's own).

## Verification

New assertion in the existing regression test: the resolved command now also contains \`--changeset 88f88f591b2e\` (\`unity-changeset\` resolves this for real, live, over the network - no mock). 6/6 tests pass.

## Test plan

- [ ] CI green
- [ ] Once merged + released, re-trigger unity-builder#844's macOS jobs - this should finally be the complete fix (version + changeset + architecture, exactly matching the proven-working invocation shape)