### PR TITLE
fix: windows build.ps1's Copy-Item lacks -Force, breaking retries

### DIFF
--- a/dist/platforms/windows/build.ps1
+++ b/dist/platforms/windows/build.ps1
@@ -67,7 +67,13 @@ else
     }
 
     # Copy the build script of Unity Builder action
-    Copy-Item -Path "c:\UnityBuilderAction" -Destination $Env:UNITY_PROJECT_PATH\Assets\Editor -Recurse
+    # -Force: without it, a retry (e.g. after a transient Unity crash) fails
+    # outright since the destination subdirectories already exist from the
+    # first attempt - "An item with the specified name ... already exists"
+    # for every already-copied file, masking the real retry attempt behind
+    # a wall of Copy-Item errors. Matches steps/build.ps1's (the native,
+    # non-container path) already-correct -Force usage for the same copy.
+    Copy-Item -Path "c:\UnityBuilderAction" -Destination $Env:UNITY_PROJECT_PATH\Assets\Editor -Recurse -Force
 
     # Set the Build method to that of UnityBuilder Action
     $Env:BUILD_METHOD="UnityBuilderAction.Builder.BuildProject"


### PR DESCRIPTION
unity-builder#844's Windows CI: a build fails on its first real attempt (unrelated Unity crash), then the retry step fails outright with a wall of Copy-Item errors ("An item with the specified name ... already exists") instead of actually retrying - the destination already has files from the first attempt and this Copy-Item has no -Force to overwrite them.

`dist/platforms/windows/steps/build.ps1` (the native, non-container path) already uses `-Force` for the equivalent copy. This is `dist/platforms/windows/build.ps1` (the Docker container path) - the same recurring pattern this session of two independently-maintained script copies drifting apart (see #159, #162).