### PR TITLE
fix: validateBuild rejects builds Unity itself reports as succeeded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "GameCI CLI - automation for game engines",
   "license": "MIT",
   "repository": {

--- a/src/model/unity/build-validation/unity-build-validation.test.ts
+++ b/src/model/unity/build-validation/unity-build-validation.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'bun:test';
+import { UnityBuildValidation } from './unity-build-validation.ts';
+
+describe('UnityBuildValidation.validateBuild', () => {
+  it('does not throw for a clean build (Errors: 0, Build succeeded!)', () => {
+    const output = `
+###########################
+#      Build results      #
+###########################
+
+Duration: 00:01:00.0000000
+Warnings: 0
+Errors: 0
+Size: 12345 bytes
+
+Build succeeded!
+`;
+    expect(() => UnityBuildValidation.validateBuild(output)).not.toThrow();
+  });
+
+  // Regression test for a real bug, confirmed live on unity-builder#844's
+  // macOS jobs: Unity's own BuildSummary.totalErrors can be nonzero on a
+  // build Unity itself considers Succeeded (BuildResult.Succeeded, which is
+  // what prints "Build succeeded!" - see StdOutReporter.cs). Treating any
+  // nonzero Errors count as fatal second-guesses Unity's own authoritative
+  // result and rejects objectively successful builds.
+  it('does not throw when Errors is nonzero but Unity itself reports Build succeeded!', () => {
+    const output = `
+###########################
+#      Build results      #
+###########################
+
+Duration: 00:02:31.6922495
+Warnings: 3
+Errors: 1
+Size: 289530813 bytes
+
+Build succeeded!
+`;
+    expect(() => UnityBuildValidation.validateBuild(output)).not.toThrow();
+  });
+
+  it('throws when Errors is nonzero and there is no Build succeeded! confirmation', () => {
+    const output = `
+###########################
+#      Build results      #
+###########################
+
+Duration: 00:01:00.0000000
+Warnings: 0
+Errors: 2
+Size: 0 bytes
+
+Build failed!
+`;
+    expect(() => UnityBuildValidation.validateBuild(output)).toThrow(/error building the project/);
+  });
+
+  it('throws when the Build results section is entirely missing', () => {
+    expect(() => UnityBuildValidation.validateBuild('some unrelated log output')).toThrow(
+      /error building the project/,
+    );
+  });
+});

--- a/src/model/unity/build-validation/unity-build-validation.ts
+++ b/src/model/unity/build-validation/unity-build-validation.ts
@@ -6,6 +6,22 @@ class UnityBuildValidation {
    * @throws Error if there are any errors in the build output
    */
   static validateBuild(buildOutput: string) {
+    // StdOutReporter.ExitWithResult prints this literal text (and calls
+    // EditorApplication.Exit(0)) only for BuildResult.Succeeded - Unity's
+    // own most authoritative pass/fail signal, already used by System.run's
+    // exit-code check to decide whether we even reach this function at all.
+    //
+    // BuildSummary.totalErrors (parsed below as a fallback) can be nonzero
+    // on a build Unity itself considers Succeeded - a known Unity quirk
+    // where totalErrors counts non-fatal issues logged during the build
+    // (e.g. a benign asset-import or package-resolution warning) that don't
+    // affect the produced player. Treating any nonzero count as fatal here
+    // second-guesses Unity's own BuildResult and produces false failures on
+    // objectively successful builds - confirmed live on unity-builder#844's
+    // macOS jobs: "Errors: 1" alongside "Build Finished, Result: Success."
+    // and "Build succeeded!", with a correctly-sized .app actually produced.
+    if (buildOutput.includes('Build succeeded!')) return;
+
     // Check for errors in the Build Results section
     const match = buildOutput.match(/^#\s*Build results\s*#(.*)^Size:/ms);
 


### PR DESCRIPTION
## What broke

Confirmed live on unity-builder#844's macOS jobs: the actual Unity build genuinely succeeds - \`Build Finished, Result: Success.\`, \`Build succeeded!\`, a correctly-sized \`.app\` produced (289530813 bytes) - yet game-ci still fails the job with \`There was an error building the project\`, because Unity's own \`BuildSummary.totalErrors\` was \`1\`.

## Root cause

\`System.run\` already throws on a nonzero process exit code, and the compiled \`Builder.cs\`/\`StdOutReporter.cs\` only calls \`EditorApplication.Exit(0)\` (and prints \`Build succeeded!\`) for \`BuildResult.Succeeded\` - Unity's own most authoritative pass/fail signal. \`validateBuild\` is a **second, independent check** on top of that, parsing the same captured output's \`Errors: N\` count and treating any nonzero value as fatal - second-guessing Unity's own result.

This is a known Unity quirk (also referenced by an existing comment in \`docker.ts\` pointing at unity-activate#111): \`totalErrors\` can count non-fatal issues logged during a build that Unity itself still considers successful.

## Fix

Trust \`Build succeeded!\` (Unity's own authoritative signal, already gated on \`BuildResult.Succeeded\`) over the \`Errors: N\` count. Falls back to the existing stricter parsing when that explicit confirmation isn't present, so a genuine failure (no \`Build succeeded!\`, possibly no \`Build results\` section at all) still throws as before.

## Verification

No test file existed for this function at all - added one (4 tests): clean build passes, \`Errors > 0\` + \`Build succeeded!\` now passes (regression test for this exact bug), \`Errors > 0\` without \`succeeded!\` still throws, missing \`Build results\` section still throws.

Used by both \`mac-builder.ts\` and \`docker.ts\` (Windows/Ubuntu container builds), so this fix applies uniformly across all three platforms.

## Test plan

- [ ] CI green
- [ ] Once merged + released, re-trigger unity-builder#844's macOS jobs and confirm they pass end-to-end