### PR TITLE
chore: bump version to 0.1.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "GameCI CLI - automation for game engines",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump for #178's validateBuild fix - should complete the macOS fix chain.