### PR TITLE
fix: windows activate.ps1/return_license.ps1 reference ACTIVATE_LICENSE_PATH without $Env: prefix

### DIFF
--- a/dist/platforms/windows/activate.ps1
+++ b/dist/platforms/windows/activate.ps1
@@ -1,6 +1,16 @@
 # Activates Unity
-Write-Host "Changing to `"$ACTIVATE_LICENSE_PATH`" directory."
-Push-Location $ACTIVATE_LICENSE_PATH
+#
+# $ACTIVATE_LICENSE_PATH (no $Env: prefix) is an unset local PowerShell
+# variable, not the environment variable set by the caller - always empty,
+# so Push-Location silently did nothing and every path built from it below
+# resolved wrong. Confirmed live: "Changing to "" directory." followed by
+# Unity's own "CreateDirectory ... failed" / "Unable to open log file,
+# exiting" cascade into "Unclassified error occured while trying to
+# activate license." on unity-builder#844's Windows CI (game-ci/cli#844
+# investigation). dist/platforms/windows/steps/activate.ps1 (the native,
+# non-container path) already uses $Env: correctly.
+Write-Host "Changing to `"$Env:ACTIVATE_LICENSE_PATH`" directory."
+Push-Location $Env:ACTIVATE_LICENSE_PATH
 
 if ($env:UNITY_LICENSING_SERVER) {
   #
@@ -20,11 +30,20 @@ if ($env:UNITY_LICENSING_SERVER) {
   $global:UNITY_EXIT_CODE = $LASTEXITCODE
 }
 else {
+  # -logfile needs a real path - without one, Unity has nowhere to write
+  # and exits immediately with "Unable to open log file, exiting." (compounded
+  # by $ACTIVATE_LICENSE_PATH being wrong before the fix above). Also: this
+  # branch never captured $LASTEXITCODE at all, so $global:UNITY_EXIT_CODE
+  # silently kept whatever value it already had (uninitialized/stale) rather
+  # than reflecting whether activation actually succeeded.
+  $LogPath = Join-Path $Env:ACTIVATE_LICENSE_PATH 'activate.log'
   & "$Env:UNITY_PATH\Editor\Unity.exe" -batchmode -quit -nographics `
                                                                             -username $Env:UNITY_EMAIL `
                                                                             -password $Env:UNITY_PASSWORD `
                                                                             -serial $Env:UNITY_SERIAL `
-                                                                            -logfile | Out-Host
+                                                                            -logfile $LogPath | Out-Host
+  $global:UNITY_EXIT_CODE = $LASTEXITCODE
+  if (Test-Path $LogPath) { Get-Content $LogPath | Out-Host }
 }
 
 #

--- a/dist/platforms/windows/return_license.ps1
+++ b/dist/platforms/windows/return_license.ps1
@@ -1,6 +1,11 @@
 # Return the active Unity license
-Write-Host "Changing to `"$ACTIVATE_LICENSE_PATH`" directory."
-Push-Location $ACTIVATE_LICENSE_PATH
+#
+# $ACTIVATE_LICENSE_PATH (no $Env: prefix, here and at the -projectPath use
+# below) is an unset local PowerShell variable, not the environment
+# variable set by the caller - see activate.ps1 for the full explanation
+# and the confirmed live failure this caused (game-ci/cli#844).
+Write-Host "Changing to `"$Env:ACTIVATE_LICENSE_PATH`" directory."
+Push-Location $Env:ACTIVATE_LICENSE_PATH
 
 if ($env:UNITY_LICENSING_SERVER) {
   #
@@ -17,12 +22,15 @@ else {
   # project, so Unity doesn't reopen the real project (and reimport its
   # library against whatever the editor's default target is) just to
   # return the license (game-ci/cli#33).
+  # -logfile needs a real path, same reasoning as activate.ps1.
+  $LogPath = Join-Path $Env:ACTIVATE_LICENSE_PATH 'return_license.log'
   & "$Env:UNITY_PATH\Editor\Unity.exe" -batchmode -quit -nographics `
                                                                             -username $Env:UNITY_EMAIL `
                                                                             -password $Env:UNITY_PASSWORD `
                                                                             -returnlicense `
-                                                                            -projectPath $ACTIVATE_LICENSE_PATH `
-                                                                            -logfile | Out-Host
+                                                                            -projectPath $Env:ACTIVATE_LICENSE_PATH `
+                                                                            -logfile $LogPath | Out-Host
+  if (Test-Path $LogPath) { Get-Content $LogPath | Out-Host }
 }
 
 Pop-Location


### PR DESCRIPTION
## What broke

Root-caused the remaining unity-builder#844 Windows failures (\`2022.3.62f3\`, all 4 target platforms - same shared activation step runs once before any of them build). Confirmed live:

\`\`\`
Changing to "" directory.
...
CreateDirectory 'C:/Users/ContainerAdministrator/AppData/Local/Unity/Caches' failed: The system cannot find the path specified.
Unable to open log file, exiting.
Unclassified error occured while trying to activate license.
\`\`\`

## Root cause

\`$ACTIVATE_LICENSE_PATH\` (no \`$Env:\` prefix) is an unset local PowerShell variable in both \`activate.ps1\` and \`return_license.ps1\`, not the environment variable the caller sets - always empty, so \`Push-Location\` silently did nothing and every path built from it downstream resolved wrong. \`dist/platforms/windows/steps/activate.ps1\` (the native, non-container path) already uses \`$Env:\` correctly throughout - the same recurring script-divergence pattern this session (#159, #162, #176).

## Two more real bugs found alongside it

- \`activate.ps1\`'s serial/professional-license \`else\` branch passed \`-logfile\` with **no path argument** (Unity has nowhere to write, exits immediately with \`Unable to open log file, exiting.\`) and never captured \`$LASTEXITCODE\` into \`$global:UNITY_EXIT_CODE\` at all, so success/failure was determined from a stale/uninitialized value regardless of what actually happened.
- \`return_license.ps1\` had the same missing \`-logfile\` path, plus a second un-prefixed \`$ACTIVATE_LICENSE_PATH\` use at \`-projectPath\`.

## Fix

All fixed to match \`steps/activate.ps1\`'s already-correct pattern (\`Join-Path\` a real log path, capture \`$LASTEXITCODE\`, use \`$Env:\` for the env var everywhere).

## Verification

Both files verified via \`[System.Management.Automation.PSParser]::Tokenize\` - syntactically valid PowerShell. No real Windows hardware/Unity install available locally to execute end-to-end, so CI + a live re-trigger on unity-builder#844 is the real gate.

## Test plan

- [ ] CI green
- [ ] Once merged + released, re-trigger unity-builder#844's Windows \`2022.3.62f3\` jobs and confirm they pass