### PR TITLE
chore: bump version to 0.1.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "GameCI CLI - automation for game engines",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump for #180's Windows activation path fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application package version to 0.1.29.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->