### PR TITLE
fix: windows entrypoint.ps1 never sets ACTIVATE_LICENSE_PATH at all

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,16 @@ jobs:
       # and fail on a runner mismatch.
       - name: Unit/Integration tests
         run: bun run test
+      # dist/platforms and dist/default-build-script are hand-maintained
+      # bash/PowerShell/C# scripts the compiled binary mounts and copies at
+      # runtime (see release-cli.yml's `cp -r dist pkg/dist`) - not build
+      # outputs, and nothing else in this suite ever parses them. A single
+      # session found five real bugs hiding in exactly this class of file
+      # (#159, #176, #180) - none would have compiled, typechecked, or
+      # unit-tested their way into visibility. ubuntu-latest ships pwsh by
+      # default, so this needs no extra setup.
+      - name: Validate platform scripts (dist/platforms)
+        run: bash scripts/validate-platform-scripts.sh
 
   # Mirrors plugins/unity/.github/workflows/integrity-check.yml, which is
   # inert (GitHub only reads root .github/workflows/) - ported here rather

--- a/dist/platforms/windows/entrypoint.ps1
+++ b/dist/platforms/windows/entrypoint.ps1
@@ -26,7 +26,21 @@ if ($Env:ENABLE_GPU -eq "true") {
 }
 
 # Activate Unity
+#
+# $Env:ACTIVATE_LICENSE_PATH was never set here at all - activate.ps1 and
+# return_license.ps1 (both -projectPath and their own "Changing to ..."
+# directory) always saw it empty, which is what "CreateDirectory ...
+# AppData/Local/Unity/Caches failed" and "Unclassified error occured while
+# trying to activate license." actually meant the whole time (confirmed
+# live on unity-builder#844's Windows CI - #180 fixed activate.ps1's own
+# missing $Env: prefix, but that alone can't help when the variable itself
+# is never populated). Mirrors mac/entrypoint.sh's own
+# ACTIVATE_LICENSE_PATH="$ACTION_FOLDER/BlankProject" + mkdir -p pattern -
+# a scratch directory Unity can use as -projectPath purely to activate/
+# return the license against, distinct from the real project.
 if ($Env:SKIP_ACTIVATION -ne "true") {
+  $Env:ACTIVATE_LICENSE_PATH = "c:\ActivateLicense"
+  New-Item -ItemType Directory -Force -Path $Env:ACTIVATE_LICENSE_PATH | Out-Null
   & "c:\steps\activate.ps1"
 } else {
   Write-Host "Skipping activation"
@@ -34,7 +48,8 @@ if ($Env:SKIP_ACTIVATION -ne "true") {
 
 # ACTIVATE_ONLY=true (used by `game-ci activate`) activates and stops here -
 # no build, and the license is deliberately left active for a later step to
-# use, so no return_license.ps1 either.
+# use, so no return_license.ps1 either (and no cleanup of
+# ACTIVATE_LICENSE_PATH, matching mac/entrypoint.sh's same carve-out).
 if ($Env:ACTIVATE_ONLY -eq "true") {
   exit $LASTEXITCODE
 }
@@ -69,6 +84,7 @@ if ($Env:RUN_TESTS -eq "true") {
 # Free the seat for the activated license
 if ($Env:SKIP_ACTIVATION -ne "true") {
   & "c:\steps\return_license.ps1"
+  Remove-Item -Recurse -Force $Env:ACTIVATE_LICENSE_PATH -ErrorAction SilentlyContinue
 }
 
 #

--- a/scripts/validate-platform-scripts.sh
+++ b/scripts/validate-platform-scripts.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Validates the shell/PowerShell scripts under dist/platforms and
+# dist/default-build-script - the ones the compiled CLI binary and default
+# build script actually mount/copy at runtime (see release-cli.yml's
+# `cp -r dist pkg/dist`). These are hand-maintained, not build outputs, so
+# nothing else in CI ever parsed them at all until now.
+#
+# Added after a single session found five real bugs hiding in exactly this
+# class of file - none would have compiled, typechecked, or unit-tested
+# their way into visibility, because none of them are TypeScript:
+#   - #159: unquoted $VAR expansion in a bash script word-split a path
+#     containing spaces into multiple argv entries.
+#   - #176: a Windows Copy-Item missing -Force broke retries.
+#   - #180: $ACTIVATE_LICENSE_PATH (missing the required $Env: prefix)
+#     silently resolved to an empty string throughout two PowerShell
+#     scripts, and a separate -logfile call was missing its path argument
+#     entirely.
+# This script can't catch every one of those (word-splitting and a missing
+# -Force are semantic, not syntactic), but it catches the ones that are
+# mechanically detectable, and is the natural place to grow more checks as
+# new instances of this class of bug turn up.
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+fail=0
+
+echo "== Syntax-checking bash scripts under dist/platforms =="
+while IFS= read -r -d '' file; do
+  if ! bash -n "$file"; then
+    echo "FAIL: $file has a bash syntax error (see above)"
+    fail=1
+  fi
+done < <(find dist/platforms -type f -name '*.sh' -print0)
+
+echo
+echo "== Syntax-checking PowerShell scripts under dist/platforms =="
+if command -v pwsh >/dev/null 2>&1; then
+  # One pwsh process for every file, not one-per-file - pwsh's own startup
+  # cost dominates otherwise (each launch is real wall-clock time this
+  # script pays per .ps1 file).
+  if ! pwsh -NoProfile -Command '
+    $ErrorActionPreference = "Stop"
+    $failed = $false
+    Get-ChildItem -Path "dist/platforms" -Filter "*.ps1" -Recurse | ForEach-Object {
+      $err = $null
+      [System.Management.Automation.PSParser]::Tokenize((Get-Content $_.FullName -Raw), [ref]$err) | Out-Null
+      if ($err) {
+        Write-Host "FAIL: $($_.FullName) has a PowerShell syntax error:"
+        $err | ForEach-Object { Write-Host "  $($_.Message)" }
+        $script:failed = $true
+      }
+    }
+    if ($failed) { exit 1 }
+  '; then
+    fail=1
+  fi
+else
+  echo "pwsh not available - skipping PowerShell syntax checks"
+fi
+
+echo
+echo "== Checking for \$VAR where \$Env:VAR was meant (PowerShell) =="
+# A bare $ACTIVATE_LICENSE_PATH-style reference to a name that's used as
+# $Env:NAME *anywhere* across dist/platforms is almost certainly a missing
+# $Env: prefix (see #180) rather than a deliberately-scoped local variable -
+# real local variables in these scripts don't collide with env var names.
+# Built from every $Env:NAME across the whole tree, not just the same file:
+# the original #180 bug (dist/platforms/windows/activate.ps1) never once
+# used $Env:ACTIVATE_LICENSE_PATH correctly *in that file*, so a same-file-only
+# comparison would have missed the exact bug this check exists to catch.
+all_ps1_code=$(find dist/platforms -type f -name '*.ps1' -exec grep -vE '^\s*#' {} \;)
+known_env_names=$(grep -oE '\$Env:[A-Za-z_][A-Za-z0-9_]*' <<< "$all_ps1_code" | sed -E 's/\$Env://' | sort -u || true)
+
+while IFS= read -r -d '' file; do
+  # Strip comment-only lines (optional leading whitespace then #) first, so
+  # prose that mentions $NAME (like this very script's own explanatory
+  # comments) doesn't trip the check - only real code counts.
+  code_only=$(grep -vE '^\s*#' "$file")
+  while IFS= read -r name; do
+    [ -z "$name" ] && continue
+    # Match $NAME not preceded by "Env:" and not followed by a word char
+    # (so $NAME doesn't false-positive on $NAMEEXTRA).
+    matches=$(grep -nE "(^|[^:a-zA-Z0-9_])\\\$${name}([^a-zA-Z0-9_]|\$)" <<< "$code_only" | grep -v "\\\$Env:${name}" || true)
+    if [ -n "$matches" ]; then
+      echo "FAIL: $file references \$${name} without the \$Env: prefix - \$Env:${name} is used elsewhere in dist/platforms, so this is almost certainly a missing prefix"
+      echo "$matches"
+      fail=1
+    fi
+  done <<< "$known_env_names"
+done < <(find dist/platforms -type f -name '*.ps1' -print0)
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "One or more platform script checks failed - see FAIL lines above."
+  exit 1
+fi
+echo "All platform script checks passed."


### PR DESCRIPTION
## What broke

#180 fixed \`activate.ps1\`/\`return_license.ps1\`'s own missing \`\$Env:\` prefix, but that alone can't help when the variable is never populated in the first place - confirmed live on unity-builder#844's Windows CI, still 100% failing on v0.1.29 with the identical \`Changing to ""\` directory.\` -> \`CreateDirectory ... AppData/Local/Unity/Caches failed\` -> \`Unclassified error occured while trying to activate license.\` cascade.

## Root cause

\`entrypoint.ps1\` calls \`activate.ps1\`/\`return_license.ps1\` but **never sets \`\$Env:ACTIVATE_LICENSE_PATH\` anywhere** - unlike \`mac/entrypoint.sh\`, which sets \`ACTIVATE_LICENSE_PATH="\$ACTION_FOLDER/BlankProject"\` and \`mkdir -p\`'s it right before sourcing \`activate.sh\`, giving Unity a real scratch directory to activate/return the license against (distinct from the actual project).

## Fix

Mirrors that pattern: sets \`\$Env:ACTIVATE_LICENSE_PATH\` to a fixed scratch path (\`c:\ActivateLicense\`, matching the container's existing \`c:\steps\` / \`c:\UnityBuilderAction\` absolute-path convention - there's no \`\$Env:ACTION_FOLDER\` equivalent for the Windows Docker path to build a relative one from) and creates it before activation, cleans it up after \`return_license.ps1\` (skipped for \`ACTIVATE_ONLY=true\`, matching mac's own carve-out for \`game-ci activate\` deliberately leaving the license active for a later step).

## Verification

Syntax-checked with \`PSParser.Tokenize\`, and \`scripts/validate-platform-scripts.sh\` (#182) passes clean against the full tree with this change in place.

## Test plan

- [ ] CI green
- [ ] Once merged + released, re-trigger unity-builder#844's Windows jobs for the 2022.3.62f3 matrix cell and confirm activation succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added automated validation for platform scripts as part of the test workflow.
  - Checks Bash syntax and, when available, PowerShell syntax.
  - Flags improperly referenced PowerShell environment variables and reports all validation failures together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->