### PR TITLE
chore: bump version to 0.1.30

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "GameCI CLI - automation for game engines",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump for #183's Windows ACTIVATE_LICENSE_PATH fix.