### PR TITLE
fix(windows): give -logfile a real path in build.ps1

### DIFF
--- a/dist/platforms/windows/build.ps1
+++ b/dist/platforms/windows/build.ps1
@@ -150,6 +150,13 @@ if ($Env:BUILD_PROFILE) {
 # images/windows/editor/Dockerfile). Unity Hub's default install location
 # ("C:\Program Files\Unity\Hub\Editor\<version>") is never used - these
 # images install to C:/UnityEditor instead (game-ci/cli#77).
+#
+# -logfile needs a real path - without one, Unity has nowhere to write and
+# exits immediately with "Unable to open log file, exiting." (return code
+# 127), same root cause as activate.ps1/return_license.ps1's own -logfile
+# bug (game-ci/cli#844 investigation). Tailed to output afterwards so the
+# build log still reaches CI output the way `| Out-Host` alone used to.
+$LogPath = Join-Path $Env:UNITY_PROJECT_PATH 'build.log'
 & "$Env:UNITY_PATH\Editor\Unity.exe" @QuitArgs -batchmode -nographics `
                                                                           -projectPath $Env:UNITY_PROJECT_PATH `
                                                                           -executeMethod $Env:BUILD_METHOD `
@@ -168,10 +175,11 @@ if ($Env:BUILD_PROFILE) {
                                                                           -androidExportType $Env:ANDROID_EXPORT_TYPE `
                                                                           -androidSymbolType $Env:ANDROID_SYMBOL_TYPE `
                                                                           $customParametersArray `
-                                                                          -logfile | Out-Host
+                                                                          -logfile $LogPath | Out-Host
 
 # Catch exit code
 $Env:BUILD_EXIT_CODE=$LastExitCode
+if (Test-Path $LogPath) { Get-Content $LogPath | Out-Host }
 
 # Display results
 if ($Env:BUILD_EXIT_CODE -eq 0)

--- a/scripts/validate-platform-scripts.sh
+++ b/scripts/validate-platform-scripts.sh
@@ -93,6 +93,24 @@ while IFS= read -r -d '' file; do
 done < <(find dist/platforms -type f -name '*.ps1' -print0)
 
 echo
+echo "== Checking for -logfile/-logFile with no path argument (PowerShell) =="
+# -logfile with nothing after it (immediately followed by a pipe, or by
+# nothing at all) gives Unity no path to write to, and it exits immediately
+# with "Unable to open log file, exiting." (exit code 127) - the same bug
+# hit twice: once in activate.ps1/return_license.ps1 (#180), and again in
+# build.ps1 (unity-builder#844 investigation) once activation itself was
+# fixed and the pipeline finally reached the build step for the first time.
+while IFS= read -r -d '' file; do
+  code_only=$(grep -vE '^\s*#' "$file")
+  matches=$(grep -inE -- '-logfile[[:space:]]*(\||`?[[:space:]]*$)' <<< "$code_only" || true)
+  if [ -n "$matches" ]; then
+    echo "FAIL: $file uses -logfile/-logFile with no path argument - Unity needs a real path or it exits immediately"
+    echo "$matches"
+    fail=1
+  fi
+done < <(find dist/platforms -type f -name '*.ps1' -print0)
+
+echo
 if [ "$fail" -ne 0 ]; then
   echo "One or more platform script checks failed - see FAIL lines above."
   exit 1


### PR DESCRIPTION
## Summary
- \`dist/platforms/windows/build.ps1\`'s Unity invocation ended with a bare \`-logfile | Out-Host\` — no path argument, so Unity has nowhere to write and exits immediately with \`Unable to open log file, exiting.\` (exit code 127).
- This is the exact same bug already fixed in \`activate.ps1\`/\`return_license.ps1\` (#180), just one step further down the pipeline — it only became visible once Windows activation itself was fixed (#183) and CI on unity-builder#844 finally reached the build step for the first time.
- Fixed by giving it a real log path (\`build.log\` under the project path), tailed to output after the run so the build log still reaches CI output.
- Extended \`scripts/validate-platform-scripts.sh\` (#182) with a new check for bare \`-logfile\`/\`-logFile\` with no path argument, since this exact mistake has now shipped twice.

## Test plan
- [x] Ran \`bash scripts/validate-platform-scripts.sh\` locally against the fixed tree — passes.
- [x] Synthetic regression: reintroduced the bare \`-logfile | Out-Host\` locally, confirmed the new validator check fails with a clear message, then restored the fix.
- [ ] CI green
- [ ] Re-verify against unity-builder#844's Windows \`2022.3.62f3\` matrix cell after release