### PR TITLE
chore: bump version to 0.1.33 for #189's macOS license-timeout retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "GameCI CLI - automation for game engines",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Follow-up release for #189.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the application version to 0.1.33.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->