### PR TITLE
fix(mac): retry activation on transient licensing timeouts too

### DIFF
--- a/dist/platforms/mac/steps/activate.sh
+++ b/dist/platforms/mac/steps/activate.sh
@@ -10,19 +10,44 @@ if [[ -n "$UNITY_SERIAL" && -n "$UNITY_EMAIL" && -n "$UNITY_PASSWORD" ]]; then
   #
   echo "Requesting activation"
 
-  # Activate license
-  /Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS/Unity \
-    -logFile - \
-    -batchmode \
-    -nographics \
-    -quit \
-    -serial "$UNITY_SERIAL" \
-    -username "$UNITY_EMAIL" \
-    -password "$UNITY_PASSWORD" \
-    -projectPath "$ACTIVATE_LICENSE_PATH"
+  # Unity's licensing client occasionally fails to reach/handshake with
+  # Unity's cloud license service in time here too, not just during the
+  # build's own Unity invocation (see build.sh's matching comment/retry) -
+  # same signatures ("Code 404/408/1500 ...", "Access token is unavailable"),
+  # same fix: retry a few times, but only on those known-transient
+  # signatures, so a genuine activation failure (bad serial, expired
+  # license, etc.) still fails immediately rather than burning retries.
+  ACTIVATE_MAX_ATTEMPTS=4
+  ACTIVATE_RETRY_DELAY_SECONDS=20
+  ACTIVATE_TRANSIENT_LICENSE_ERROR_PATTERN='TimeoutPolicy did not complete|Access token is unavailable|entitlement groups and 0 free entitlements|License activation has failed'
 
-  # Store the exit code from the verify command
-  UNITY_EXIT_CODE=$?
+  ACTIVATE_LOG="$(mktemp)"
+  for ACTIVATE_ATTEMPT in $(seq 1 "$ACTIVATE_MAX_ATTEMPTS"); do
+    # Activate license
+    /Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS/Unity \
+      -logFile - \
+      -batchmode \
+      -nographics \
+      -quit \
+      -serial "$UNITY_SERIAL" \
+      -username "$UNITY_EMAIL" \
+      -password "$UNITY_PASSWORD" \
+      -projectPath "$ACTIVATE_LICENSE_PATH" 2>&1 | tee "$ACTIVATE_LOG"
+    UNITY_EXIT_CODE=${PIPESTATUS[0]}
+
+    if [ "$UNITY_EXIT_CODE" -eq 0 ]; then
+      break
+    fi
+
+    if [ "$ACTIVATE_ATTEMPT" -lt "$ACTIVATE_MAX_ATTEMPTS" ] && grep -qE "$ACTIVATE_TRANSIENT_LICENSE_ERROR_PATTERN" "$ACTIVATE_LOG"; then
+      echo "Unity activation failed with a known-transient licensing error (attempt $ACTIVATE_ATTEMPT/$ACTIVATE_MAX_ATTEMPTS) - retrying in ${ACTIVATE_RETRY_DELAY_SECONDS}s..."
+      sleep "$ACTIVATE_RETRY_DELAY_SECONDS"
+      continue
+    fi
+
+    break
+  done
+  rm -f "$ACTIVATE_LOG"
 elif [[ -n "$UNITY_LICENSING_SERVER" ]]; then
   #
   # Custom Unity License Server

--- a/dist/platforms/mac/steps/build.sh
+++ b/dist/platforms/mac/steps/build.sh
@@ -195,8 +195,8 @@ run_unity_build() {
 # automatically rather than failing the whole job on what's effectively a
 # flaky network call. A build that fails for a real reason (compile error,
 # missing scene, etc.) never matches these patterns and is not retried.
-UNITY_BUILD_MAX_ATTEMPTS=3
-UNITY_BUILD_RETRY_DELAY_SECONDS=15
+UNITY_BUILD_MAX_ATTEMPTS=4
+UNITY_BUILD_RETRY_DELAY_SECONDS=20
 UNITY_BUILD_TRANSIENT_LICENSE_ERROR_PATTERN='TimeoutPolicy did not complete|Access token is unavailable|entitlement groups and 0 free entitlements|License activation has failed'
 
 BUILD_LOG="$(mktemp)"


### PR DESCRIPTION
## Summary
#189 added retry-on-known-transient-signature to build.sh's Unity invocation, but not activate.sh's - and re-verifying against unity-builder#844 with v0.1.33 showed exactly why that's a gap: a build failure showing `No ULF license found ... No license activation found for this computer` alongside the familiar `0 entitlement groups` signature, meaning activation itself silently degraded under the same transient issue on that run. No amount of retrying the *build* step fixes an activation that never actually took.

Same fix, same reasoning, now applied to activate.sh's serial-license Unity invocation. Also bumps both scripts from 3 attempts/15s to 4 attempts/20s - the v0.1.33 CI run showed a build exhaust all 3 attempts within ~40s, suggesting the outage window can outlast a shorter budget.

## Test plan
- [x] `bash scripts/validate-platform-scripts.sh` passes
- [x] Isolated logic test: activate.sh retry succeeds on 2nd attempt after one transient failure
- [ ] CI green
- [ ] Re-verify against unity-builder#844's macOS matrix after release