### PR TITLE
chore: bump version to 0.1.34 for #191's macOS activation retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "GameCI CLI - automation for game engines",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Follow-up release for #191.