### PR TITLE
fix(mac): widen the transient-license-error pattern coverage

### DIFF
--- a/dist/platforms/mac/steps/activate.sh
+++ b/dist/platforms/mac/steps/activate.sh
@@ -19,7 +19,7 @@ if [[ -n "$UNITY_SERIAL" && -n "$UNITY_EMAIL" && -n "$UNITY_PASSWORD" ]]; then
   # license, etc.) still fails immediately rather than burning retries.
   ACTIVATE_MAX_ATTEMPTS=4
   ACTIVATE_RETRY_DELAY_SECONDS=20
-  ACTIVATE_TRANSIENT_LICENSE_ERROR_PATTERN='TimeoutPolicy did not complete|Access token is unavailable|entitlement groups and 0 free entitlements|License activation has failed'
+  ACTIVATE_TRANSIENT_LICENSE_ERROR_PATTERN='TimeoutPolicy did not complete|Access token is unavailable|entitlement groups and 0 free entitlements|License activation has failed|No valid Unity Editor license found|License is not active'
 
   ACTIVATE_LOG="$(mktemp)"
   for ACTIVATE_ATTEMPT in $(seq 1 "$ACTIVATE_MAX_ATTEMPTS"); do

--- a/dist/platforms/mac/steps/build.sh
+++ b/dist/platforms/mac/steps/build.sh
@@ -197,7 +197,7 @@ run_unity_build() {
 # missing scene, etc.) never matches these patterns and is not retried.
 UNITY_BUILD_MAX_ATTEMPTS=4
 UNITY_BUILD_RETRY_DELAY_SECONDS=20
-UNITY_BUILD_TRANSIENT_LICENSE_ERROR_PATTERN='TimeoutPolicy did not complete|Access token is unavailable|entitlement groups and 0 free entitlements|License activation has failed'
+UNITY_BUILD_TRANSIENT_LICENSE_ERROR_PATTERN='TimeoutPolicy did not complete|Access token is unavailable|entitlement groups and 0 free entitlements|License activation has failed|No valid Unity Editor license found|License is not active'
 
 BUILD_LOG="$(mktemp)"
 for ATTEMPT in $(seq 1 "$UNITY_BUILD_MAX_ATTEMPTS"); do


### PR DESCRIPTION
## Summary
Real CI on unity-builder#844 (v0.1.34) found a licensing-flake variant neither build.sh's nor activate.sh's retry pattern covered:

\`\`\`
[Licensing::Module] Error: License is not active (com.unity.editor.headless). HasEntitlements will fail.
No valid Unity Editor license found. Please activate your license.
\`\`\`

Since the retry only engages when the failure output matches the known signature list, this variant fell straight through to a same-attempt failure with no retry at all - the exact failure mode #189/#191 were meant to fix.

\`No valid Unity Editor license found\` has appeared in every single licensing-flake variant observed this session (Code 404/408/1500, "Access token is unavailable", and now this one) - it's the most reliable anchor available, so both patterns now include it and "License is not active" alongside the existing signatures.

## Test plan
- [x] Verified the new pattern matches the exact failure text from the real CI log
- [ ] CI green
- [ ] Re-verify against unity-builder#844's macOS matrix after release