### PR TITLE
chore: bump version to 0.1.35 for #194's widened license-error pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "GameCI CLI - automation for game engines",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Follow-up release for #194.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.1.35.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->