### PR TITLE
fix(mac): UnityLicensingClient path for Unity 6000.3+, port return-floating

### DIFF
--- a/dist/platforms/mac/steps/activate.sh
+++ b/dist/platforms/mac/steps/activate.sh
@@ -58,7 +58,16 @@ elif [[ -n "$UNITY_LICENSING_SERVER" ]]; then
   # auditing for divergence from unity-builder's real source).
   echo "Requesting floating license"
 
-  /Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/Frameworks/UnityLicensingClient.app/Contents/MacOS/Unity.Licensing.Client \
+  # Unity 6000.3+ moved UnityLicensingClient from Contents/Frameworks to
+  # Contents/Helpers (https://docs.unity.com/en-us/licensing-server/client-config)
+  # - a hardcoded Frameworks path 127'd ("No such file or directory") on
+  # every 6000.3+ mac build using a license server (game-ci/unity-builder#842).
+  UNITY_LICENSING_CLIENT_SUBDIR="Frameworks"
+  if [[ "$UNITY_VERSION" =~ ^6000\.([3-9]|[1-9][0-9]) ]]; then
+    UNITY_LICENSING_CLIENT_SUBDIR="Helpers"
+  fi
+
+  "/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/$UNITY_LICENSING_CLIENT_SUBDIR/UnityLicensingClient.app/Contents/MacOS/Unity.Licensing.Client" \
     --acquire-floating > license.txt
   UNITY_EXIT_CODE=$?
 

--- a/dist/platforms/mac/steps/return_license.sh
+++ b/dist/platforms/mac/steps/return_license.sh
@@ -4,15 +4,44 @@
 echo "Changing to \"$ACTIVATE_LICENSE_PATH\" directory."
 pushd "$ACTIVATE_LICENSE_PATH"
 
-/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS/Unity \
-  -logFile - \
-  -batchmode \
-  -nographics \
-  -quit \
-  -username "$UNITY_EMAIL" \
-  -password "$UNITY_PASSWORD" \
-  -returnlicense \
-  -projectPath "$ACTIVATE_LICENSE_PATH"
+if [[ -n "$UNITY_LICENSING_SERVER" ]]; then
+  #
+  # Return any floating license used.
+  #
+  # This branch was missing entirely - activate.sh's own UNITY_LICENSING_SERVER
+  # branch acquires a floating license via UnityLicensingClient, but with no
+  # matching return step here, that license seat was never released back to
+  # the server after a build, for every single mac floating-license build
+  # (found while porting game-ci/unity-builder#842's Unity 6000.3+ path fix,
+  # which patches this exact branch on unity-builder's side).
+  echo "Returning floating license: \"$FLOATING_LICENSE\""
+
+  # Unity 6000.3+ moved UnityLicensingClient from Contents/Frameworks to
+  # Contents/Helpers (https://docs.unity.com/en-us/licensing-server/client-config) -
+  # same reasoning as activate.sh's matching acquire-floating call.
+  UNITY_LICENSING_CLIENT_SUBDIR="Frameworks"
+  if [[ "$UNITY_VERSION" =~ ^6000\.([3-9]|[1-9][0-9]) ]]; then
+    UNITY_LICENSING_CLIENT_SUBDIR="Helpers"
+  fi
+
+  "/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/$UNITY_LICENSING_CLIENT_SUBDIR/UnityLicensingClient.app/Contents/MacOS/Unity.Licensing.Client" \
+    --return-floating "$FLOATING_LICENSE"
+elif [[ -n "$UNITY_SERIAL" ]]; then
+  #
+  # SERIAL LICENSE MODE
+  #
+  # This will return the license that is currently in use.
+  #
+  /Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS/Unity \
+    -logFile - \
+    -batchmode \
+    -nographics \
+    -quit \
+    -username "$UNITY_EMAIL" \
+    -password "$UNITY_PASSWORD" \
+    -returnlicense \
+    -projectPath "$ACTIVATE_LICENSE_PATH"
+fi
 
 # Return to previous working directory
 popd


### PR DESCRIPTION
## Summary
Ports [game-ci/unity-builder#842](https://github.com/game-ci/unity-builder/pull/842) (community contribution by @alexis-gervacio): Unity 6000.3+ moved UnityLicensingClient from \`Contents/Frameworks\` to \`Contents/Helpers\` ([Unity docs](https://docs.unity.com/en-us/licensing-server/client-config)). A hardcoded Frameworks path failed with exit 127 ("No such file or directory") on every 6000.3+ mac build using a license server. Both scripts now detect the version and pick the right subdirectory.

Also fixes a gap found while porting this: \`return_license.sh\` had no \`UNITY_LICENSING_SERVER\` branch at all - \`activate.sh\`'s own branch acquires a floating license via UnityLicensingClient, but with no matching return step, that license seat was never released back to the server after a single mac floating-license build. unity-builder's own \`return_license.sh\` has this branch; this repo's copy was missing it entirely.

Since unity-builder is now a thin wrapper around this CLI ([game-ci/unity-builder#844](https://github.com/game-ci/unity-builder/pull/844)), engine-specific fixes like this belong here instead - unity-builder#842 is being closed in favor of this PR.

## Test plan
- [x] \`bash scripts/validate-platform-scripts.sh\` passes
- [x] Verified the version regex against 6000.2.5f1 (Frameworks), 6000.3.5f2/6000.10.1f1 (Helpers), and older non-6000 versions (Frameworks)
- [ ] CI green