### PR TITLE
fix(ubuntu): set HOME/USER explicitly for runAsHostUser's su call

### DIFF
--- a/dist/platforms/ubuntu/entrypoint.sh
+++ b/dist/platforms/ubuntu/entrypoint.sh
@@ -87,8 +87,15 @@ if [[ "$RUN_AS_HOST_USER" == "true" ]]; then
   # Don't stop on error when running our scripts as error handling is baked in
   set +e
 
-  # Switch to the host user so we can create files with the correct ownership
-  su $USERNAME -c "$SHELL -c 'source /steps/runsteps.sh'"
+  # Switch to the host user so we can create files with the correct ownership.
+  # Pass HOME/USER explicitly so the Unity Licensing Client (which writes to
+  # ~/.config/unity3d) resolves a real, writable home directory rather than
+  # falling back to root's environment - without this, a floating-license
+  # server build under RUN_AS_HOST_USER could silently fall through to a
+  # license lacking the requested platform support instead of raising an
+  # error (game-ci/unity-builder#739, fixed there by #838). -p preserves the
+  # rest of the env from root.
+  su -p $USERNAME -c "HOME=/home/$USERNAME USER=$USERNAME LOGNAME=$USERNAME $SHELL -c 'source /steps/runsteps.sh'"
 else
   echo "Running as root"
 


### PR DESCRIPTION
## Summary
Ports [game-ci/unity-builder#838](https://github.com/game-ci/unity-builder/pull/838) (@frostebite): with \`runAsHostUser=true\`, \`su \$USERNAME -c "..."\` switched the effective UID but not \`HOME\`/\`USER\` - the host user inherited root's environment (\`HOME=/root\`, \`USER\` unset), so the Unity Licensing Client (which writes to \`~/.config/unity3d\`) couldn't resolve a writable home directory. Traced in [game-ci/unity-builder#739](https://github.com/game-ci/unity-builder/issues/739) from a symptom of \`-buildTarget Android\` being silently ignored: when the Licensing Client can't resolve the right entitlement, Unity falls through to a license lacking the requested platform support and produces a Linux Standalone artifact without raising an error.

Now passes \`HOME\`/\`USER\`/\`LOGNAME\` explicitly on the inner shell command while preserving the rest of root's env via \`su -p\`. Opt-in and backwards compatible: entirely inside the \`runAsHostUser=="true"\` branch, so anyone not using it sees zero change.

Since unity-builder is now a thin wrapper around this CLI ([game-ci/unity-builder#844](https://github.com/game-ci/unity-builder/pull/844)) and no longer ships its own \`dist/platforms\` at all, this fix belongs here instead - unity-builder#838 is being closed in favor of this PR.

## Test plan
- [x] \`bash scripts/validate-platform-scripts.sh\` passes
- [ ] CI green