### PR TITLE
feat: make the mac license-retry behavior a real, documented option

### DIFF
--- a/dist/platforms/mac/steps/activate.sh
+++ b/dist/platforms/mac/steps/activate.sh
@@ -17,7 +17,11 @@ if [[ -n "$UNITY_SERIAL" && -n "$UNITY_EMAIL" && -n "$UNITY_PASSWORD" ]]; then
   # same fix: retry a few times, but only on those known-transient
   # signatures, so a genuine activation failure (bad serial, expired
   # license, etc.) still fails immediately rather than burning retries.
-  ACTIVATE_MAX_ATTEMPTS=4
+  # Same UNITY_LICENSE_RETRY_MAX_ATTEMPTS as build.sh's matching retry - set
+  # from the real --licenseRetryMaxAttempts CLI option (see
+  # UnityEnvironment.getVariables), one knob covers both since they're the
+  # same underlying flakiness. --licenseRetryMaxAttempts=1 disables retrying.
+  ACTIVATE_MAX_ATTEMPTS="${UNITY_LICENSE_RETRY_MAX_ATTEMPTS:-4}"
   ACTIVATE_RETRY_DELAY_SECONDS=20
   ACTIVATE_TRANSIENT_LICENSE_ERROR_PATTERN='TimeoutPolicy did not complete|Access token is unavailable|entitlement groups and 0 free entitlements|License activation has failed|No valid Unity Editor license found|License is not active'
 

--- a/dist/platforms/mac/steps/build.sh
+++ b/dist/platforms/mac/steps/build.sh
@@ -195,7 +195,12 @@ run_unity_build() {
 # automatically rather than failing the whole job on what's effectively a
 # flaky network call. A build that fails for a real reason (compile error,
 # missing scene, etc.) never matches these patterns and is not retried.
-UNITY_BUILD_MAX_ATTEMPTS=4
+# UNITY_LICENSE_RETRY_MAX_ATTEMPTS is set from the real --licenseRetryMaxAttempts
+# CLI option (see UnityEnvironment.getVariables) - not a bare, undocumented env
+# var - so a genuine (non-transient) license misconfiguration can be set to
+# fail on the first attempt (--licenseRetryMaxAttempts=1) instead of always
+# paying for 4 attempts with no way to turn it down.
+UNITY_BUILD_MAX_ATTEMPTS="${UNITY_LICENSE_RETRY_MAX_ATTEMPTS:-4}"
 UNITY_BUILD_RETRY_DELAY_SECONDS=20
 UNITY_BUILD_TRANSIENT_LICENSE_ERROR_PATTERN='TimeoutPolicy did not complete|Access token is unavailable|entitlement groups and 0 free entitlements|License activation has failed|No valid Unity Editor license found|License is not active'
 

--- a/src/command-options/unity-options.ts
+++ b/src/command-options/unity-options.ts
@@ -64,6 +64,15 @@ export class UnityOptions implements IOptions {
           demandOption: false,
           default: '',
         },
+        licenseRetryMaxAttempts: {
+          description: String.dedent`Number of times to retry Unity activation/build on a known-transient
+          Unity licensing-server error (timeout, "0 entitlement groups", "No valid Unity Editor license
+          found", etc. - see mac/steps/activate.sh and build.sh). Set to 1 to disable retrying - e.g. if
+          a persistent license failure is being masked by retries instead of failing fast.`,
+          type: 'number',
+          demandOption: false,
+          default: 4,
+        },
       })
       .coerce('unityLicense', async (arg: string) => {
         if (UnityLicense.isNonActivatedLicenseFile(arg)) {

--- a/src/logic/unity/environment.ts
+++ b/src/logic/unity/environment.ts
@@ -16,6 +16,13 @@ const UnityEnvironment = {
       { name: 'UNITY_PASSWORD', value: options.unityPassword },
       { name: 'UNITY_SERIAL', value: options.unitySerial },
       { name: 'UNITY_LICENSING_SERVER', value: options.unityLicensingServer },
+      // Consumed by dist/platforms/mac/steps/activate.sh + build.sh's retry
+      // loop around known-transient licensing errors. Currently mac-only
+      // (Windows/Ubuntu build through Docker, where a container failure
+      // isn't the same class of flaky host-process license handshake), but
+      // an engine-wide env var rather than a mac-specific one since nothing
+      // about the option itself is mac-specific.
+      { name: 'UNITY_LICENSE_RETRY_MAX_ATTEMPTS', value: options.licenseRetryMaxAttempts?.toString() },
       // Not a documented core CLI option (core build/test/activate stay
       // lean) - this is Orchestrator's advanced-ops surface
       // (--engineLaunchWrapper on `orchestrate`). Reading the raw env var


### PR DESCRIPTION
## Summary
The retry logic added in #189/#191/#194 was unconditional - every mac build/activate call now retries up to 4 times on a known-transient licensing error, with no way to turn it down. A genuine (non-transient) license misconfiguration would pay for all 4 attempts before failing, and there was no supported way to opt out.

Adds \`--licenseRetryMaxAttempts\` (default 4, matching current behavior) as a real CLI option, threaded through \`UnityEnvironment.getVariables\` to \`UNITY_LICENSE_RETRY_MAX_ATTEMPTS\` - the same Options -> env var pattern every other option here already uses (see \`unityLicensingServer\`, \`dockerShmSize\`, etc.), not a bare ad-hoc env var outside that flow. Set to 1 to fail on the first attempt.

The retry delay itself stays a fixed 20s - an implementation detail, not something that needed its own option.

## Test plan
- [x] \`bash scripts/validate-platform-scripts.sh\` passes
- [x] \`bun run test\` passes (220/220)
- [x] Manually confirmed \`--licenseRetryMaxAttempts\` is accepted (no "Unknown argument" error) via \`game-ci activate\`
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Unity configuration option to control the maximum number of retries for transient licensing-server failures.
  * Retries default to 4 attempts; setting the value to 1 disables retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->