### PR TITLE
chore: bump version to 0.1.36 for #196/#197/#198

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "description": "GameCI CLI - automation for game engines",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Follow-up release for #196 (mac 6000.3+ licensing path), #197 (ubuntu runAsHostUser HOME/USER), #198 (license retry configurability).