### PR TITLE
fix(windows): retry Docker-based activation/test on transient licensing errors

### DIFF
--- a/dist/platforms/windows/activate.ps1
+++ b/dist/platforms/windows/activate.ps1
@@ -37,13 +37,39 @@ else {
   # silently kept whatever value it already had (uninitialized/stale) rather
   # than reflecting whether activation actually succeeded.
   $LogPath = Join-Path $Env:ACTIVATE_LICENSE_PATH 'activate.log'
-  & "$Env:UNITY_PATH\Editor\Unity.exe" -batchmode -quit -nographics `
-                                                                            -username $Env:UNITY_EMAIL `
-                                                                            -password $Env:UNITY_PASSWORD `
-                                                                            -serial $Env:UNITY_SERIAL `
-                                                                            -logfile $LogPath | Out-Host
-  $global:UNITY_EXIT_CODE = $LASTEXITCODE
-  if (Test-Path $LogPath) { Get-Content $LogPath | Out-Host }
+
+  # Same known-transient Unity license-server flakiness as the mac retry
+  # (see mac/steps/activate.sh's matching comment) - "0 entitlement groups",
+  # "Access token is unavailable", "No valid Unity Editor license found",
+  # etc. Retried a few times rather than failing the whole job on what's
+  # effectively a flaky call to Unity's cloud license service. Configurable
+  # via the same --licenseRetryMaxAttempts CLI option / UNITY_LICENSE_RETRY_MAX_ATTEMPTS
+  # env var as the mac scripts (see UnityEnvironment.getVariables) - it's
+  # engine-wide, not mac-specific, so this needs no new plumbing.
+  $MaxAttempts = if ($Env:UNITY_LICENSE_RETRY_MAX_ATTEMPTS) { [int]$Env:UNITY_LICENSE_RETRY_MAX_ATTEMPTS } else { 4 }
+  $RetryDelaySeconds = 20
+  $TransientPattern = 'TimeoutPolicy did not complete|Access token is unavailable|entitlement groups and 0 free entitlements|License activation has failed|No valid Unity Editor license found|License is not active'
+
+  for ($Attempt = 1; $Attempt -le $MaxAttempts; $Attempt++) {
+    & "$Env:UNITY_PATH\Editor\Unity.exe" -batchmode -quit -nographics `
+                                                                              -username $Env:UNITY_EMAIL `
+                                                                              -password $Env:UNITY_PASSWORD `
+                                                                              -serial $Env:UNITY_SERIAL `
+                                                                              -logfile $LogPath | Out-Host
+    $global:UNITY_EXIT_CODE = $LASTEXITCODE
+    $LogContent = if (Test-Path $LogPath) { Get-Content $LogPath -Raw } else { '' }
+    if ($LogContent) { Get-Content $LogPath | Out-Host }
+
+    if ($global:UNITY_EXIT_CODE -eq 0) { break }
+
+    if ($Attempt -lt $MaxAttempts -and $LogContent -match $TransientPattern) {
+      Write-Host "Unity activation failed with a known-transient licensing error (attempt $Attempt/$MaxAttempts) - retrying in ${RetryDelaySeconds}s..."
+      Start-Sleep -Seconds $RetryDelaySeconds
+      continue
+    }
+
+    break
+  }
 }
 
 #

--- a/dist/platforms/windows/steps/test.ps1
+++ b/dist/platforms/windows/steps/test.ps1
@@ -214,10 +214,34 @@ foreach ($Platform in $Platforms) {
 
   $LogPath = Join-Path $FullArtifactsPath "$Platform.log"
 
-  Invoke-UnityLaunch -ExePath $UnityExePath -batchmode -logFile $LogPath -projectPath $Env:UNITY_PROJECT_PATH @RunTestsArgs @CoverageFlags @CustomParametersArray | Out-Host
-  $TestExitCode = $LASTEXITCODE
+  # Same known-transient Unity license-server flakiness as the mac retry
+  # (see mac/steps/build.sh's matching comment) - retried a few times, but
+  # only when the exit code isn't a legitimate test-result code (0 = all
+  # passed, 2 = some tests failed - both mean real results exist and are
+  # never retried) and the log matches a known-transient signature, so a
+  # real test failure or a real license misconfiguration still fails
+  # immediately. Same --licenseRetryMaxAttempts / UNITY_LICENSE_RETRY_MAX_ATTEMPTS
+  # knob as activate.ps1 and the mac scripts.
+  $MaxAttempts = if ($Env:UNITY_LICENSE_RETRY_MAX_ATTEMPTS) { [int]$Env:UNITY_LICENSE_RETRY_MAX_ATTEMPTS } else { 4 }
+  $RetryDelaySeconds = 20
+  $TransientPattern = 'TimeoutPolicy did not complete|Access token is unavailable|entitlement groups and 0 free entitlements|License activation has failed|No valid Unity Editor license found|License is not active'
 
-  if (Test-Path $LogPath) { Get-Content $LogPath | Out-Host }
+  for ($Attempt = 1; $Attempt -le $MaxAttempts; $Attempt++) {
+    Invoke-UnityLaunch -ExePath $UnityExePath -batchmode -logFile $LogPath -projectPath $Env:UNITY_PROJECT_PATH @RunTestsArgs @CoverageFlags @CustomParametersArray | Out-Host
+    $TestExitCode = $LASTEXITCODE
+    $LogContent = if (Test-Path $LogPath) { Get-Content $LogPath -Raw } else { '' }
+    if ($LogContent) { Get-Content $LogPath | Out-Host }
+
+    if ($TestExitCode -eq 0 -or $TestExitCode -eq 2) { break }
+
+    if ($Attempt -lt $MaxAttempts -and $LogContent -match $TransientPattern) {
+      Write-Host "Unity test run failed with a known-transient licensing error (attempt $Attempt/$MaxAttempts) - retrying in ${RetryDelaySeconds}s..."
+      Start-Sleep -Seconds $RetryDelaySeconds
+      continue
+    }
+
+    break
+  }
 
   if ($TestExitCode -eq 0 -and $Platform -eq 'standalone') {
     Write-Host ''


### PR DESCRIPTION
## Summary
Found via unity-test-runner's own thin-wrapper CI ([#310](https://github.com/game-ci/unity-test-runner/pull/310)): windows-2022 Docker jobs hit the same class of Unity license-server flakiness already fixed for mac in #189/#191/#194 (\`Access token is unavailable\`, \`License is not active\`, \`No valid Unity Editor license found\`) - but those fixes only cover mac's native Unity.exe path. Windows' Docker container path (\`activate.ps1\`, \`steps/test.ps1\`) had no equivalent retry at all.

Same pattern, same signatures, same \`--licenseRetryMaxAttempts\`/\`UNITY_LICENSE_RETRY_MAX_ATTEMPTS\` knob (already engine-wide via \`UnityEnvironment.getVariables\`, so no new plumbing needed) - a real failure (bad serial, real test failure, exit code 2 meaning tests genuinely failed) is never retried.

\`windows/build.ps1\` and the ubuntu Docker scripts aren't touched here - no failing CI evidence for either yet.

## Test plan
- [x] \`bash scripts/validate-platform-scripts.sh\` passes
- [x] PowerShell syntax check (PSParser) on both files
- [x] Isolated logic test: simulated 2 transient failures then success - retries twice, succeeds on 3rd attempt
- [ ] CI green
- [ ] Re-verify against unity-test-runner#310's Windows matrix after release