### PR TITLE
fix: retry license return, not just activate/build - prevents seat leaks

### DIFF
--- a/dist/platforms/mac/steps/return_license.sh
+++ b/dist/platforms/mac/steps/return_license.sh
@@ -4,6 +4,21 @@
 echo "Changing to \"$ACTIVATE_LICENSE_PATH\" directory."
 pushd "$ACTIVATE_LICENSE_PATH"
 
+# A failed license *return* is worse than a failed activate/build: it leaks
+# the seat back to Unity's license pool. Every subsequent job (this run and
+# every other one sharing the same account) then has one fewer seat/entitlement
+# available, which surfaces as exactly the same "0 entitlement groups"/
+# "License is not active" symptoms build.sh and activate.sh already retry on
+# - a cascading failure mode that gets worse the longer a busy CI account runs,
+# not a one-off flake. Neither branch below ever checked its exit code before
+# now, so a failed return was silent - this retries on the same known-transient
+# signatures and, critically, logs loudly if every attempt is exhausted, since
+# a genuinely leaked seat needs a human to know about it (nothing here can
+# force Unity's server to release a seat it thinks is still in use).
+UNITY_LICENSE_RETURN_MAX_ATTEMPTS="${UNITY_LICENSE_RETRY_MAX_ATTEMPTS:-4}"
+UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS=20
+UNITY_LICENSE_RETURN_TRANSIENT_PATTERN='TimeoutPolicy did not complete|Access token is unavailable|entitlement groups and 0 free entitlements|License activation has failed|No valid Unity Editor license found|License is not active|Serial number unavailable'
+
 if [[ -n "$UNITY_LICENSING_SERVER" ]]; then
   #
   # Return any floating license used.
@@ -24,23 +39,63 @@ if [[ -n "$UNITY_LICENSING_SERVER" ]]; then
     UNITY_LICENSING_CLIENT_SUBDIR="Helpers"
   fi
 
-  "/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/$UNITY_LICENSING_CLIENT_SUBDIR/UnityLicensingClient.app/Contents/MacOS/Unity.Licensing.Client" \
-    --return-floating "$FLOATING_LICENSE"
+  RETURN_LOG="$(mktemp)"
+  for ATTEMPT in $(seq 1 "$UNITY_LICENSE_RETURN_MAX_ATTEMPTS"); do
+    "/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/$UNITY_LICENSING_CLIENT_SUBDIR/UnityLicensingClient.app/Contents/MacOS/Unity.Licensing.Client" \
+      --return-floating "$FLOATING_LICENSE" 2>&1 | tee "$RETURN_LOG"
+    RETURN_EXIT_CODE=${PIPESTATUS[0]}
+
+    if [ "$RETURN_EXIT_CODE" -eq 0 ]; then
+      break
+    fi
+
+    if [ "$ATTEMPT" -lt "$UNITY_LICENSE_RETURN_MAX_ATTEMPTS" ] && grep -qE "$UNITY_LICENSE_RETURN_TRANSIENT_PATTERN" "$RETURN_LOG"; then
+      echo "Floating license return failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_LICENSE_RETURN_MAX_ATTEMPTS) - retrying in ${UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS}s..."
+      sleep "$UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS"
+      continue
+    fi
+
+    break
+  done
+  if [ "$RETURN_EXIT_CODE" -ne 0 ]; then
+    echo "##[warning] Failed to return floating license \"$FLOATING_LICENSE\" after $UNITY_LICENSE_RETURN_MAX_ATTEMPTS attempts - this seat may still be held by Unity's license server."
+  fi
+  rm -f "$RETURN_LOG"
 elif [[ -n "$UNITY_SERIAL" ]]; then
   #
   # SERIAL LICENSE MODE
   #
   # This will return the license that is currently in use.
   #
-  /Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS/Unity \
-    -logFile - \
-    -batchmode \
-    -nographics \
-    -quit \
-    -username "$UNITY_EMAIL" \
-    -password "$UNITY_PASSWORD" \
-    -returnlicense \
-    -projectPath "$ACTIVATE_LICENSE_PATH"
+  RETURN_LOG="$(mktemp)"
+  for ATTEMPT in $(seq 1 "$UNITY_LICENSE_RETURN_MAX_ATTEMPTS"); do
+    /Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS/Unity \
+      -logFile - \
+      -batchmode \
+      -nographics \
+      -quit \
+      -username "$UNITY_EMAIL" \
+      -password "$UNITY_PASSWORD" \
+      -returnlicense \
+      -projectPath "$ACTIVATE_LICENSE_PATH" 2>&1 | tee "$RETURN_LOG"
+    RETURN_EXIT_CODE=${PIPESTATUS[0]}
+
+    if [ "$RETURN_EXIT_CODE" -eq 0 ]; then
+      break
+    fi
+
+    if [ "$ATTEMPT" -lt "$UNITY_LICENSE_RETURN_MAX_ATTEMPTS" ] && grep -qE "$UNITY_LICENSE_RETURN_TRANSIENT_PATTERN" "$RETURN_LOG"; then
+      echo "License return failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_LICENSE_RETURN_MAX_ATTEMPTS) - retrying in ${UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS}s..."
+      sleep "$UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS"
+      continue
+    fi
+
+    break
+  done
+  if [ "$RETURN_EXIT_CODE" -ne 0 ]; then
+    echo "##[warning] Failed to return the Unity license after $UNITY_LICENSE_RETURN_MAX_ATTEMPTS attempts - this seat may still be held by Unity's license server."
+  fi
+  rm -f "$RETURN_LOG"
 fi
 
 # Return to previous working directory

--- a/dist/platforms/ubuntu/steps/activate.sh
+++ b/dist/platforms/ubuntu/steps/activate.sh
@@ -4,6 +4,14 @@
 echo "Changing to \"$ACTIVATE_LICENSE_PATH\" directory."
 pushd "$ACTIVATE_LICENSE_PATH"
 
+# Same known-transient Unity license-server flakiness as mac/windows (see
+# mac/steps/build.sh's matching comment) - retried a few times, but only on
+# those known-transient signatures, so a genuine activation failure (bad
+# serial, expired license, etc.) still fails immediately.
+UNITY_ACTIVATE_MAX_ATTEMPTS="${UNITY_LICENSE_RETRY_MAX_ATTEMPTS:-4}"
+UNITY_ACTIVATE_RETRY_DELAY_SECONDS=20
+UNITY_ACTIVATE_TRANSIENT_PATTERN='TimeoutPolicy did not complete|Access token is unavailable|entitlement groups and 0 free entitlements|License activation has failed|No valid Unity Editor license found|License is not active'
+
 if [[ -n "$UNITY_LICENSE" ]] || [[ -n "$UNITY_LICENSE_FILE" ]]; then
   #
   # PERSONAL LICENSE MODE
@@ -27,28 +35,39 @@ if [[ -n "$UNITY_LICENSE" ]] || [[ -n "$UNITY_LICENSE_FILE" ]]; then
     cat "$UNITY_LICENSE_FILE" | tr -d '\r' > $FILE_PATH
   fi
 
-  # Activate license
-  ACTIVATION_OUTPUT=$(${ENGINE_LAUNCH_WRAPPER:-} unity-editor \
-      -logFile /dev/stdout \
-      -quit \
-      -manualLicenseFile $FILE_PATH)
+  for ATTEMPT in $(seq 1 "$UNITY_ACTIVATE_MAX_ATTEMPTS"); do
+    # Activate license
+    ACTIVATION_OUTPUT=$(${ENGINE_LAUNCH_WRAPPER:-} unity-editor \
+        -logFile /dev/stdout \
+        -quit \
+        -manualLicenseFile $FILE_PATH)
 
-  # Store the exit code from the verify command
-  UNITY_EXIT_CODE=$?
+    # Store the exit code from the verify command
+    UNITY_EXIT_CODE=$?
 
-  # The exit code for personal activation is always 1;
-  # Determine whether activation was successful.
-  #
-  # Successful output should include the following:
-  #
-  #   "LICENSE SYSTEM [2020120 18:51:20] Next license update check is after 2019-11-25T18:23:38"
-  #
-  ACTIVATION_SUCCESSFUL=$(echo $ACTIVATION_OUTPUT | grep 'Next license update check is after' | wc -l)
+    # The exit code for personal activation is always 1;
+    # Determine whether activation was successful.
+    #
+    # Successful output should include the following:
+    #
+    #   "LICENSE SYSTEM [2020120 18:51:20] Next license update check is after 2019-11-25T18:23:38"
+    #
+    ACTIVATION_SUCCESSFUL=$(echo "$ACTIVATION_OUTPUT" | grep 'Next license update check is after' | wc -l)
 
-  # Set exit code to 0 if activation was successful
-  if [[ $ACTIVATION_SUCCESSFUL -eq 1 ]]; then
-    UNITY_EXIT_CODE=0
-  fi;
+    # Set exit code to 0 if activation was successful
+    if [[ $ACTIVATION_SUCCESSFUL -eq 1 ]]; then
+      UNITY_EXIT_CODE=0
+      break
+    fi
+
+    if [ "$ATTEMPT" -lt "$UNITY_ACTIVATE_MAX_ATTEMPTS" ] && grep -qE "$UNITY_ACTIVATE_TRANSIENT_PATTERN" <<< "$ACTIVATION_OUTPUT"; then
+      echo "Unity activation failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_ACTIVATE_MAX_ATTEMPTS) - retrying in ${UNITY_ACTIVATE_RETRY_DELAY_SECONDS}s..."
+      sleep "$UNITY_ACTIVATE_RETRY_DELAY_SECONDS"
+      continue
+    fi
+
+    break
+  done
 
   # Remove license file
   rm -f $FILE_PATH
@@ -63,16 +82,32 @@ elif [[ -n "$UNITY_SERIAL" && -n "$UNITY_EMAIL" && -n "$UNITY_PASSWORD" ]]; then
   #
   echo "Requesting activation (professional license)"
 
-  # Activate license
-  ${ENGINE_LAUNCH_WRAPPER:-} unity-editor \
-    -logFile /dev/stdout \
-    -quit \
-    -serial "$UNITY_SERIAL" \
-    -username "$UNITY_EMAIL" \
-    -password "$UNITY_PASSWORD"
+  ACTIVATE_LOG="$(mktemp)"
+  for ATTEMPT in $(seq 1 "$UNITY_ACTIVATE_MAX_ATTEMPTS"); do
+    # Activate license
+    ${ENGINE_LAUNCH_WRAPPER:-} unity-editor \
+      -logFile /dev/stdout \
+      -quit \
+      -serial "$UNITY_SERIAL" \
+      -username "$UNITY_EMAIL" \
+      -password "$UNITY_PASSWORD" 2>&1 | tee "$ACTIVATE_LOG"
 
-  # Store the exit code from the verify command
-  UNITY_EXIT_CODE=$?
+    # Store the exit code from the verify command
+    UNITY_EXIT_CODE=${PIPESTATUS[0]}
+
+    if [ "$UNITY_EXIT_CODE" -eq 0 ]; then
+      break
+    fi
+
+    if [ "$ATTEMPT" -lt "$UNITY_ACTIVATE_MAX_ATTEMPTS" ] && grep -qE "$UNITY_ACTIVATE_TRANSIENT_PATTERN" "$ACTIVATE_LOG"; then
+      echo "Unity activation failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_ACTIVATE_MAX_ATTEMPTS) - retrying in ${UNITY_ACTIVATE_RETRY_DELAY_SECONDS}s..."
+      sleep "$UNITY_ACTIVATE_RETRY_DELAY_SECONDS"
+      continue
+    fi
+
+    break
+  done
+  rm -f "$ACTIVATE_LOG"
 
 elif [[ -n "$UNITY_LICENSING_SERVER" ]]; then
   #
@@ -80,15 +115,31 @@ elif [[ -n "$UNITY_LICENSING_SERVER" ]]; then
   #
   echo "Adding licensing server config"
 
-  /opt/unity/Editor/Data/Resources/Licensing/Client/Unity.Licensing.Client --acquire-floating > license.txt #is this accessible in a env variable?
+  ACTIVATE_LOG="$(mktemp)"
+  for ATTEMPT in $(seq 1 "$UNITY_ACTIVATE_MAX_ATTEMPTS"); do
+    /opt/unity/Editor/Data/Resources/Licensing/Client/Unity.Licensing.Client --acquire-floating 2>&1 | tee license.txt "$ACTIVATE_LOG" > /dev/null
+    UNITY_EXIT_CODE=${PIPESTATUS[0]}
+
+    if [ "$UNITY_EXIT_CODE" -eq 0 ]; then
+      break
+    fi
+
+    if [ "$ATTEMPT" -lt "$UNITY_ACTIVATE_MAX_ATTEMPTS" ] && grep -qE "$UNITY_ACTIVATE_TRANSIENT_PATTERN" "$ACTIVATE_LOG"; then
+      echo "Floating license acquisition failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_ACTIVATE_MAX_ATTEMPTS) - retrying in ${UNITY_ACTIVATE_RETRY_DELAY_SECONDS}s..."
+      sleep "$UNITY_ACTIVATE_RETRY_DELAY_SECONDS"
+      continue
+    fi
+
+    break
+  done
+  rm -f "$ACTIVATE_LOG"
+
   PARSEDFILE=$(grep -oP '\".*?\"' < license.txt | tr -d '"')
   export FLOATING_LICENSE
   FLOATING_LICENSE=$(sed -n 2p <<< "$PARSEDFILE")
   FLOATING_LICENSE_TIMEOUT=$(sed -n 4p <<< "$PARSEDFILE")
 
   echo "Acquired floating license: \"$FLOATING_LICENSE\" with timeout $FLOATING_LICENSE_TIMEOUT"
-  # Store the exit code from the verify command
-  UNITY_EXIT_CODE=$?
 else
   #
   # NO LICENSE ACTIVATION STRATEGY MATCHED

--- a/dist/platforms/ubuntu/steps/return_license.sh
+++ b/dist/platforms/ubuntu/steps/return_license.sh
@@ -4,12 +4,48 @@
 echo "Changing to \"$ACTIVATE_LICENSE_PATH\" directory."
 pushd "$ACTIVATE_LICENSE_PATH"
 
+# A failed license *return* is worse than a failed activate/build: it leaks
+# the seat back to Unity's license pool. Every subsequent job (this run and
+# every other one sharing the same account, on any OS) then has one fewer
+# seat/entitlement available, which surfaces as exactly the same "0
+# entitlement groups"/"License is not active" symptoms elsewhere - a
+# cascading failure mode that gets worse the longer a busy CI account runs,
+# not a one-off flake. Neither branch below ever checked its exit code
+# before now, so a failed return was silent - this retries on the same
+# known-transient signatures build.sh/activate.sh already retry on (see
+# mac/steps/build.sh) and, critically, logs loudly if every attempt is
+# exhausted, since a genuinely leaked seat needs a human to know about it.
+UNITY_LICENSE_RETURN_MAX_ATTEMPTS="${UNITY_LICENSE_RETRY_MAX_ATTEMPTS:-4}"
+UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS=20
+UNITY_LICENSE_RETURN_TRANSIENT_PATTERN='TimeoutPolicy did not complete|Access token is unavailable|entitlement groups and 0 free entitlements|License activation has failed|No valid Unity Editor license found|License is not active|Serial number unavailable'
+
 if [[ -n "$UNITY_LICENSING_SERVER" ]]; then  #
   #
   # Return any floating license used.
   #
   echo "Returning floating license: \"$FLOATING_LICENSE\""
-  /opt/unity/Editor/Data/Resources/Licensing/Client/Unity.Licensing.Client --return-floating "$FLOATING_LICENSE"
+
+  RETURN_LOG="$(mktemp)"
+  for ATTEMPT in $(seq 1 "$UNITY_LICENSE_RETURN_MAX_ATTEMPTS"); do
+    /opt/unity/Editor/Data/Resources/Licensing/Client/Unity.Licensing.Client --return-floating "$FLOATING_LICENSE" 2>&1 | tee "$RETURN_LOG"
+    RETURN_EXIT_CODE=${PIPESTATUS[0]}
+
+    if [ "$RETURN_EXIT_CODE" -eq 0 ]; then
+      break
+    fi
+
+    if [ "$ATTEMPT" -lt "$UNITY_LICENSE_RETURN_MAX_ATTEMPTS" ] && grep -qE "$UNITY_LICENSE_RETURN_TRANSIENT_PATTERN" "$RETURN_LOG"; then
+      echo "Floating license return failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_LICENSE_RETURN_MAX_ATTEMPTS) - retrying in ${UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS}s..."
+      sleep "$UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS"
+      continue
+    fi
+
+    break
+  done
+  if [ "$RETURN_EXIT_CODE" -ne 0 ]; then
+    echo "##[warning] Failed to return floating license \"$FLOATING_LICENSE\" after $UNITY_LICENSE_RETURN_MAX_ATTEMPTS attempts - this seat may still be held by Unity's license server."
+  fi
+  rm -f "$RETURN_LOG"
 elif [[ -n "$UNITY_SERIAL" ]]; then
   #
   # PROFESSIONAL (SERIAL) LICENSE MODE
@@ -20,11 +56,31 @@ elif [[ -n "$UNITY_SERIAL" ]]; then
   # project, so Unity doesn't reopen the real project (and reimport its
   # library against whatever the editor's default target is) just to
   # return the license (game-ci/cli#33).
-  unity-editor \
-    -logFile /dev/stdout \
-    -quit \
-    -returnlicense \
-    -projectPath "$ACTIVATE_LICENSE_PATH"
+  RETURN_LOG="$(mktemp)"
+  for ATTEMPT in $(seq 1 "$UNITY_LICENSE_RETURN_MAX_ATTEMPTS"); do
+    unity-editor \
+      -logFile /dev/stdout \
+      -quit \
+      -returnlicense \
+      -projectPath "$ACTIVATE_LICENSE_PATH" 2>&1 | tee "$RETURN_LOG"
+    RETURN_EXIT_CODE=${PIPESTATUS[0]}
+
+    if [ "$RETURN_EXIT_CODE" -eq 0 ]; then
+      break
+    fi
+
+    if [ "$ATTEMPT" -lt "$UNITY_LICENSE_RETURN_MAX_ATTEMPTS" ] && grep -qE "$UNITY_LICENSE_RETURN_TRANSIENT_PATTERN" "$RETURN_LOG"; then
+      echo "License return failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_LICENSE_RETURN_MAX_ATTEMPTS) - retrying in ${UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS}s..."
+      sleep "$UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS"
+      continue
+    fi
+
+    break
+  done
+  if [ "$RETURN_EXIT_CODE" -ne 0 ]; then
+    echo "##[warning] Failed to return the Unity license after $UNITY_LICENSE_RETURN_MAX_ATTEMPTS attempts - this seat may still be held by Unity's license server."
+  fi
+  rm -f "$RETURN_LOG"
 fi
 
 # Return to previous working directory

--- a/dist/platforms/windows/return_license.ps1
+++ b/dist/platforms/windows/return_license.ps1
@@ -7,6 +7,22 @@
 Write-Host "Changing to `"$Env:ACTIVATE_LICENSE_PATH`" directory."
 Push-Location $Env:ACTIVATE_LICENSE_PATH
 
+# A failed license *return* is worse than a failed activate/build: it leaks
+# the seat back to Unity's license pool. Every subsequent job (this run and
+# every other one sharing the same account) then has one fewer seat/entitlement
+# available, which surfaces as exactly the same "0 entitlement groups"/
+# "License is not active" symptoms activate.ps1 and steps/test.ps1 already
+# retry on - a cascading failure mode that gets worse the longer a busy CI
+# account runs, not a one-off flake. Neither branch below ever checked its
+# exit code before now, so a failed return was silent - this retries on the
+# same known-transient signatures and, critically, logs loudly if every
+# attempt is exhausted, since a genuinely leaked seat needs a human to know
+# about it (nothing here can force Unity's server to release a seat it
+# thinks is still in use).
+$MaxAttempts = if ($Env:UNITY_LICENSE_RETRY_MAX_ATTEMPTS) { [int]$Env:UNITY_LICENSE_RETRY_MAX_ATTEMPTS } else { 4 }
+$RetryDelaySeconds = 20
+$TransientPattern = 'TimeoutPolicy did not complete|Access token is unavailable|entitlement groups and 0 free entitlements|License activation has failed|No valid Unity Editor license found|License is not active|Serial number unavailable'
+
 if ($env:UNITY_LICENSING_SERVER) {
   #
   # Return any floating license used.
@@ -15,7 +31,24 @@ if ($env:UNITY_LICENSING_SERVER) {
   # Was single-quoted, so $Env:UNITY_VERSION was never interpolated at all
   # (literal text) on top of pointing at the wrong install location -
   # see build.ps1 for why UNITY_PATH (game-ci/cli#77).
-  & "$Env:UNITY_PATH\Editor\Data\Resources\Licensing\Client\Unity.Licensing.Client.exe" --return-floating $global:FLOATING_LICENSE
+  for ($Attempt = 1; $Attempt -le $MaxAttempts; $Attempt++) {
+    $ReturnOutput = & "$Env:UNITY_PATH\Editor\Data\Resources\Licensing\Client\Unity.Licensing.Client.exe" --return-floating $global:FLOATING_LICENSE 2>&1 | Tee-Object -Variable ReturnOutputVar
+    $ReturnOutput | Out-Host
+    $ReturnExitCode = $LASTEXITCODE
+    $ReturnText = ($ReturnOutputVar | Out-String)
+
+    if ($ReturnExitCode -eq 0) { break }
+
+    if ($Attempt -lt $MaxAttempts -and $ReturnText -match $TransientPattern) {
+      Write-Host "Floating license return failed with a known-transient licensing error (attempt $Attempt/$MaxAttempts) - retrying in ${RetryDelaySeconds}s..."
+      Start-Sleep -Seconds $RetryDelaySeconds
+      continue
+    }
+    break
+  }
+  if ($ReturnExitCode -ne 0) {
+    Write-Host "##[warning] Failed to return floating license `"$($global:FLOATING_LICENSE)`" after $MaxAttempts attempts - this seat may still be held by Unity's license server."
+  }
 }
 else {
   # -projectPath points at the scratch activation directory, not the built
@@ -24,13 +57,30 @@ else {
   # return the license (game-ci/cli#33).
   # -logfile needs a real path, same reasoning as activate.ps1.
   $LogPath = Join-Path $Env:ACTIVATE_LICENSE_PATH 'return_license.log'
-  & "$Env:UNITY_PATH\Editor\Unity.exe" -batchmode -quit -nographics `
-                                                                            -username $Env:UNITY_EMAIL `
-                                                                            -password $Env:UNITY_PASSWORD `
-                                                                            -returnlicense `
-                                                                            -projectPath $Env:ACTIVATE_LICENSE_PATH `
-                                                                            -logfile $LogPath | Out-Host
-  if (Test-Path $LogPath) { Get-Content $LogPath | Out-Host }
+
+  for ($Attempt = 1; $Attempt -le $MaxAttempts; $Attempt++) {
+    & "$Env:UNITY_PATH\Editor\Unity.exe" -batchmode -quit -nographics `
+                                                                              -username $Env:UNITY_EMAIL `
+                                                                              -password $Env:UNITY_PASSWORD `
+                                                                              -returnlicense `
+                                                                              -projectPath $Env:ACTIVATE_LICENSE_PATH `
+                                                                              -logfile $LogPath | Out-Host
+    $ReturnExitCode = $LASTEXITCODE
+    $LogContent = if (Test-Path $LogPath) { Get-Content $LogPath -Raw } else { '' }
+    if ($LogContent) { Get-Content $LogPath | Out-Host }
+
+    if ($ReturnExitCode -eq 0) { break }
+
+    if ($Attempt -lt $MaxAttempts -and $LogContent -match $TransientPattern) {
+      Write-Host "License return failed with a known-transient licensing error (attempt $Attempt/$MaxAttempts) - retrying in ${RetryDelaySeconds}s..."
+      Start-Sleep -Seconds $RetryDelaySeconds
+      continue
+    }
+    break
+  }
+  if ($ReturnExitCode -ne 0) {
+    Write-Host "##[warning] Failed to return the Unity license after $MaxAttempts attempts - this seat may still be held by Unity's license server."
+  }
 }
 
 Pop-Location


### PR DESCRIPTION
## Summary
The retry logic added across #189/#191/#194/#200 covers activate and build/test, but never the license *return* step - and a failed return is categorically worse than a failed activate or build: it leaks the seat back to Unity's license pool instead of releasing it. Every subsequent job sharing the same account (any platform, since the seat pool is shared) then has one fewer entitlement available, surfacing as exactly the same "0 entitlement groups"/"License is not active" symptoms already being retried elsewhere - a cascading failure mode that gets *worse* the longer a busy CI account runs, not a one-off flake. This is very likely why today's session saw license flakiness increase over many hours of heavy concurrent CI, up to Windows jobs failing almost every attempt by the end.

None of \`return_license.sh\` (mac/ubuntu) or \`return_license.ps1\` (windows) ever checked their Unity invocation's exit code before this - a failed return was completely silent. All three now retry on the same known-transient signatures as activate/build, plus "Serial number unavailable" (seen specifically on return failures), and - critically - log a loud warning if every attempt is exhausted, since a genuinely leaked seat needs a human to know about it.

Also extends the same activate retry to \`ubuntu/steps/activate.sh\` (mac and windows already had it) - all three platforms now retry consistently on both activate and return.

## Test plan
- [x] \`bash scripts/validate-platform-scripts.sh\` passes
- [x] PowerShell syntax check (PSParser) on \`return_license.ps1\`
- [x] Isolated logic test: simulated 2 "Serial number unavailable" return failures then success - retries twice, succeeds
- [ ] CI green
- [ ] Re-verify against unity-builder#844 / unity-test-runner#310 after release - expect flakiness to *decrease* over subsequent runs as leaked seats stop accumulating