### PR TITLE
chore: bump version to 0.1.38 for #202's license-return retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "description": "GameCI CLI - automation for game engines",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Follow-up release for #202 - the license-return retry fix that should meaningfully reduce cascading license flakiness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version from 0.1.37 to 0.1.38.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->