### PR TITLE
fix: add personal-license (UNITY_LICENSE) activation to mac and windows

### DIFF
--- a/dist/platforms/mac/steps/activate.sh
+++ b/dist/platforms/mac/steps/activate.sh
@@ -4,26 +4,71 @@
 echo "Changing to \"$ACTIVATE_LICENSE_PATH\" directory."
 pushd "$ACTIVATE_LICENSE_PATH"
 
-if [[ -n "$UNITY_SERIAL" && -n "$UNITY_EMAIL" && -n "$UNITY_PASSWORD" ]]; then
+# Same UNITY_LICENSE_RETRY_MAX_ATTEMPTS as build.sh's matching retry - set
+# from the real --licenseRetryMaxAttempts CLI option (see
+# UnityEnvironment.getVariables), one knob covers all activation modes since
+# they're the same underlying flakiness. --licenseRetryMaxAttempts=1
+# disables retrying.
+ACTIVATE_MAX_ATTEMPTS="${UNITY_LICENSE_RETRY_MAX_ATTEMPTS:-4}"
+ACTIVATE_RETRY_DELAY_SECONDS=20
+ACTIVATE_TRANSIENT_LICENSE_ERROR_PATTERN='TimeoutPolicy did not complete|Access token is unavailable|entitlement groups and 0 free entitlements|License activation has failed|No valid Unity Editor license found|License is not active'
+
+if [[ -n "$UNITY_LICENSE" ]] || [[ -n "$UNITY_LICENSE_FILE" ]]; then
+  #
+  # PERSONAL LICENSE MODE
+  #
+  # mac never had this branch at all - only ubuntu/steps/activate.sh did,
+  # going all the way back to before the thin-wrapper migration (confirmed
+  # against unity-builder's own pre-migration mac script). A repo whose only
+  # configured credential is UNITY_LICENSE (no UNITY_SERIAL/EMAIL/PASSWORD -
+  # exactly game-ci/unity-test-runner's actual repo secrets) had no way to
+  # activate on mac at all: activation always fell through to serial mode
+  # with empty credentials, producing the same "License is not active"/"0
+  # entitlement groups" symptoms as genuine license-server flakiness, but
+  # persistent and 100% reproducible rather than transient - no amount of
+  # retrying a fundamentally missing credential ever helps.
+  echo "Requesting activation (personal license)"
+
+  FILE_PATH=UnityLicenseFile.ulf
+  if [[ -n "$UNITY_LICENSE" ]]; then
+    echo "$UNITY_LICENSE" | tr -d '\r' > "$FILE_PATH"
+  elif [[ -n "$UNITY_LICENSE_FILE" ]]; then
+    cat "$UNITY_LICENSE_FILE" | tr -d '\r' > "$FILE_PATH"
+  fi
+
+  ACTIVATE_LOG="$(mktemp)"
+  for ACTIVATE_ATTEMPT in $(seq 1 "$ACTIVATE_MAX_ATTEMPTS"); do
+    # The exit code for personal activation is always 1 - success is
+    # determined from the log output instead (same as ubuntu's own personal-
+    # license branch).
+    /Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS/Unity \
+      -logFile - \
+      -batchmode \
+      -nographics \
+      -quit \
+      -manualLicenseFile "$FILE_PATH" \
+      -projectPath "$ACTIVATE_LICENSE_PATH" 2>&1 | tee "$ACTIVATE_LOG"
+
+    if grep -q 'Next license update check is after' "$ACTIVATE_LOG"; then
+      UNITY_EXIT_CODE=0
+      break
+    fi
+    UNITY_EXIT_CODE=1
+
+    if [ "$ACTIVATE_ATTEMPT" -lt "$ACTIVATE_MAX_ATTEMPTS" ] && grep -qE "$ACTIVATE_TRANSIENT_LICENSE_ERROR_PATTERN" "$ACTIVATE_LOG"; then
+      echo "Unity activation failed with a known-transient licensing error (attempt $ACTIVATE_ATTEMPT/$ACTIVATE_MAX_ATTEMPTS) - retrying in ${ACTIVATE_RETRY_DELAY_SECONDS}s..."
+      sleep "$ACTIVATE_RETRY_DELAY_SECONDS"
+      continue
+    fi
+
+    break
+  done
+  rm -f "$ACTIVATE_LOG" "$FILE_PATH"
+elif [[ -n "$UNITY_SERIAL" && -n "$UNITY_EMAIL" && -n "$UNITY_PASSWORD" ]]; then
   #
   # SERIAL LICENSE MODE
   #
   echo "Requesting activation"
-
-  # Unity's licensing client occasionally fails to reach/handshake with
-  # Unity's cloud license service in time here too, not just during the
-  # build's own Unity invocation (see build.sh's matching comment/retry) -
-  # same signatures ("Code 404/408/1500 ...", "Access token is unavailable"),
-  # same fix: retry a few times, but only on those known-transient
-  # signatures, so a genuine activation failure (bad serial, expired
-  # license, etc.) still fails immediately rather than burning retries.
-  # Same UNITY_LICENSE_RETRY_MAX_ATTEMPTS as build.sh's matching retry - set
-  # from the real --licenseRetryMaxAttempts CLI option (see
-  # UnityEnvironment.getVariables), one knob covers both since they're the
-  # same underlying flakiness. --licenseRetryMaxAttempts=1 disables retrying.
-  ACTIVATE_MAX_ATTEMPTS="${UNITY_LICENSE_RETRY_MAX_ATTEMPTS:-4}"
-  ACTIVATE_RETRY_DELAY_SECONDS=20
-  ACTIVATE_TRANSIENT_LICENSE_ERROR_PATTERN='TimeoutPolicy did not complete|Access token is unavailable|entitlement groups and 0 free entitlements|License activation has failed|No valid Unity Editor license found|License is not active'
 
   ACTIVATE_LOG="$(mktemp)"
   for ACTIVATE_ATTEMPT in $(seq 1 "$ACTIVATE_MAX_ATTEMPTS"); do

--- a/dist/platforms/windows/activate.ps1
+++ b/dist/platforms/windows/activate.ps1
@@ -12,7 +12,61 @@
 Write-Host "Changing to `"$Env:ACTIVATE_LICENSE_PATH`" directory."
 Push-Location $Env:ACTIVATE_LICENSE_PATH
 
-if ($env:UNITY_LICENSING_SERVER) {
+# Same UNITY_LICENSE_RETRY_MAX_ATTEMPTS as build.ps1's matching retry - one
+# knob covers every activation mode below since they're the same underlying
+# flakiness.
+$MaxAttempts = if ($Env:UNITY_LICENSE_RETRY_MAX_ATTEMPTS) { [int]$Env:UNITY_LICENSE_RETRY_MAX_ATTEMPTS } else { 4 }
+$RetryDelaySeconds = 20
+$TransientPattern = 'TimeoutPolicy did not complete|Access token is unavailable|entitlement groups and 0 free entitlements|License activation has failed|No valid Unity Editor license found|License is not active'
+
+if ($Env:UNITY_LICENSE -or $Env:UNITY_LICENSE_FILE) {
+  #
+  # PERSONAL LICENSE MODE
+  #
+  # windows never had this branch at all - only ubuntu/steps/activate.sh
+  # did. A repo whose only configured credential is UNITY_LICENSE (no
+  # UNITY_SERIAL/EMAIL/PASSWORD - exactly game-ci/unity-test-runner's actual
+  # repo secrets) had no way to activate on windows at all: activation
+  # always fell through to serial mode with empty credentials, producing
+  # the same "License is not active"/"0 entitlement groups" symptoms as
+  # genuine license-server flakiness, but persistent and 100% reproducible
+  # rather than transient - no amount of retrying a fundamentally missing
+  # credential ever helps.
+  Write-Host "Requesting activation (personal license)"
+
+  $FilePath = Join-Path $Env:ACTIVATE_LICENSE_PATH 'UnityLicenseFile.ulf'
+  if ($Env:UNITY_LICENSE) {
+    ($Env:UNITY_LICENSE -replace "`r", '') | Set-Content -Path $FilePath -NoNewline
+  } elseif ($Env:UNITY_LICENSE_FILE) {
+    (Get-Content -Raw $Env:UNITY_LICENSE_FILE) -replace "`r", '' | Set-Content -Path $FilePath -NoNewline
+  }
+
+  for ($Attempt = 1; $Attempt -le $MaxAttempts; $Attempt++) {
+    # The exit code for personal activation is always 1 - success is
+    # determined from the output instead (same as ubuntu's own personal-
+    # license branch).
+    $ActivationOutput = & "$Env:UNITY_PATH\Editor\Unity.exe" -batchmode -quit -nographics `
+                                                                              -manualLicenseFile $FilePath `
+                                                                              -projectPath $Env:ACTIVATE_LICENSE_PATH 2>&1 | Tee-Object -Variable ActivationOutputVar
+    $ActivationOutput | Out-Host
+    $ActivationText = ($ActivationOutputVar | Out-String)
+
+    if ($ActivationText -match 'Next license update check is after') {
+      $global:UNITY_EXIT_CODE = 0
+      break
+    }
+    $global:UNITY_EXIT_CODE = 1
+
+    if ($Attempt -lt $MaxAttempts -and $ActivationText -match $TransientPattern) {
+      Write-Host "Unity activation failed with a known-transient licensing error (attempt $Attempt/$MaxAttempts) - retrying in ${RetryDelaySeconds}s..."
+      Start-Sleep -Seconds $RetryDelaySeconds
+      continue
+    }
+    break
+  }
+  Remove-Item -Force -ErrorAction SilentlyContinue $FilePath
+}
+elseif ($env:UNITY_LICENSING_SERVER) {
   #
   # Custom Unity License Server
   #
@@ -37,18 +91,6 @@ else {
   # silently kept whatever value it already had (uninitialized/stale) rather
   # than reflecting whether activation actually succeeded.
   $LogPath = Join-Path $Env:ACTIVATE_LICENSE_PATH 'activate.log'
-
-  # Same known-transient Unity license-server flakiness as the mac retry
-  # (see mac/steps/activate.sh's matching comment) - "0 entitlement groups",
-  # "Access token is unavailable", "No valid Unity Editor license found",
-  # etc. Retried a few times rather than failing the whole job on what's
-  # effectively a flaky call to Unity's cloud license service. Configurable
-  # via the same --licenseRetryMaxAttempts CLI option / UNITY_LICENSE_RETRY_MAX_ATTEMPTS
-  # env var as the mac scripts (see UnityEnvironment.getVariables) - it's
-  # engine-wide, not mac-specific, so this needs no new plumbing.
-  $MaxAttempts = if ($Env:UNITY_LICENSE_RETRY_MAX_ATTEMPTS) { [int]$Env:UNITY_LICENSE_RETRY_MAX_ATTEMPTS } else { 4 }
-  $RetryDelaySeconds = 20
-  $TransientPattern = 'TimeoutPolicy did not complete|Access token is unavailable|entitlement groups and 0 free entitlements|License activation has failed|No valid Unity Editor license found|License is not active'
 
   for ($Attempt = 1; $Attempt -le $MaxAttempts; $Attempt++) {
     & "$Env:UNITY_PATH\Editor\Unity.exe" -batchmode -quit -nographics `


### PR DESCRIPTION
## Summary
Real root cause found while investigating unity-test-runner#310's Windows CI: it failed **100% of jobs (14/14)** while Ubuntu passed **75% (9/12)** using the same account. That split - not a partial/random failure rate - pointed at a credential gap rather than transient flakiness: \`gh secret list\` on \`game-ci/unity-test-runner\` shows only \`UNITY_LICENSE\` configured at the repo level, no \`UNITY_SERIAL\`/\`EMAIL\`/\`PASSWORD\`. But \`mac/steps/activate.sh\` and \`windows/activate.ps1\` only ever had a serial-mode branch (plus \`UNITY_LICENSING_SERVER\`) - never a personal-license (\`UNITY_LICENSE\`/\`UNITY_LICENSE_FILE\`) branch. Confirmed this gap predates the thin-wrapper migration entirely: unity-builder's own original (pre-migration) mac script never had it either.

So any repo/workflow configured with only \`UNITY_LICENSE\` - exactly unity-test-runner's actual secrets - had no way to activate on mac or windows at all: activation always fell through to serial mode with empty credentials, producing the exact same "License is not active"/"0 entitlement groups" symptoms as genuine license-server flakiness, but persistent and 100% reproducible rather than transient. No amount of retrying a fundamentally missing credential path was ever going to fix this - #189/#191/#194/#200/#202's retry logic was correctly firing on a real signature, just for the wrong underlying reason on this specific repo.

Ported from \`ubuntu/steps/activate.sh\`'s existing personal-license branch (success is determined from output text - "Next license update check is after" - since Unity's exit code for personal activation is always 1), wired through the same retry loop already used for serial/floating-license activation on each platform.

## Test plan
- [x] \`bash scripts/validate-platform-scripts.sh\` passes
- [x] PowerShell syntax check (PSParser) on \`activate.ps1\`
- [x] Isolated logic test: personal-license success detection correctly reads exit code 0 from the "Next license update check is after" marker
- [ ] CI green
- [ ] Re-verify against unity-test-runner#310's Windows matrix after release - expect this to actually fix Windows, not just reduce flakiness