### PR TITLE
chore: bump version to 0.1.39 for #204's mac/windows personal-license activation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "description": "GameCI CLI - automation for game engines",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Follow-up release for #204 - the real root-cause fix for unity-test-runner's Windows failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version from 0.1.38 to 0.1.39.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->