### PR TITLE
fix: prefer serial credentials over personal-license when both are set

### DIFF
--- a/dist/platforms/mac/steps/activate.sh
+++ b/dist/platforms/mac/steps/activate.sh
@@ -13,7 +13,15 @@ ACTIVATE_MAX_ATTEMPTS="${UNITY_LICENSE_RETRY_MAX_ATTEMPTS:-4}"
 ACTIVATE_RETRY_DELAY_SECONDS=20
 ACTIVATE_TRANSIENT_LICENSE_ERROR_PATTERN='TimeoutPolicy did not complete|Access token is unavailable|entitlement groups and 0 free entitlements|License activation has failed|No valid Unity Editor license found|License is not active'
 
-if [[ -n "$UNITY_LICENSE" ]] || [[ -n "$UNITY_LICENSE_FILE" ]]; then
+# Serial mode is preferred over personal-license (below) whenever both are
+# configured: a manually-activated .ulf is bound to the machine fingerprint
+# of whatever machine originally requested it, which real CI evidence shows
+# genuinely doesn't match every runner - confirmed via unity-test-runner's
+# own CI, where the identical .ulf activates cleanly through this same
+# script's ubuntu counterpart but fails windows with "Machine bindings
+# don't match" every single time. Serial credentials have no such
+# constraint, so given a choice, prefer them.
+if [[ -z "$UNITY_SERIAL" || -z "$UNITY_EMAIL" || -z "$UNITY_PASSWORD" ]] && { [[ -n "$UNITY_LICENSE" ]] || [[ -n "$UNITY_LICENSE_FILE" ]]; }; then
   #
   # PERSONAL LICENSE MODE
   #

--- a/dist/platforms/ubuntu/steps/activate.sh
+++ b/dist/platforms/ubuntu/steps/activate.sh
@@ -12,7 +12,12 @@ UNITY_ACTIVATE_MAX_ATTEMPTS="${UNITY_LICENSE_RETRY_MAX_ATTEMPTS:-4}"
 UNITY_ACTIVATE_RETRY_DELAY_SECONDS=20
 UNITY_ACTIVATE_TRANSIENT_PATTERN='TimeoutPolicy did not complete|Access token is unavailable|entitlement groups and 0 free entitlements|License activation has failed|No valid Unity Editor license found|License is not active'
 
-if [[ -n "$UNITY_LICENSE" ]] || [[ -n "$UNITY_LICENSE_FILE" ]]; then
+# Serial mode is preferred over personal-license (below) whenever both are
+# configured - see mac/steps/activate.sh's matching comment: a manually-
+# activated .ulf is bound to the machine fingerprint of whatever machine
+# originally requested it, which doesn't necessarily match every runner.
+# Serial credentials have no such constraint, so given a choice, prefer them.
+if [[ -z "$UNITY_SERIAL" || -z "$UNITY_EMAIL" || -z "$UNITY_PASSWORD" ]] && { [[ -n "$UNITY_LICENSE" ]] || [[ -n "$UNITY_LICENSE_FILE" ]]; }; then
   #
   # PERSONAL LICENSE MODE
   #

--- a/dist/platforms/windows/activate.ps1
+++ b/dist/platforms/windows/activate.ps1
@@ -19,7 +19,16 @@ $MaxAttempts = if ($Env:UNITY_LICENSE_RETRY_MAX_ATTEMPTS) { [int]$Env:UNITY_LICE
 $RetryDelaySeconds = 20
 $TransientPattern = 'TimeoutPolicy did not complete|Access token is unavailable|entitlement groups and 0 free entitlements|License activation has failed|No valid Unity Editor license found|License is not active'
 
-if ($Env:UNITY_LICENSE -or $Env:UNITY_LICENSE_FILE) {
+# Serial mode is preferred over personal-license (below) whenever both are
+# configured - see mac/steps/activate.sh's matching comment: a manually-
+# activated .ulf is bound to the machine fingerprint of whatever machine
+# originally requested it, which real CI evidence shows genuinely doesn't
+# match every runner (confirmed "Machine bindings don't match" on windows
+# specifically, with the identical .ulf activating cleanly elsewhere).
+# Serial credentials have no such constraint, so given a choice, prefer them.
+$HasSerialCredentials = $Env:UNITY_SERIAL -and $Env:UNITY_EMAIL -and $Env:UNITY_PASSWORD
+
+if ((-not $HasSerialCredentials) -and ($Env:UNITY_LICENSE -or $Env:UNITY_LICENSE_FILE)) {
   #
   # PERSONAL LICENSE MODE
   #


### PR DESCRIPTION
## Summary
#204 added personal-license (\`UNITY_LICENSE\`) activation to mac/windows, but all three platforms checked it *before* serial mode - so even after syncing working \`UNITY_SERIAL\`/\`EMAIL\`/\`PASSWORD\` into unity-test-runner ([game-ci/unity-builder#844](https://github.com/game-ci/unity-builder/pull/844)'s \`sync-secrets.yml\` run), Windows kept using the broken \`.ulf\` path anyway, since \`UNITY_LICENSE\` was still present and checked first. Confirmed live: the identical "Machine bindings don't match" failure persisted after the secret sync.

Serial credentials have no machine-binding constraint, so prefer them whenever both are configured - personal-license stays the fallback for repos that only have \`UNITY_LICENSE\`.

## Test plan
- [x] \`bash scripts/validate-platform-scripts.sh\` passes
- [x] PowerShell syntax check (PSParser) on \`activate.ps1\`
- [x] Isolated logic test: all 4 credential combinations (both/license-only/serial-only/neither) resolve to the correct branch
- [ ] CI green
- [ ] Re-verify against unity-test-runner#310's Windows matrix after release