### PR TITLE
chore: bump version to 0.1.40 for #206's serial-over-personal-license priority fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@game-ci/cli",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "description": "GameCI CLI - automation for game engines",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Follow-up release for #206 - this should be the actual fix for unity-test-runner's Windows failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 0.1.40.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->