### PR TITLE
feat: exponential backoff for license retries (20s/40s/80s/160s...)

### DIFF
--- a/dist/platforms/mac/steps/activate.sh
+++ b/dist/platforms/mac/steps/activate.sh
@@ -64,8 +64,14 @@ if [[ -z "$UNITY_SERIAL" || -z "$UNITY_EMAIL" || -z "$UNITY_PASSWORD" ]] && { [[
     UNITY_EXIT_CODE=1
 
     if [ "$ACTIVATE_ATTEMPT" -lt "$ACTIVATE_MAX_ATTEMPTS" ] && grep -qE "$ACTIVATE_TRANSIENT_LICENSE_ERROR_PATTERN" "$ACTIVATE_LOG"; then
-      echo "Unity activation failed with a known-transient licensing error (attempt $ACTIVATE_ATTEMPT/$ACTIVATE_MAX_ATTEMPTS) - retrying in ${ACTIVATE_RETRY_DELAY_SECONDS}s..."
-      sleep "$ACTIVATE_RETRY_DELAY_SECONDS"
+      # Exponential backoff (20s, 40s, 80s, ...): a genuine Unity license-
+      # server outage can outlast a flat delay's total retry window, seen
+      # live this session on both mac and windows - doubling the wait each
+      # attempt gives meaningfully more headroom to ride one out without
+      # slowing down the common case (most retries succeed on attempt 2).
+      ACTIVATE_RETRY_DELAY=$((ACTIVATE_RETRY_DELAY_SECONDS * (1 << (ACTIVATE_ATTEMPT - 1))))
+      echo "Unity activation failed with a known-transient licensing error (attempt $ACTIVATE_ATTEMPT/$ACTIVATE_MAX_ATTEMPTS) - retrying in ${ACTIVATE_RETRY_DELAY}s..."
+      sleep "$ACTIVATE_RETRY_DELAY"
       continue
     fi
 
@@ -97,8 +103,14 @@ elif [[ -n "$UNITY_SERIAL" && -n "$UNITY_EMAIL" && -n "$UNITY_PASSWORD" ]]; then
     fi
 
     if [ "$ACTIVATE_ATTEMPT" -lt "$ACTIVATE_MAX_ATTEMPTS" ] && grep -qE "$ACTIVATE_TRANSIENT_LICENSE_ERROR_PATTERN" "$ACTIVATE_LOG"; then
-      echo "Unity activation failed with a known-transient licensing error (attempt $ACTIVATE_ATTEMPT/$ACTIVATE_MAX_ATTEMPTS) - retrying in ${ACTIVATE_RETRY_DELAY_SECONDS}s..."
-      sleep "$ACTIVATE_RETRY_DELAY_SECONDS"
+      # Exponential backoff (20s, 40s, 80s, ...): a genuine Unity license-
+      # server outage can outlast a flat delay's total retry window, seen
+      # live this session on both mac and windows - doubling the wait each
+      # attempt gives meaningfully more headroom to ride one out without
+      # slowing down the common case (most retries succeed on attempt 2).
+      ACTIVATE_RETRY_DELAY=$((ACTIVATE_RETRY_DELAY_SECONDS * (1 << (ACTIVATE_ATTEMPT - 1))))
+      echo "Unity activation failed with a known-transient licensing error (attempt $ACTIVATE_ATTEMPT/$ACTIVATE_MAX_ATTEMPTS) - retrying in ${ACTIVATE_RETRY_DELAY}s..."
+      sleep "$ACTIVATE_RETRY_DELAY"
       continue
     fi
 

--- a/dist/platforms/mac/steps/build.sh
+++ b/dist/platforms/mac/steps/build.sh
@@ -214,8 +214,11 @@ for ATTEMPT in $(seq 1 "$UNITY_BUILD_MAX_ATTEMPTS"); do
   fi
 
   if [ "$ATTEMPT" -lt "$UNITY_BUILD_MAX_ATTEMPTS" ] && grep -qE "$UNITY_BUILD_TRANSIENT_LICENSE_ERROR_PATTERN" "$BUILD_LOG"; then
-    echo "Unity build failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_BUILD_MAX_ATTEMPTS) - retrying in ${UNITY_BUILD_RETRY_DELAY_SECONDS}s..."
-    sleep "$UNITY_BUILD_RETRY_DELAY_SECONDS"
+    # Exponential backoff (20s, 40s, 80s, ...) - see activate.sh's matching
+    # comment.
+    UNITY_BUILD_RETRY_DELAY=$((UNITY_BUILD_RETRY_DELAY_SECONDS * (1 << (ATTEMPT - 1))))
+    echo "Unity build failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_BUILD_MAX_ATTEMPTS) - retrying in ${UNITY_BUILD_RETRY_DELAY}s..."
+    sleep "$UNITY_BUILD_RETRY_DELAY"
     continue
   fi
 

--- a/dist/platforms/mac/steps/return_license.sh
+++ b/dist/platforms/mac/steps/return_license.sh
@@ -50,8 +50,10 @@ if [[ -n "$UNITY_LICENSING_SERVER" ]]; then
     fi
 
     if [ "$ATTEMPT" -lt "$UNITY_LICENSE_RETURN_MAX_ATTEMPTS" ] && grep -qE "$UNITY_LICENSE_RETURN_TRANSIENT_PATTERN" "$RETURN_LOG"; then
-      echo "Floating license return failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_LICENSE_RETURN_MAX_ATTEMPTS) - retrying in ${UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS}s..."
-      sleep "$UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS"
+      # Exponential backoff - see mac/steps/activate.sh's matching comment.
+      UNITY_LICENSE_RETURN_DELAY=$((UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS * (1 << (ATTEMPT - 1))))
+      echo "Floating license return failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_LICENSE_RETURN_MAX_ATTEMPTS) - retrying in ${UNITY_LICENSE_RETURN_DELAY}s..."
+      sleep "$UNITY_LICENSE_RETURN_DELAY"
       continue
     fi
 
@@ -85,8 +87,10 @@ elif [[ -n "$UNITY_SERIAL" ]]; then
     fi
 
     if [ "$ATTEMPT" -lt "$UNITY_LICENSE_RETURN_MAX_ATTEMPTS" ] && grep -qE "$UNITY_LICENSE_RETURN_TRANSIENT_PATTERN" "$RETURN_LOG"; then
-      echo "License return failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_LICENSE_RETURN_MAX_ATTEMPTS) - retrying in ${UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS}s..."
-      sleep "$UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS"
+      # Exponential backoff - see mac/steps/activate.sh's matching comment.
+      UNITY_LICENSE_RETURN_DELAY=$((UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS * (1 << (ATTEMPT - 1))))
+      echo "License return failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_LICENSE_RETURN_MAX_ATTEMPTS) - retrying in ${UNITY_LICENSE_RETURN_DELAY}s..."
+      sleep "$UNITY_LICENSE_RETURN_DELAY"
       continue
     fi
 

--- a/dist/platforms/ubuntu/steps/activate.sh
+++ b/dist/platforms/ubuntu/steps/activate.sh
@@ -66,8 +66,10 @@ if [[ -z "$UNITY_SERIAL" || -z "$UNITY_EMAIL" || -z "$UNITY_PASSWORD" ]] && { [[
     fi
 
     if [ "$ATTEMPT" -lt "$UNITY_ACTIVATE_MAX_ATTEMPTS" ] && grep -qE "$UNITY_ACTIVATE_TRANSIENT_PATTERN" <<< "$ACTIVATION_OUTPUT"; then
-      echo "Unity activation failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_ACTIVATE_MAX_ATTEMPTS) - retrying in ${UNITY_ACTIVATE_RETRY_DELAY_SECONDS}s..."
-      sleep "$UNITY_ACTIVATE_RETRY_DELAY_SECONDS"
+      # Exponential backoff - see mac/steps/activate.sh's matching comment.
+      UNITY_ACTIVATE_RETRY_DELAY=$((UNITY_ACTIVATE_RETRY_DELAY_SECONDS * (1 << (ATTEMPT - 1))))
+      echo "Unity activation failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_ACTIVATE_MAX_ATTEMPTS) - retrying in ${UNITY_ACTIVATE_RETRY_DELAY}s..."
+      sleep "$UNITY_ACTIVATE_RETRY_DELAY"
       continue
     fi
 
@@ -105,8 +107,10 @@ elif [[ -n "$UNITY_SERIAL" && -n "$UNITY_EMAIL" && -n "$UNITY_PASSWORD" ]]; then
     fi
 
     if [ "$ATTEMPT" -lt "$UNITY_ACTIVATE_MAX_ATTEMPTS" ] && grep -qE "$UNITY_ACTIVATE_TRANSIENT_PATTERN" "$ACTIVATE_LOG"; then
-      echo "Unity activation failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_ACTIVATE_MAX_ATTEMPTS) - retrying in ${UNITY_ACTIVATE_RETRY_DELAY_SECONDS}s..."
-      sleep "$UNITY_ACTIVATE_RETRY_DELAY_SECONDS"
+      # Exponential backoff - see mac/steps/activate.sh's matching comment.
+      UNITY_ACTIVATE_RETRY_DELAY=$((UNITY_ACTIVATE_RETRY_DELAY_SECONDS * (1 << (ATTEMPT - 1))))
+      echo "Unity activation failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_ACTIVATE_MAX_ATTEMPTS) - retrying in ${UNITY_ACTIVATE_RETRY_DELAY}s..."
+      sleep "$UNITY_ACTIVATE_RETRY_DELAY"
       continue
     fi
 
@@ -130,8 +134,10 @@ elif [[ -n "$UNITY_LICENSING_SERVER" ]]; then
     fi
 
     if [ "$ATTEMPT" -lt "$UNITY_ACTIVATE_MAX_ATTEMPTS" ] && grep -qE "$UNITY_ACTIVATE_TRANSIENT_PATTERN" "$ACTIVATE_LOG"; then
-      echo "Floating license acquisition failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_ACTIVATE_MAX_ATTEMPTS) - retrying in ${UNITY_ACTIVATE_RETRY_DELAY_SECONDS}s..."
-      sleep "$UNITY_ACTIVATE_RETRY_DELAY_SECONDS"
+      # Exponential backoff - see mac/steps/activate.sh's matching comment.
+      UNITY_ACTIVATE_RETRY_DELAY=$((UNITY_ACTIVATE_RETRY_DELAY_SECONDS * (1 << (ATTEMPT - 1))))
+      echo "Floating license acquisition failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_ACTIVATE_MAX_ATTEMPTS) - retrying in ${UNITY_ACTIVATE_RETRY_DELAY}s..."
+      sleep "$UNITY_ACTIVATE_RETRY_DELAY"
       continue
     fi
 

--- a/dist/platforms/ubuntu/steps/return_license.sh
+++ b/dist/platforms/ubuntu/steps/return_license.sh
@@ -35,8 +35,10 @@ if [[ -n "$UNITY_LICENSING_SERVER" ]]; then  #
     fi
 
     if [ "$ATTEMPT" -lt "$UNITY_LICENSE_RETURN_MAX_ATTEMPTS" ] && grep -qE "$UNITY_LICENSE_RETURN_TRANSIENT_PATTERN" "$RETURN_LOG"; then
-      echo "Floating license return failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_LICENSE_RETURN_MAX_ATTEMPTS) - retrying in ${UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS}s..."
-      sleep "$UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS"
+      # Exponential backoff - see mac/steps/activate.sh's matching comment.
+      UNITY_LICENSE_RETURN_DELAY=$((UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS * (1 << (ATTEMPT - 1))))
+      echo "Floating license return failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_LICENSE_RETURN_MAX_ATTEMPTS) - retrying in ${UNITY_LICENSE_RETURN_DELAY}s..."
+      sleep "$UNITY_LICENSE_RETURN_DELAY"
       continue
     fi
 
@@ -70,8 +72,10 @@ elif [[ -n "$UNITY_SERIAL" ]]; then
     fi
 
     if [ "$ATTEMPT" -lt "$UNITY_LICENSE_RETURN_MAX_ATTEMPTS" ] && grep -qE "$UNITY_LICENSE_RETURN_TRANSIENT_PATTERN" "$RETURN_LOG"; then
-      echo "License return failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_LICENSE_RETURN_MAX_ATTEMPTS) - retrying in ${UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS}s..."
-      sleep "$UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS"
+      # Exponential backoff - see mac/steps/activate.sh's matching comment.
+      UNITY_LICENSE_RETURN_DELAY=$((UNITY_LICENSE_RETURN_RETRY_DELAY_SECONDS * (1 << (ATTEMPT - 1))))
+      echo "License return failed with a known-transient licensing error (attempt $ATTEMPT/$UNITY_LICENSE_RETURN_MAX_ATTEMPTS) - retrying in ${UNITY_LICENSE_RETURN_DELAY}s..."
+      sleep "$UNITY_LICENSE_RETURN_DELAY"
       continue
     fi
 

--- a/dist/platforms/windows/activate.ps1
+++ b/dist/platforms/windows/activate.ps1
@@ -67,8 +67,11 @@ if ((-not $HasSerialCredentials) -and ($Env:UNITY_LICENSE -or $Env:UNITY_LICENSE
     $global:UNITY_EXIT_CODE = 1
 
     if ($Attempt -lt $MaxAttempts -and $ActivationText -match $TransientPattern) {
-      Write-Host "Unity activation failed with a known-transient licensing error (attempt $Attempt/$MaxAttempts) - retrying in ${RetryDelaySeconds}s..."
-      Start-Sleep -Seconds $RetryDelaySeconds
+      # Exponential backoff (20s, 40s, 80s, ...) - see mac/steps/activate.sh's
+      # matching comment.
+      $CurrentRetryDelay = $RetryDelaySeconds * [math]::Pow(2, $Attempt - 1)
+      Write-Host "Unity activation failed with a known-transient licensing error (attempt $Attempt/$MaxAttempts) - retrying in ${CurrentRetryDelay}s..."
+      Start-Sleep -Seconds $CurrentRetryDelay
       continue
     }
     break
@@ -114,8 +117,11 @@ else {
     if ($global:UNITY_EXIT_CODE -eq 0) { break }
 
     if ($Attempt -lt $MaxAttempts -and $LogContent -match $TransientPattern) {
-      Write-Host "Unity activation failed with a known-transient licensing error (attempt $Attempt/$MaxAttempts) - retrying in ${RetryDelaySeconds}s..."
-      Start-Sleep -Seconds $RetryDelaySeconds
+      # Exponential backoff (20s, 40s, 80s, ...) - see mac/steps/activate.sh's
+      # matching comment.
+      $CurrentRetryDelay = $RetryDelaySeconds * [math]::Pow(2, $Attempt - 1)
+      Write-Host "Unity activation failed with a known-transient licensing error (attempt $Attempt/$MaxAttempts) - retrying in ${CurrentRetryDelay}s..."
+      Start-Sleep -Seconds $CurrentRetryDelay
       continue
     }
 

--- a/dist/platforms/windows/return_license.ps1
+++ b/dist/platforms/windows/return_license.ps1
@@ -40,8 +40,10 @@ if ($env:UNITY_LICENSING_SERVER) {
     if ($ReturnExitCode -eq 0) { break }
 
     if ($Attempt -lt $MaxAttempts -and $ReturnText -match $TransientPattern) {
-      Write-Host "Floating license return failed with a known-transient licensing error (attempt $Attempt/$MaxAttempts) - retrying in ${RetryDelaySeconds}s..."
-      Start-Sleep -Seconds $RetryDelaySeconds
+      # Exponential backoff - see mac/steps/activate.sh's matching comment.
+      $CurrentRetryDelay = $RetryDelaySeconds * [math]::Pow(2, $Attempt - 1)
+      Write-Host "Floating license return failed with a known-transient licensing error (attempt $Attempt/$MaxAttempts) - retrying in ${CurrentRetryDelay}s..."
+      Start-Sleep -Seconds $CurrentRetryDelay
       continue
     }
     break
@@ -72,8 +74,10 @@ else {
     if ($ReturnExitCode -eq 0) { break }
 
     if ($Attempt -lt $MaxAttempts -and $LogContent -match $TransientPattern) {
-      Write-Host "License return failed with a known-transient licensing error (attempt $Attempt/$MaxAttempts) - retrying in ${RetryDelaySeconds}s..."
-      Start-Sleep -Seconds $RetryDelaySeconds
+      # Exponential backoff - see mac/steps/activate.sh's matching comment.
+      $CurrentRetryDelay = $RetryDelaySeconds * [math]::Pow(2, $Attempt - 1)
+      Write-Host "License return failed with a known-transient licensing error (attempt $Attempt/$MaxAttempts) - retrying in ${CurrentRetryDelay}s..."
+      Start-Sleep -Seconds $CurrentRetryDelay
       continue
     }
     break

--- a/dist/platforms/windows/steps/test.ps1
+++ b/dist/platforms/windows/steps/test.ps1
@@ -235,8 +235,10 @@ foreach ($Platform in $Platforms) {
     if ($TestExitCode -eq 0 -or $TestExitCode -eq 2) { break }
 
     if ($Attempt -lt $MaxAttempts -and $LogContent -match $TransientPattern) {
-      Write-Host "Unity test run failed with a known-transient licensing error (attempt $Attempt/$MaxAttempts) - retrying in ${RetryDelaySeconds}s..."
-      Start-Sleep -Seconds $RetryDelaySeconds
+      # Exponential backoff - see mac/steps/activate.sh's matching comment.
+      $CurrentRetryDelay = $RetryDelaySeconds * [math]::Pow(2, $Attempt - 1)
+      Write-Host "Unity test run failed with a known-transient licensing error (attempt $Attempt/$MaxAttempts) - retrying in ${CurrentRetryDelay}s..."
+      Start-Sleep -Seconds $CurrentRetryDelay
       continue
     }
 


### PR DESCRIPTION
## Summary
All license-retry sites across mac, ubuntu, and windows (activate, build/test, return) used a flat 20s delay between attempts - with the default 4 attempts, that's only 60s of total retry window. Real CI evidence this session showed genuine Unity license-server outages that outlasted that window on both mac and windows, exhausting all retries even though the underlying signature was correctly identified as transient.

Doubling the delay each attempt (20s, 40s, 80s with the default 4 attempts - 140s total vs 60s before) gives meaningfully more headroom to ride out a real outage, without slowing down the common case: most retries still succeed on the second attempt, which still only waits 20s.

## Test plan
- [x] \`bash scripts/validate-platform-scripts.sh\` passes
- [x] PowerShell syntax check (PSParser) on all three \`.ps1\` files
- [x] Verified the exponential formula produces 20/40/80/160 in both bash and PowerShell
- [ ] CI green