### PR TITLE
feat(steam-deploy): multi-depot, TOTP, and configVdf support

### DIFF
--- a/plugins/steam-deploy/src/steam-deploy-command.ts
+++ b/plugins/steam-deploy/src/steam-deploy-command.ts
@@ -3,6 +3,8 @@ import * as path from "node:path";
 import { generateAppVdf, generateDepotVdf } from "./vdf-generator";
 import { SteamCmdRunner } from "./steamcmd-runner";
 
+const MAX_EXTRA_DEPOTS = 9;
+
 export interface SteamDeployOptions {
   buildPath?: string;
   appId?: string;
@@ -13,6 +15,13 @@ export interface SteamDeployOptions {
   steamCmdPath?: string;
   steamConfigDir?: string;
   extraExclusions?: string;
+  debugBranch?: boolean;
+  /**
+   * When additional depots are used (depotNPath), the first extra depot ID
+   * defaults to depotId+1, depotId+2, ... . Set this to override where that
+   * sequence starts - matches steam-deploy's own firstDepotIdOverride input.
+   */
+  firstDepotIdOverride?: string;
   [key: string]: unknown;
 }
 
@@ -63,7 +72,29 @@ export class SteamDeployCommand {
         describe:
           "Comma-separated extra file-exclusion glob patterns for the depot, beyond the built-in defaults (*.pdb, *.log, *.vdf, Burst debug/backup folders).",
         type: "string",
+      })
+      .option("debugBranch", {
+        describe: "Ship debug symbols (*.pdb, Burst debug/backup folders) instead of excluding them.",
+        type: "boolean",
+        default: false,
+      })
+      .option("firstDepotIdOverride", {
+        describe:
+          "Depot ID to start numbering extra depots (depot1Path..depot9Path) from. Defaults to depotId+1, depotId+2, ...",
+        type: "string",
       });
+
+    for (let index = 1; index <= MAX_EXTRA_DEPOTS; index++) {
+      yargs
+        .option(`depot${index}Path`, {
+          describe: `Path (relative to the build) mapped by extra depot #${index}, beyond the primary --depotId depot.`,
+          type: "string",
+        })
+        .option(`depot${index}InstallScriptPath`, {
+          describe: `Install script (relative to extra depot #${index}'s content) to run after it installs.`,
+          type: "string",
+        });
+    }
   }
 
   public async execute(options: SteamDeployOptions): Promise<boolean> {
@@ -91,24 +122,44 @@ export class SteamDeployCommand {
     const extraExclusions = options.extraExclusions
       ? options.extraExclusions.split(",").map((s) => s.trim())
       : undefined;
+    const includeDebugSymbols = options.debugBranch ?? false;
 
     const absoluteBuildPath = path.resolve(buildPath);
     const contentRoot = mode === "docker" ? "/build" : absoluteBuildPath.replace(/\\/g, "/");
-    const depotFileName = `depot_build_${depotId}.vdf`;
 
-    const depotVdf = generateDepotVdf({ depotId, extraExclusions });
-    const appVdf = generateAppVdf({ appId, depotId, branch, description, depotVdfFileName: depotFileName })
+    const extraDepots = this.collectExtraDepots(options, depotId);
+    const allDepots = [{ depotId, localPath: undefined as string | undefined, installScript: undefined as string | undefined }, ...extraDepots];
+
+    const depotEntries = allDepots.map((depot) => ({
+      depotId: depot.depotId,
+      vdfFileName: `depot_build_${depot.depotId}.vdf`,
+    }));
+
+    for (const depot of allDepots) {
+      const depotVdf = generateDepotVdf({
+        depotId: depot.depotId,
+        localPath: depot.localPath,
+        installScript: depot.installScript,
+        extraExclusions: depot.depotId === depotId ? extraExclusions : undefined,
+        includeDebugSymbols,
+      });
+      fs.writeFileSync(path.join(absoluteBuildPath, `depot_build_${depot.depotId}.vdf`), depotVdf, "utf8");
+    }
+
+    const appVdf = generateAppVdf({ appId, depots: depotEntries, branch, description })
       // generateAppVdf's contentroot/buildoutput default to "./" - override to
       // the path the running steamcmd process will actually see (an absolute
       // host path for local mode, or the container mount point for docker).
       .replace('"contentroot" "./"', `"contentroot" "${contentRoot}"`)
       .replace('"buildoutput" "./"', `"buildoutput" "${contentRoot}"`);
 
-    fs.writeFileSync(path.join(absoluteBuildPath, depotFileName), depotVdf, "utf8");
     fs.writeFileSync(path.join(absoluteBuildPath, "manifest.vdf"), appVdf, "utf8");
 
-    console.log(`Deploying ${absoluteBuildPath} to Steam app ${appId}, depot ${depotId}, branch "${branch}"`);
+    const depotIdList = depotEntries.map((d) => d.depotId).join(", ");
+    console.log(`Deploying ${absoluteBuildPath} to Steam app ${appId}, depot(s) ${depotIdList}, branch "${branch}"`);
 
+    // Steam Guard TOTP and a pre-authorized config.vdf are both credentials -
+    // env vars only, never CLI arguments (argv can leak through process listings).
     const runner = new SteamCmdRunner();
     const result = await runner.run({
       buildDir: absoluteBuildPath,
@@ -117,6 +168,8 @@ export class SteamDeployCommand {
       mode,
       steamCmdPath: options.steamCmdPath,
       steamConfigDir: options.steamConfigDir,
+      totp: process.env.STEAM_TOTP,
+      configVdfBase64: process.env.STEAM_CONFIG_VDF_BASE64,
     });
 
     if (!result.success) {
@@ -130,5 +183,33 @@ export class SteamDeployCommand {
     }
 
     return true;
+  }
+
+  /**
+   * Reads depot1Path..depot9Path (+ matching depot{n}InstallScriptPath) and
+   * assigns each a sequential depot ID after the primary --depotId, starting
+   * from --firstDepotIdOverride if given - matches steam-deploy's own
+   * up-to-9-extra-depots convention.
+   */
+  private collectExtraDepots(
+    options: SteamDeployOptions,
+    primaryDepotId: string,
+  ): Array<{ depotId: string; localPath: string; installScript?: string }> {
+    const firstExtraId = options.firstDepotIdOverride
+      ? Number.parseInt(options.firstDepotIdOverride, 10)
+      : Number.parseInt(primaryDepotId, 10) + 1;
+
+    const extras: Array<{ depotId: string; localPath: string; installScript?: string }> = [];
+    for (let index = 1; index <= MAX_EXTRA_DEPOTS; index++) {
+      const localPath = options[`depot${index}Path`] as string | undefined;
+      if (!localPath) continue;
+
+      extras.push({
+        depotId: String(firstExtraId + extras.length),
+        localPath: `./${localPath.replace(/^\.?\/*/, "")}/*`,
+        installScript: options[`depot${index}InstallScriptPath`] as string | undefined,
+      });
+    }
+    return extras;
   }
 }

--- a/plugins/steam-deploy/src/steamcmd-runner.test.ts
+++ b/plugins/steam-deploy/src/steamcmd-runner.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { EventEmitter } from "node:events";
+import { SteamCmdRunner } from "./steamcmd-runner";
+
+/** A fake child_process that immediately succeeds with the given stdout, matching the shape SteamCmdRunner reads from. */
+function fakeSpawn(stdout: string, exitCode = 0) {
+  const calls: Array<{ command: string; args: string[] }> = [];
+  const spawnFn = vi.fn((command: string, args: string[]) => {
+    calls.push({ command, args });
+    const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    // Deferred so listeners are attached before events fire - matches real child_process timing.
+    setImmediate(() => {
+      child.stdout.emit("data", Buffer.from(stdout));
+      child.emit("close", exitCode);
+    });
+    return child as unknown as ReturnType<typeof import("node:child_process").spawn>;
+  });
+  return { spawnFn, calls };
+}
+
+describe("SteamCmdRunner", () => {
+  let tempDir: string;
+  let localSteamCmdPath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "steamcmd-runner-test-"));
+    localSteamCmdPath = path.join(tempDir, "steamcmd.sh");
+    fs.writeFileSync(localSteamCmdPath, "#!/bin/sh\n");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("logs in with username/password only when no totp is given", async () => {
+    const { spawnFn, calls } = fakeSpawn("Success!");
+    const runner = new SteamCmdRunner(spawnFn);
+
+    await runner.run({
+      buildDir: tempDir,
+      username: "u",
+      password: "p",
+      mode: "local",
+      steamCmdPath: localSteamCmdPath,
+    });
+
+    expect(calls[0].args).toEqual([
+      "+login",
+      "u",
+      "p",
+      "+run_app_build",
+      `${tempDir.replace(/\\/g, "/")}/manifest.vdf`,
+      "+quit",
+    ]);
+  });
+
+  it("prepends +set_steam_guard_code when totp is given", async () => {
+    const { spawnFn, calls } = fakeSpawn("Success!");
+    const runner = new SteamCmdRunner(spawnFn);
+
+    await runner.run({
+      buildDir: tempDir,
+      username: "u",
+      password: "p",
+      mode: "local",
+      steamCmdPath: localSteamCmdPath,
+      totp: "123456",
+    });
+
+    expect(calls[0].args.slice(0, 5)).toEqual(["+set_steam_guard_code", "123456", "+login", "u", "p"]);
+  });
+
+  it("writes configVdfBase64 to steamHome/config/config.vdf in local mode", async () => {
+    const { spawnFn } = fakeSpawn("Success!");
+    const runner = new SteamCmdRunner(spawnFn);
+    const steamHome = path.join(tempDir, "steam-home");
+    const decoded = "fake config.vdf contents";
+
+    await runner.run({
+      buildDir: tempDir,
+      username: "u",
+      password: "p",
+      mode: "local",
+      steamCmdPath: localSteamCmdPath,
+      steamHome,
+      configVdfBase64: Buffer.from(decoded).toString("base64"),
+    });
+
+    expect(fs.readFileSync(path.join(steamHome, "config", "config.vdf"), "utf8")).toBe(decoded);
+  });
+
+  it("does not write config.vdf when totp is given, even if configVdfBase64 is also set", async () => {
+    const { spawnFn } = fakeSpawn("Success!");
+    const runner = new SteamCmdRunner(spawnFn);
+    const steamHome = path.join(tempDir, "steam-home");
+
+    await runner.run({
+      buildDir: tempDir,
+      username: "u",
+      password: "p",
+      mode: "local",
+      steamCmdPath: localSteamCmdPath,
+      steamHome,
+      totp: "123456",
+      configVdfBase64: Buffer.from("should not be written").toString("base64"),
+    });
+
+    expect(fs.existsSync(path.join(steamHome, "config", "config.vdf"))).toBe(false);
+  });
+
+  it("runs via docker when mode=docker, mounting the build dir and a steamConfigDir when given", async () => {
+    const { spawnFn, calls } = fakeSpawn("Success!");
+    const runner = new SteamCmdRunner(spawnFn);
+
+    await runner.run({
+      buildDir: "/host/build",
+      username: "u",
+      password: "p",
+      mode: "docker",
+      steamConfigDir: "/host/steam-config",
+    });
+
+    expect(calls[0].command).toBe("docker");
+    expect(calls[0].args).toContain("-v");
+    expect(calls[0].args).toContain("/host/build:/build");
+    expect(calls[0].args).toContain("/host/steam-config:/home/steam/Steam");
+    expect(calls[0].args).toContain("cm2network/steamcmd:latest");
+  });
+
+  it("mounts a config.vdf written from configVdfBase64 in docker mode when no steamConfigDir is given", async () => {
+    const { spawnFn, calls } = fakeSpawn("Success!");
+    const runner = new SteamCmdRunner(spawnFn);
+    const steamHome = path.join(tempDir, "steam-home-docker");
+
+    await runner.run({
+      buildDir: "/host/build",
+      username: "u",
+      password: "p",
+      mode: "docker",
+      steamHome,
+      configVdfBase64: Buffer.from("docker config contents").toString("base64"),
+    });
+
+    expect(fs.readFileSync(path.join(steamHome, "config", "config.vdf"), "utf8")).toBe("docker config contents");
+    expect(calls[0].args).toContain(`${steamHome}:/home/steam/Steam`);
+  });
+
+  it("throws a clear error when local mode is requested but steamcmd can't be found", async () => {
+    const { spawnFn } = fakeSpawn("unused");
+    const runner = new SteamCmdRunner(spawnFn);
+
+    await expect(
+      runner.run({
+        buildDir: tempDir,
+        username: "u",
+        password: "p",
+        mode: "local",
+        steamCmdPath: path.join(tempDir, "does-not-exist.sh"),
+      }),
+    ).rejects.toThrow(/steamcmd was not found locally/);
+  });
+});

--- a/plugins/steam-deploy/src/steamcmd-runner.ts
+++ b/plugins/steam-deploy/src/steamcmd-runner.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import * as fs from "node:fs";
+import * as path from "node:path";
 import { parseSteamCmdOutput, type SteamCmdParseResult } from "./parse-steamcmd-output";
 
 export interface RunSteamCmdOptions {
@@ -13,6 +14,22 @@ export interface RunSteamCmdOptions {
   steamCmdPath?: string;
   /** Host directory containing Steam's own config.vdf, mounted into the Docker container so login sessions persist across runs. */
   steamConfigDir?: string;
+  /**
+   * Steam Guard TOTP code, passed to steamcmd via +set_steam_guard_code.
+   * Mutually exclusive with configVdfBase64 in practice (steam-deploy's own
+   * action treats them that way too - "If set, configVdf will be
+   * ignored.") - if both are given, totp takes priority.
+   */
+  totp?: string;
+  /**
+   * Base64-encoded contents of Steam's own config/config.vdf, written to
+   * steamHome/config/config.vdf before login so a previously-authorized
+   * session (SteamGuard already completed once, outside CI) can be reused
+   * without a TOTP code on every run. Ignored when totp is set.
+   */
+  configVdfBase64?: string;
+  /** Directory steamcmd treats as its home (holds config/, logs/, etc). Defaults to $STEAM_HOME or ~/Steam, matching steam-deploy's own default. */
+  steamHome?: string;
 }
 
 type SpawnFn = typeof spawn;
@@ -25,6 +42,30 @@ const LOCAL_STEAMCMD_CANDIDATES =
 function findLocalSteamCmd(explicitPath?: string): string | null {
   if (explicitPath) return fs.existsSync(explicitPath) ? explicitPath : null;
   return LOCAL_STEAMCMD_CANDIDATES.find((candidate) => fs.existsSync(candidate)) ?? null;
+}
+
+function resolveSteamHome(explicit?: string): string {
+  return explicit ?? process.env.STEAM_HOME ?? path.join(process.env.HOME ?? process.env.USERPROFILE ?? ".", "Steam");
+}
+
+/**
+ * Writes a base64-encoded config.vdf to steamHome/config/config.vdf, if
+ * given - lets a session authorized once (outside CI, where an interactive
+ * SteamGuard prompt is possible) be reused on every subsequent run without
+ * a fresh TOTP code. Ported from steam-deploy's own bash implementation.
+ */
+function writeConfigVdfIfProvided(steamHome: string, configVdfBase64?: string): void {
+  if (!configVdfBase64) return;
+
+  const configDir = path.join(steamHome, "config");
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(path.join(configDir, "config.vdf"), Buffer.from(configVdfBase64, "base64"));
+}
+
+function loginArgs(options: RunSteamCmdOptions): string[] {
+  // set_steam_guard_code must precede +login for steamcmd to associate it
+  // with that login attempt.
+  return options.totp ? ["+set_steam_guard_code", options.totp, "+login", options.username, options.password] : ["+login", options.username, options.password];
 }
 
 function runProcess(spawnFn: SpawnFn, command: string, args: string[]): Promise<{ output: string; exitCode: number }> {
@@ -56,11 +97,11 @@ export class SteamCmdRunner {
       );
     }
 
+    writeConfigVdfIfProvided(resolveSteamHome(options.steamHome), options.totp ? undefined : options.configVdfBase64);
+
     const manifestPath = `${options.buildDir}/manifest.vdf`.replace(/\\/g, "/");
     const { output, exitCode } = await runProcess(this.spawnFn, localPath, [
-      "+login",
-      options.username,
-      options.password,
+      ...loginArgs(options),
       "+run_app_build",
       manifestPath,
       "+quit",
@@ -74,14 +115,20 @@ export class SteamCmdRunner {
 
     if (options.steamConfigDir) {
       dockerArgs.push("-v", `${options.steamConfigDir}:/home/steam/Steam`);
+    } else if (!options.totp && options.configVdfBase64) {
+      // No mounted config dir was given, but a config.vdf was - write it to
+      // a real host directory and mount that, so it's actually visible
+      // inside the container (writing to resolveSteamHome() alone would
+      // land on the host filesystem, not the container's).
+      const steamHome = resolveSteamHome(options.steamHome);
+      writeConfigVdfIfProvided(steamHome, options.configVdfBase64);
+      dockerArgs.push("-v", `${steamHome}:/home/steam/Steam`);
     }
 
     dockerArgs.push(
       "cm2network/steamcmd:latest",
       "/home/steam/steamcmd/steamcmd.sh",
-      "+login",
-      options.username,
-      options.password,
+      ...loginArgs(options),
       "+run_app_build",
       "/build/manifest.vdf",
       "+quit",

--- a/plugins/steam-deploy/src/vdf-generator.test.ts
+++ b/plugins/steam-deploy/src/vdf-generator.test.ts
@@ -17,21 +17,76 @@ describe("generateDepotVdf", () => {
     expect(vdf).toContain('"FileExclusion"\t"*.pdb"');
     expect(vdf).toContain('"FileExclusion"\t"*.debug"');
   });
+
+  it("defaults LocalPath to the whole build (./*)", () => {
+    const vdf = generateDepotVdf({ depotId: "12345" });
+
+    expect(vdf).toContain('"LocalPath"\t"./*"');
+  });
+
+  it("uses a custom localPath when given - for multi-depot builds where each depot maps its own subdirectory", () => {
+    const vdf = generateDepotVdf({ depotId: "12345", localPath: "./depot1Path/*" });
+
+    expect(vdf).toContain('"LocalPath"\t"./depot1Path/*"');
+  });
+
+  it("omits debug-symbol exclusions when includeDebugSymbols is true - matches steam-deploy's own debugBranch input", () => {
+    const vdf = generateDepotVdf({ depotId: "12345", includeDebugSymbols: true });
+
+    expect(vdf).not.toContain('"FileExclusion"\t"*.pdb"');
+    expect(vdf).not.toContain("BurstDebugInformation");
+    // Always-excluded patterns (not debug-symbol-specific) still apply.
+    expect(vdf).toContain('"FileExclusion"\t"*.log"');
+  });
+
+  it("adds an InstallScript directive when given", () => {
+    const vdf = generateDepotVdf({ depotId: "12345", installScript: "install.vdf" });
+
+    expect(vdf).toContain('"InstallScript" "install.vdf"');
+  });
+
+  it("omits the InstallScript directive when not given", () => {
+    const vdf = generateDepotVdf({ depotId: "12345" });
+
+    expect(vdf).not.toContain("InstallScript");
+  });
 });
 
 describe("generateAppVdf", () => {
-  it("produces a manifest referencing the depot VDF file by name", () => {
+  it("produces a manifest referencing a single depot VDF file by name", () => {
     const vdf = generateAppVdf({
       appId: "999",
-      depotId: "1000",
+      depots: [{ depotId: "1000", vdfFileName: "depot_build_1000.vdf" }],
       branch: "beta",
       description: "Test build",
-      depotVdfFileName: "depot_build_1000.vdf",
     });
 
     expect(vdf).toContain('"appid" "999"');
     expect(vdf).toContain('"setlive" "beta"');
     expect(vdf).toContain('"desc" "Test build"');
     expect(vdf).toContain('"1000" "depot_build_1000.vdf"');
+  });
+
+  it("references every depot when given more than one", () => {
+    const vdf = generateAppVdf({
+      appId: "999",
+      depots: [
+        { depotId: "1000", vdfFileName: "depot_build_1000.vdf" },
+        { depotId: "1001", vdfFileName: "depot_build_1001.vdf" },
+        { depotId: "1002", vdfFileName: "depot_build_1002.vdf" },
+      ],
+      branch: "default",
+      description: "Test build",
+    });
+
+    expect(vdf).toContain('"1000" "depot_build_1000.vdf"');
+    expect(vdf).toContain('"1001" "depot_build_1001.vdf"');
+    expect(vdf).toContain('"1002" "depot_build_1002.vdf"');
+  });
+
+  it("throws when given no depots", () => {
+    expect(() =>
+      generateAppVdf({ appId: "999", depots: [], branch: "default", description: "x" }),
+    ).toThrow(/at least one depot/);
   });
 });

--- a/plugins/steam-deploy/src/vdf-generator.ts
+++ b/plugins/steam-deploy/src/vdf-generator.ts
@@ -1,27 +1,43 @@
 /**
- * Generates SteamCMD's two VDF (Valve Data Format) files: the app build
- * manifest and a depot definition. Ported from a real, production
- * PowerShell script (BuildVdfFiles.ps1) - the file-exclusion list in
- * particular reflects real hard-won Unity-build knowledge (Burst debug
- * info and backup folders that shouldn't ship to Steam).
+ * Generates SteamCMD's VDF (Valve Data Format) files: the app build
+ * manifest and one depot definition per depot. Ported from a real,
+ * production PowerShell script (BuildVdfFiles.ps1) - the file-exclusion
+ * list in particular reflects real hard-won Unity-build knowledge (Burst
+ * debug info and backup folders that shouldn't ship to Steam) - and from
+ * game-ci/steam-deploy's own multi-depot bash implementation, for parity
+ * with the up-to-9-depots-per-app support that action shipped.
  */
 
 export interface DepotVdfOptions {
   depotId: string;
+  /** Path (relative to the depot's own working directory) SteamCMD maps this depot's files from. Defaults to "./*" - the whole build. */
+  localPath?: string;
+  /** Path to an install script (relative to the depot's content) to run after this depot installs. */
+  installScript?: string;
   /** Glob-style exclusion patterns, e.g. "*.pdb". Applied in addition to the built-in defaults. */
   extraExclusions?: string[];
+  /**
+   * When true, ships debug symbols/directories instead of excluding them -
+   * matches game-ci/steam-deploy's own `debugBranch` input. Defaults to
+   * false (exclude them), the safer default for a release build.
+   */
+  includeDebugSymbols?: boolean;
 }
 
-const DEFAULT_EXCLUSIONS = [
+const ALWAYS_EXCLUDED = ["*.log", "*.vdf"];
+
+const DEBUG_SYMBOL_EXCLUSIONS = [
   "*.pdb",
-  "*.log",
-  "*.vdf",
   "*_BurstDebugInformation_DoNotShip*",
   "*_BackUpThisFolder_ButDontShipItWithYourGame*",
 ];
 
 export function generateDepotVdf(options: DepotVdfOptions): string {
-  const exclusions = [...DEFAULT_EXCLUSIONS, ...(options.extraExclusions ?? [])];
+  const exclusions = [
+    ...ALWAYS_EXCLUDED,
+    ...(options.includeDebugSymbols ? [] : DEBUG_SYMBOL_EXCLUSIONS),
+    ...(options.extraExclusions ?? []),
+  ];
   const exclusionLines = exclusions.map((pattern) => `    "FileExclusion"\t"${pattern}"`).join("\n");
 
   return [
@@ -30,26 +46,40 @@ export function generateDepotVdf(options: DepotVdfOptions): string {
     `    "depotid" "${options.depotId}"`,
     '    "FileMapping"',
     "    {",
-    '        "LocalPath"\t"./*"',
+    `        "LocalPath"\t"${options.localPath ?? "./*"}"`,
     '        "DepotPath"\t"."',
     '        "recursive"\t"1"',
     "    }",
     exclusionLines,
+    ...(options.installScript ? [`    "InstallScript" "${options.installScript}"`] : []),
     "}",
   ].join("\n");
 }
 
+export interface AppVdfDepotEntry {
+  depotId: string;
+  vdfFileName: string;
+}
+
 export interface AppVdfOptions {
   appId: string;
-  depotId: string;
+  /** One or more depots to include in the build - see game-ci/cli#212's multi-depot support. */
+  depots: AppVdfDepotEntry[];
   /** Steam branch to publish to (Steam's "setlive" field), e.g. "default", "beta". */
   branch: string;
   /** Human-readable build description shown in the Steam build history. */
   description: string;
-  depotVdfFileName: string;
 }
 
 export function generateAppVdf(options: AppVdfOptions): string {
+  if (options.depots.length === 0) {
+    throw new Error("generateAppVdf requires at least one depot");
+  }
+
+  const depotLines = options.depots
+    .map((depot) => `        "${depot.depotId}" "${depot.vdfFileName}"`)
+    .join("\n");
+
   return [
     '"appbuild"',
     "{",
@@ -60,7 +90,7 @@ export function generateAppVdf(options: AppVdfOptions): string {
     `    "setlive" "${options.branch}"`,
     '    "depots"',
     "    {",
-    `        "${options.depotId}" "${options.depotVdfFileName}"`,
+    depotLines,
     "    }",
     "}",
   ].join("\n");


### PR DESCRIPTION
## Summary
Brings `deploy steam` to feature parity with the old standalone `game-ci/steam-deploy` Action, ahead of converting that repo into a thin wrapper over this CLI:

- `generateDepotVdf`/`generateAppVdf` support multiple depots (each with its own `localPath`/`installScript`) and a `debugBranch` toggle that ships debug symbols instead of excluding them.
- `SteamCmdRunner` supports Steam Guard TOTP codes and a pre-authorized `config.vdf`, both read from environment variables only, never CLI arguments (argv can leak through process listings — same rule already applied to `STEAM_USERNAME`/`STEAM_PASSWORD`).
- `deploy steam` exposes `depot1Path`..`depot9Path` (+ matching `depot{n}InstallScriptPath`), `firstDepotIdOverride`, and `debugBranch`, and reads `STEAM_TOTP`/`STEAM_CONFIG_VDF_BASE64` from the environment — matching the old action's up-to-9-depots-per-app support.

## Test plan
- [x] `bunx vitest run` in `plugins/steam-deploy` — 23/23 passing (new `steamcmd-runner.test.ts` covers TOTP prefixing, config.vdf writing in both local/docker mode, and the local-steamcmd-not-found error path)
- [x] `bunx tsc --noEmit` in `plugins/steam-deploy` — clean