### PR TITLE
feat(steam-deploy): support a custom path/install-script for the primary depot

### DIFF
--- a/plugins/steam-deploy/src/steam-deploy-command.ts
+++ b/plugins/steam-deploy/src/steam-deploy-command.ts
@@ -22,6 +22,8 @@ export interface SteamDeployOptions {
    * sequence starts - matches steam-deploy's own firstDepotIdOverride input.
    */
   firstDepotIdOverride?: string;
+  depotPath?: string;
+  depotInstallScriptPath?: string;
   [key: string]: unknown;
 }
 
@@ -82,6 +84,14 @@ export class SteamDeployCommand {
         describe:
           "Depot ID to start numbering extra depots (depot1Path..depot9Path) from. Defaults to depotId+1, depotId+2, ...",
         type: "string",
+      })
+      .option("depotPath", {
+        describe: "Path (relative to the build) mapped by the primary --depotId depot. Defaults to the whole build.",
+        type: "string",
+      })
+      .option("depotInstallScriptPath", {
+        describe: "Install script (relative to the primary depot's content) to run after it installs.",
+        type: "string",
       });
 
     for (let index = 1; index <= MAX_EXTRA_DEPOTS; index++) {
@@ -128,7 +138,11 @@ export class SteamDeployCommand {
     const contentRoot = mode === "docker" ? "/build" : absoluteBuildPath.replace(/\\/g, "/");
 
     const extraDepots = this.collectExtraDepots(options, depotId);
-    const allDepots = [{ depotId, localPath: undefined as string | undefined, installScript: undefined as string | undefined }, ...extraDepots];
+    const primaryLocalPath = options.depotPath ? `./${options.depotPath.replace(/^\.?\/*/, "")}/*` : undefined;
+    const allDepots = [
+      { depotId, localPath: primaryLocalPath, installScript: options.depotInstallScriptPath },
+      ...extraDepots,
+    ];
 
     const depotEntries = allDepots.map((depot) => ({
       depotId: depot.depotId,


### PR DESCRIPTION
## Summary
Adds \`--depotPath\`/\`--depotInstallScriptPath\` for the primary \`--depotId\` depot, matching what every extra depot (\`depot1Path\`..\`depot9Path\`) already supported. Needed so the upcoming \`game-ci/steam-deploy\` thin wrapper can map the old standalone action's \`depot1Path\`/\`depot1InstallScriptPath\` inputs 1:1 onto the primary depot instead of forcing it to always mean "the whole build".

## Test plan
- [x] \`bunx vitest run\` in \`plugins/steam-deploy\` — 23/23 passing
- [x] \`bunx tsc --noEmit\` — clean