### PR TITLE
fix(steam-deploy): password optional when configVdf or totp is set

### DIFF
--- a/plugins/steam-deploy/src/steam-deploy-command.ts
+++ b/plugins/steam-deploy/src/steam-deploy-command.ts
@@ -118,9 +118,19 @@ export class SteamDeployCommand {
 
     const username = process.env.STEAM_USERNAME;
     const password = process.env.STEAM_PASSWORD;
-    if (!username || !password) {
+    const totp = process.env.STEAM_TOTP;
+    const configVdfBase64 = process.env.STEAM_CONFIG_VDF_BASE64;
+    if (!username) {
       throw new Error(
-        "STEAM_USERNAME and STEAM_PASSWORD must be set as environment variables (never as CLI arguments - argv can leak through process listings).",
+        "STEAM_USERNAME must be set as an environment variable (never as a CLI argument - argv can leak through process listings).",
+      );
+    }
+    // Password is required unless a configVdf (a session already authorized
+    // outside CI) or a TOTP code is given - matches the old standalone
+    // game-ci/steam-deploy action's own behavior.
+    if (!password && !totp && !configVdfBase64) {
+      throw new Error(
+        "STEAM_PASSWORD must be set as an environment variable, unless STEAM_TOTP or STEAM_CONFIG_VDF_BASE64 is set (never as a CLI argument - argv can leak through process listings).",
       );
     }
 
@@ -182,8 +192,8 @@ export class SteamDeployCommand {
       mode,
       steamCmdPath: options.steamCmdPath,
       steamConfigDir: options.steamConfigDir,
-      totp: process.env.STEAM_TOTP,
-      configVdfBase64: process.env.STEAM_CONFIG_VDF_BASE64,
+      totp,
+      configVdfBase64,
     });
 
     if (!result.success) {

--- a/plugins/steam-deploy/src/steamcmd-runner.test.ts
+++ b/plugins/steam-deploy/src/steamcmd-runner.test.ts
@@ -80,6 +80,38 @@ describe("SteamCmdRunner", () => {
     ]);
   });
 
+  it("reuses the same configVdf session across repeated runs without ever needing a TOTP code", async () => {
+    // Regression test for a real gotcha in the old standalone action's
+    // history (raised on game-ci/steam-deploy#92's review): once a 2FA
+    // method is applied, it must persist across runs - a config.vdf is
+    // exactly that persisted session, supplied fresh from a secret on
+    // every run (not derived from on-disk state), so no run after the
+    // first should ever need a TOTP prompt as long as configVdfBase64 is
+    // set. Mirrors steam-deploy's own CI "Deploy to Steam" job, which runs
+    // the action twice in a row with the same configVdf and no totp.
+    const steamHome = path.join(tempDir, "steam-home-repeat");
+    const configVdfBase64 = Buffer.from("persisted session").toString("base64");
+
+    for (let run = 0; run < 2; run++) {
+      const { spawnFn, calls } = fakeSpawn("Success!");
+      const runner = new SteamCmdRunner(spawnFn);
+
+      await runner.run({
+        buildDir: tempDir,
+        username: "u",
+        mode: "local",
+        steamCmdPath: localSteamCmdPath,
+        steamHome,
+        configVdfBase64,
+      });
+
+      expect(calls[0].args).not.toContain("+set_steam_guard_code");
+      expect(calls[0].args[0]).toBe("+login");
+      expect(calls[0].args[1]).toBe("u");
+      expect(fs.readFileSync(path.join(steamHome, "config", "config.vdf"), "utf8")).toBe("persisted session");
+    }
+  });
+
   it("prepends +set_steam_guard_code when totp is given", async () => {
     const { spawnFn, calls } = fakeSpawn("Success!");
     const runner = new SteamCmdRunner(spawnFn);

--- a/plugins/steam-deploy/src/steamcmd-runner.test.ts
+++ b/plugins/steam-deploy/src/steamcmd-runner.test.ts
@@ -59,6 +59,27 @@ describe("SteamCmdRunner", () => {
     ]);
   });
 
+  it("logs in with just the username when password is omitted (relying on a configVdf session)", async () => {
+    const { spawnFn, calls } = fakeSpawn("Success!");
+    const runner = new SteamCmdRunner(spawnFn);
+
+    await runner.run({
+      buildDir: tempDir,
+      username: "u",
+      mode: "local",
+      steamCmdPath: localSteamCmdPath,
+      configVdfBase64: Buffer.from("session").toString("base64"),
+    });
+
+    expect(calls[0].args).toEqual([
+      "+login",
+      "u",
+      "+run_app_build",
+      `${tempDir.replace(/\\/g, "/")}/manifest.vdf`,
+      "+quit",
+    ]);
+  });
+
   it("prepends +set_steam_guard_code when totp is given", async () => {
     const { spawnFn, calls } = fakeSpawn("Success!");
     const runner = new SteamCmdRunner(spawnFn);

--- a/plugins/steam-deploy/src/steamcmd-runner.ts
+++ b/plugins/steam-deploy/src/steamcmd-runner.ts
@@ -7,7 +7,15 @@ export interface RunSteamCmdOptions {
   /** Directory containing manifest.vdf and the depot VDF(s), already patched with correct ContentRoot/BuildOutput. */
   buildDir: string;
   username: string;
-  password: string;
+  /**
+   * Required unless configVdfBase64 or totp is set - a configVdf carries a
+   * previously-authorized session (SteamGuard already completed once,
+   * outside CI) that steamcmd can log in with using just the username,
+   * matching the old standalone game-ci/steam-deploy action's own
+   * behavior (its password input was "required if totp is set", i.e.
+   * optional otherwise).
+   */
+  password?: string;
   /** 'local' runs steamcmd directly; 'docker' runs it via the cm2network/steamcmd image; 'auto' picks whichever is available, preferring local. */
   mode: "auto" | "local" | "docker";
   /** Explicit path to steamcmd's executable. Skips PATH/common-location auto-detection when set - recommended for CI determinism. */
@@ -63,9 +71,16 @@ function writeConfigVdfIfProvided(steamHome: string, configVdfBase64?: string): 
 }
 
 function loginArgs(options: RunSteamCmdOptions): string[] {
+  // Password omitted entirely (not passed as "") when unset - a configVdf
+  // carries a session already authorized outside CI, and steamcmd logs in
+  // with just the username in that case, same as the old action's own
+  // second-stage login (its test-login used the password, but the actual
+  // build-upload login didn't).
+  const loginArgsBase = options.password ? [options.username, options.password] : [options.username];
+
   // set_steam_guard_code must precede +login for steamcmd to associate it
   // with that login attempt.
-  return options.totp ? ["+set_steam_guard_code", options.totp, "+login", options.username, options.password] : ["+login", options.username, options.password];
+  return options.totp ? ["+set_steam_guard_code", options.totp, "+login", ...loginArgsBase] : ["+login", ...loginArgsBase];
 }
 
 function runProcess(spawnFn: SpawnFn, command: string, args: string[]): Promise<{ output: string; exitCode: number }> {


### PR DESCRIPTION
## Summary
\`deploy steam\` unconditionally required \`STEAM_PASSWORD\`, but the old standalone game-ci/steam-deploy action's own \`password\` input was "required if totp is set" - i.e. optional when relying on a \`configVdf\`'s already-authorized session. Confirmed as a real regression via the steam-deploy thin-wrapper PR's own CI (game-ci/steam-deploy#92), whose test workflow only configures \`STEAM_USERNAME\`/\`STEAM_CONFIG_VDF\`/\`TEST_APP_ID\` secrets - no password.

\`SteamCmdRunner\`'s login now omits the password argument entirely when unset, matching the old action's own two-stage login (test login used the password; the actual build-upload login didn't).

## Test plan
- [x] \`bunx vitest run\` in \`plugins/steam-deploy\` - 24/24 passing (new test covers the password-omitted login path)
- [x] \`bunx tsc --noEmit\` - clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Steam deployments can now authenticate using a pre-authorized session configuration without requiring a password.
  * TOTP-based authentication remains supported alongside username-only session authentication.

* **Bug Fixes**
  * Improved credential validation and clearer errors for missing Steam authentication details.
  * Prevented passwords from being included in login commands when they are not needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->