### PR TITLE
fix(steam-deploy): surface the actual steamcmd output on an unrecognized failure

### DIFF
--- a/plugins/steam-deploy/src/parse-steamcmd-output.test.ts
+++ b/plugins/steam-deploy/src/parse-steamcmd-output.test.ts
@@ -50,12 +50,28 @@ describe("parseSteamCmdOutput", () => {
     expect(result.failureReason).toContain("missing chunks");
   });
 
-  it("falls back to the raw exit code when no known failure signature is present", () => {
+  it("falls back to the exit code plus the tail of the output when no known failure signature is present", () => {
     const output = "Something unexpected happened.\n";
 
     const result = parseSteamCmdOutput(output, 7);
 
     expect(result.success).toBe(false);
-    expect(result.failureReason).toBe("exit code 7");
+    expect(result.failureReason).toBe("exit code 7: Something unexpected happened.");
+  });
+
+  it("falls back to a bare exit code when the output is empty", () => {
+    const result = parseSteamCmdOutput("", 5);
+
+    expect(result.success).toBe(false);
+    expect(result.failureReason).toBe("exit code 5");
+  });
+
+  it("reports failure with a specific reason when login failed", () => {
+    const output = "Logging in user 'someuser' to Steam Public...FAILED (Invalid Password)\n";
+
+    const result = parseSteamCmdOutput(output, 5);
+
+    expect(result.success).toBe(false);
+    expect(result.failureReason).toContain("login failed");
   });
 });

--- a/plugins/steam-deploy/src/parse-steamcmd-output.ts
+++ b/plugins/steam-deploy/src/parse-steamcmd-output.ts
@@ -33,6 +33,7 @@ export function parseSteamCmdOutput(output: string, exitCode: number): SteamCmdP
   const disconnected = /disconnected from steam/i.test(output);
   const errorBuild = /ERROR!.*Build for depot.*failed/.test(output);
   const errorChunks = /ERROR!.*Failed to get list of missing chunks/.test(output);
+  const loginFailed = /Logging in.*FAILED|Login Failure/i.exec(output);
 
   if (successConfirmed) {
     return { success: true, buildId };
@@ -46,7 +47,21 @@ export function parseSteamCmdOutput(output: string, exitCode: number): SteamCmdP
   if (disconnected) reasons.push("Steam connection dropped (request revoked)");
   if (errorChunks) reasons.push("failed to get list of missing chunks (lost connection)");
   if (errorBuild) reasons.push("depot build reported failure");
-  if (reasons.length === 0) reasons.push(`exit code ${exitCode}`);
+  if (loginFailed) reasons.push("login failed");
+  if (reasons.length === 0) {
+    // No known failure signature matched - surface the tail of the actual
+    // output instead of a bare exit code, which on its own gives a human
+    // debugging a real failure nothing to go on (see game-ci/steam-deploy#92,
+    // where "exit code 5" alone gave no clue whether it was an auth,
+    // network, or Steam-side issue).
+    const tail = output
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .slice(-5)
+      .join(" | ");
+    reasons.push(tail ? `exit code ${exitCode}: ${tail}` : `exit code ${exitCode}`);
+  }
 
   return { success: false, buildId: "", failureReason: reasons.join("; ") };
 }


### PR DESCRIPTION
## Summary
\`parseSteamCmdOutput\`'s fallback reported a bare \`exit code N\` with no other context when none of the known failure signatures matched - confirmed unhelpful live via game-ci/steam-deploy#92's own CI, which failed with just "Steam deployment failed: exit code 5" and no way to tell whether it was an auth, network, or Steam-side issue.

- Appends the last few non-empty output lines when no known signature matches.
- Recognizes steamcmd's actual login-failure text ("Logging in user '...' to Steam Public...FAILED (Invalid Password)") as a specific "login failed" reason.

## Test plan
- [x] \`bunx vitest run\` in \`plugins/steam-deploy\` - 27/27 passing