### PR TITLE
feat(github-release-deploy): implement the plugin for real

### DIFF
--- a/plugins/github-release-deploy/README.md
+++ b/plugins/github-release-deploy/README.md
@@ -1,37 +1,53 @@
-> **EXPERIMENTAL — NOT IMPLEMENTED.** This is a structural draft only: the plugin
-> shape is real, but its domain logic is not written. Any command it claims will
-> throw. It is not published to npm and is never loaded unless you pass
-> `--plugin @game-ci/github-release-deploy` explicitly.
+> **EXPERIMENTAL.** Functional, but not published to npm and never loaded
+> unless you pass `--plugin @game-ci/github-release-deploy` explicitly -
+> and not yet wired into core's default load list.
 
-# @game-ci/github-release-deploy (draft)
+# @game-ci/github-release-deploy
 
-GitHub/GitLab Release deploy plugin. **Not functional yet** - structural
-skeleton only. Mirrors `@game-ci/steam-deploy`'s `deploy <target>`
-dispatch shape, reusing core's existing `deploy` command registration.
+`game-ci deploy github-release <buildPath>` attaches built artifacts to a
+GitHub Release - a deploy target for games distributed outside
+Steam/itch (open-source games, internal builds, anything shipped
+straight from a repo). Mirrors `@game-ci/steam-deploy`'s `deploy
+<target>` dispatch shape, reusing core's existing `deploy` command
+registration.
 
-## Why this
+## Usage
 
-Fills a real gap: games not on Steam or itch (open-source games, internal
-builds, anything distributed straight from a repo) have no deploy target
-today. Flagged as the thinnest of the recent plugin-idea batch - closest
-in spirit to what a generic release-upload action already does - but
-still worth having as a first-party, game-artifact-aware option.
+```bash
+GITHUB_TOKEN=... game-ci deploy github-release ./build --repo owner/repo --tag v1.2.3
+```
 
-## What's real vs. TODO
+- `buildPath` may be a single file (uploaded as-is, optionally renamed
+  via `--assetName`) or a directory - every top-level regular file
+  inside it is uploaded as a separate asset, named after itself. Not
+  recursive, so a build step that produces one artifact per
+  platform/target lays out predictably; nested folders are ignored (run
+  the command once per platform if you need per-platform releases from a
+  build that groups them in subdirectories).
+- `--tag` reuses an existing release for that tag if one exists (its
+  assets updated), or creates a new one - re-running against the same
+  tag (e.g. a retried CI job) is idempotent: an asset that already
+  exists on the release is deleted and re-uploaded rather than failing
+  with GitHub's `422 already_exists`.
+- The token is read from `$GITHUB_TOKEN` (or `$GH_TOKEN`) only, never a
+  CLI argument - matches `steam-deploy`'s credential handling.
+- `--repo` defaults to `$GITHUB_REPOSITORY`, which GitHub Actions sets
+  automatically.
 
-- Plugin/command registration shape: real, mirrors `steam-deploy`.
-- `execute()`: throws immediately, pointing here.
+## Options
 
-## Remaining work before this is real
+| Option              | Description                                                                    |
+| -------------------- | -------------------------------------------------------------------------------- |
+| `--repo`             | `owner/repo`. Defaults to `$GITHUB_REPOSITORY`.                                 |
+| `--tag`              | Release tag. Required.                                                          |
+| `--releaseNotes`     | Release body/description.                                                       |
+| `--draft`            | Create the release as a draft. Default `false`.                                 |
+| `--prerelease`       | Mark the release as a prerelease. Default `false`.                              |
+| `--assetName`        | Override the uploaded asset's file name. Only valid for a single-file buildPath. |
+| `--targetCommitish`  | Commit/branch to create the tag from, if it doesn't already exist.              |
 
-1. Decide GitHub vs. GitLab scope for the first version (likely GitHub
-   first, given this repo's own hosting) and the auth token convention
-   (env var only, matching `steam-deploy`'s credential handling - never
-   CLI args).
-2. Multi-platform artifact naming/packaging - if `buildPath` contains
-   builds for multiple `targetPlatform`s, decide whether this plugin
-   zips each separately with a platform-suffixed name, or expects to be
-   invoked once per platform.
-3. Release creation vs. update-existing-release handling (idempotent
-   re-runs on the same tag).
-4. Tests once the above is real.
+## Scope of this first version
+
+GitLab Release support was scoped out (GitHub first, given this repo's
+own hosting) - the command/option shape doesn't preclude adding it later
+behind a `--provider` flag without a breaking change.

--- a/plugins/github-release-deploy/package.json
+++ b/plugins/github-release-deploy/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@game-ci/github-release-deploy",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
-  "description": "EXPERIMENTAL (draft, not implemented): GitHub/GitLab Release deploy plugin (draft). Attaches built artifacts to a GitHub or GitLab Release, for games distributed outside Steam/itch.",
+  "description": "EXPERIMENTAL: GitHub Release deploy plugin. Attaches built artifacts to a GitHub Release, for games distributed outside Steam/itch.",
   "license": "MIT",
   "repository": "git@github.com:game-ci/cli.git",
   "files": [

--- a/plugins/github-release-deploy/src/github-api.test.ts
+++ b/plugins/github-release-deploy/src/github-api.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  getReleaseByTag,
+  createRelease,
+  deleteAsset,
+  uploadAsset,
+  stripUploadUrlTemplate,
+  type GitHubApiOptions,
+} from "./github-api";
+
+function fakeOptions(fetchFn: typeof fetch): GitHubApiOptions {
+  return { repo: "owner/repo", token: "secret-token", fetchFn };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
+
+describe("stripUploadUrlTemplate", () => {
+  it("strips a URI template suffix", () => {
+    expect(stripUploadUrlTemplate("https://uploads.github.com/repos/o/r/releases/1/assets{?name,label}")).toBe(
+      "https://uploads.github.com/repos/o/r/releases/1/assets",
+    );
+  });
+
+  it("leaves a URL with no template suffix untouched", () => {
+    expect(stripUploadUrlTemplate("https://uploads.github.com/repos/o/r/releases/1/assets")).toBe(
+      "https://uploads.github.com/repos/o/r/releases/1/assets",
+    );
+  });
+});
+
+describe("getReleaseByTag", () => {
+  it("returns null on a 404 (no release for this tag yet)", async () => {
+    const fetchFn = vi.fn(async () => new Response(null, { status: 404 }));
+    const result = await getReleaseByTag(fakeOptions(fetchFn as unknown as typeof fetch), "v1.0.0");
+    expect(result).toBeNull();
+  });
+
+  it("returns the release on a 200", async () => {
+    const fetchFn = vi.fn(async () => jsonResponse({ id: 42, upload_url: "u", html_url: "h", assets: [] }));
+    const result = await getReleaseByTag(fakeOptions(fetchFn as unknown as typeof fetch), "v1.0.0");
+    expect(result?.id).toBe(42);
+  });
+
+  it("sends the Authorization header and hits the tags endpoint", async () => {
+    const fetchFn = vi.fn(async () => new Response(null, { status: 404 }));
+    await getReleaseByTag(fakeOptions(fetchFn as unknown as typeof fetch), "v1.0.0");
+
+    const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.github.com/repos/owner/repo/releases/tags/v1.0.0");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer secret-token");
+  });
+
+  it("throws on an unexpected non-404 error status", async () => {
+    const fetchFn = vi.fn(async () => new Response(null, { status: 500 }));
+    await expect(getReleaseByTag(fakeOptions(fetchFn as unknown as typeof fetch), "v1.0.0")).rejects.toThrow(/500/);
+  });
+});
+
+describe("createRelease", () => {
+  it("posts the expected JSON body", async () => {
+    const fetchFn = vi.fn(async () => jsonResponse({ id: 1, upload_url: "u", html_url: "h", assets: [] }));
+    await createRelease(fakeOptions(fetchFn as unknown as typeof fetch), {
+      tag: "v1.0.0",
+      body: "notes",
+      draft: true,
+      prerelease: false,
+    });
+
+    const [, init] = fetchFn.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body).toMatchObject({ tag_name: "v1.0.0", name: "v1.0.0", body: "notes", draft: true, prerelease: false });
+  });
+
+  it("throws with the response body on failure", async () => {
+    const fetchFn = vi.fn(async () => new Response("nope", { status: 422 }));
+    await expect(
+      createRelease(fakeOptions(fetchFn as unknown as typeof fetch), { tag: "v1.0.0" }),
+    ).rejects.toThrow(/422/);
+  });
+});
+
+describe("deleteAsset", () => {
+  it("does not throw on a 404 (already gone is fine)", async () => {
+    const fetchFn = vi.fn(async () => new Response(null, { status: 404 }));
+    await expect(deleteAsset(fakeOptions(fetchFn as unknown as typeof fetch), 99)).resolves.toBeUndefined();
+  });
+
+  it("throws on a genuine error status", async () => {
+    const fetchFn = vi.fn(async () => new Response(null, { status: 500 }));
+    await expect(deleteAsset(fakeOptions(fetchFn as unknown as typeof fetch), 99)).rejects.toThrow(/500/);
+  });
+});
+
+describe("uploadAsset", () => {
+  it("strips the URL template and appends the asset name as a query param", async () => {
+    const fetchFn = vi.fn(async () => jsonResponse({ id: 7, name: "build.zip" }));
+    await uploadAsset(
+      fakeOptions(fetchFn as unknown as typeof fetch),
+      "https://uploads.github.com/repos/o/r/releases/1/assets{?name,label}",
+      "build.zip",
+      Buffer.from("content"),
+      "application/zip",
+    );
+
+    const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://uploads.github.com/repos/o/r/releases/1/assets?name=build.zip");
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe("application/zip");
+  });
+
+  it("throws with the response body on failure", async () => {
+    const fetchFn = vi.fn(async () => new Response("already_exists", { status: 422 }));
+    await expect(
+      uploadAsset(fakeOptions(fetchFn as unknown as typeof fetch), "https://u", "a", Buffer.from(""), "application/octet-stream"),
+    ).rejects.toThrow(/422/);
+  });
+});

--- a/plugins/github-release-deploy/src/github-api.ts
+++ b/plugins/github-release-deploy/src/github-api.ts
@@ -1,0 +1,132 @@
+/**
+ * Minimal GitHub Releases API client - just the four calls
+ * github-release-deploy-command.ts needs (find-by-tag, create, list
+ * assets, delete asset, upload asset). No octokit dependency: this repo
+ * has no other GitHub API client to share, and pulling one in for four
+ * endpoints isn't worth the dependency weight.
+ */
+
+export interface GitHubReleaseAsset {
+  id: number;
+  name: string;
+}
+
+export interface GitHubRelease {
+  id: number;
+  upload_url: string;
+  html_url: string;
+  assets: GitHubReleaseAsset[];
+}
+
+export interface GitHubApiOptions {
+  /** "owner/repo". */
+  repo: string;
+  /** Never logged, never passed as a CLI argument - read from GITHUB_TOKEN only. */
+  token: string;
+  /** Overridable for GitHub Enterprise Server; defaults to the public API. */
+  apiBaseUrl?: string;
+  fetchFn?: typeof fetch;
+}
+
+function headersFor(options: GitHubApiOptions, extra?: Record<string, string>): Record<string, string> {
+  return {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${options.token}`,
+    "X-GitHub-Api-Version": "2022-11-28",
+    ...extra,
+  };
+}
+
+function apiBase(options: GitHubApiOptions): string {
+  return options.apiBaseUrl ?? "https://api.github.com";
+}
+
+/** Returns null if no release exists for the tag (a 404 is expected, not an error, on a first run). */
+export async function getReleaseByTag(options: GitHubApiOptions, tag: string): Promise<GitHubRelease | null> {
+  const fetchFn = options.fetchFn ?? fetch;
+  const response = await fetchFn(`${apiBase(options)}/repos/${options.repo}/releases/tags/${encodeURIComponent(tag)}`, {
+    headers: headersFor(options),
+  });
+
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    throw new Error(`Failed to look up release for tag "${tag}": GitHub API returned ${response.status}.`);
+  }
+  return (await response.json()) as GitHubRelease;
+}
+
+export interface CreateReleaseOptions {
+  tag: string;
+  /** Defaults to tag when unset. */
+  name?: string;
+  body?: string;
+  draft?: boolean;
+  prerelease?: boolean;
+  /** Commit/branch the tag is created from, when the tag doesn't already exist. */
+  targetCommitish?: string;
+}
+
+export async function createRelease(options: GitHubApiOptions, release: CreateReleaseOptions): Promise<GitHubRelease> {
+  const fetchFn = options.fetchFn ?? fetch;
+  const response = await fetchFn(`${apiBase(options)}/repos/${options.repo}/releases`, {
+    method: "POST",
+    headers: headersFor(options, { "Content-Type": "application/json" }),
+    body: JSON.stringify({
+      tag_name: release.tag,
+      name: release.name ?? release.tag,
+      body: release.body,
+      draft: release.draft ?? false,
+      prerelease: release.prerelease ?? false,
+      ...(release.targetCommitish ? { target_commitish: release.targetCommitish } : {}),
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to create release for tag "${release.tag}": GitHub API returned ${response.status}. ${text}`);
+  }
+  return (await response.json()) as GitHubRelease;
+}
+
+export async function deleteAsset(options: GitHubApiOptions, assetId: number): Promise<void> {
+  const fetchFn = options.fetchFn ?? fetch;
+  const response = await fetchFn(`${apiBase(options)}/repos/${options.repo}/releases/assets/${assetId}`, {
+    method: "DELETE",
+    headers: headersFor(options),
+  });
+
+  if (!response.ok && response.status !== 404) {
+    throw new Error(`Failed to delete existing asset ${assetId}: GitHub API returned ${response.status}.`);
+  }
+}
+
+/** uploadUrl is the release's own upload_url (a URI template - stripUploadUrlTemplate below strips the {?name,label} part). */
+export function stripUploadUrlTemplate(uploadUrl: string): string {
+  return uploadUrl.replace(/\{[^}]*\}$/, "");
+}
+
+export async function uploadAsset(
+  options: GitHubApiOptions,
+  uploadUrl: string,
+  assetName: string,
+  content: Buffer,
+  contentType: string,
+): Promise<GitHubReleaseAsset> {
+  const fetchFn = options.fetchFn ?? fetch;
+  const url = `${stripUploadUrlTemplate(uploadUrl)}?name=${encodeURIComponent(assetName)}`;
+
+  const response = await fetchFn(url, {
+    method: "POST",
+    headers: headersFor(options, {
+      "Content-Type": contentType,
+      "Content-Length": String(content.byteLength),
+    }),
+    body: content,
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to upload asset "${assetName}": GitHub API returned ${response.status}. ${text}`);
+  }
+  return (await response.json()) as GitHubReleaseAsset;
+}

--- a/plugins/github-release-deploy/src/github-release-deploy-command.test.ts
+++ b/plugins/github-release-deploy/src/github-release-deploy-command.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { GithubReleaseDeployCommand } from "./github-release-deploy-command";
+import * as githubApi from "./github-api";
+
+describe("GithubReleaseDeployCommand", () => {
+  let tempDir: string;
+  const originalToken = process.env.GITHUB_TOKEN;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "github-release-deploy-test-"));
+    process.env.GITHUB_TOKEN = "test-token";
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    process.env.GITHUB_TOKEN = originalToken;
+    vi.restoreAllMocks();
+  });
+
+  it("throws when GITHUB_TOKEN is not set", async () => {
+    delete process.env.GITHUB_TOKEN;
+    const command = new GithubReleaseDeployCommand();
+
+    await expect(command.execute({ buildPath: tempDir, repo: "o/r", tag: "v1" })).rejects.toThrow(/GITHUB_TOKEN/);
+  });
+
+  it("throws when neither --repo nor $GITHUB_REPOSITORY is set", async () => {
+    const command = new GithubReleaseDeployCommand();
+
+    await expect(command.execute({ buildPath: tempDir, tag: "v1" })).rejects.toThrow(/--repo/);
+  });
+
+  it("throws when the build path does not exist", async () => {
+    const command = new GithubReleaseDeployCommand();
+
+    await expect(
+      command.execute({ buildPath: path.join(tempDir, "does-not-exist"), repo: "o/r", tag: "v1" }),
+    ).rejects.toThrow(/does not exist/);
+  });
+
+  it("throws when --assetName is given for a directory buildPath", async () => {
+    const command = new GithubReleaseDeployCommand();
+
+    await expect(
+      command.execute({ buildPath: tempDir, repo: "o/r", tag: "v1", assetName: "renamed.zip" }),
+    ).rejects.toThrow(/only valid when buildPath is a single file/);
+  });
+
+  it("creates a new release and uploads every top-level file in a directory", async () => {
+    fs.writeFileSync(path.join(tempDir, "windows-build.zip"), "win");
+    fs.writeFileSync(path.join(tempDir, "linux-build.zip"), "linux");
+    fs.mkdirSync(path.join(tempDir, "nested"));
+    fs.writeFileSync(path.join(tempDir, "nested", "ignored.txt"), "not top-level");
+
+    vi.spyOn(githubApi, "getReleaseByTag").mockResolvedValue(null);
+    const created = { id: 1, upload_url: "https://uploads/assets{?name}", html_url: "https://release", assets: [] };
+    const createReleaseSpy = vi.spyOn(githubApi, "createRelease").mockResolvedValue(created);
+    const uploadSpy = vi.spyOn(githubApi, "uploadAsset").mockResolvedValue({ id: 1, name: "x" });
+
+    const command = new GithubReleaseDeployCommand();
+    const result = await command.execute({ buildPath: tempDir, repo: "o/r", tag: "v1.0.0", releaseNotes: "notes" });
+
+    expect(result).toBe(true);
+    expect(createReleaseSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ tag: "v1.0.0", body: "notes" }));
+    expect(uploadSpy).toHaveBeenCalledTimes(2);
+    const uploadedNames = uploadSpy.mock.calls.map((call) => call[2]).sort();
+    expect(uploadedNames).toEqual(["linux-build.zip", "windows-build.zip"]);
+  });
+
+  it("reuses an existing release for the tag instead of creating a new one", async () => {
+    fs.writeFileSync(path.join(tempDir, "build.zip"), "content");
+
+    const existingRelease = { id: 5, upload_url: "https://uploads/assets{?name}", html_url: "https://release", assets: [] };
+    vi.spyOn(githubApi, "getReleaseByTag").mockResolvedValue(existingRelease);
+    const createReleaseSpy = vi.spyOn(githubApi, "createRelease");
+    vi.spyOn(githubApi, "uploadAsset").mockResolvedValue({ id: 1, name: "build.zip" });
+
+    const command = new GithubReleaseDeployCommand();
+    await command.execute({ buildPath: tempDir, repo: "o/r", tag: "v1.0.0" });
+
+    expect(createReleaseSpy).not.toHaveBeenCalled();
+  });
+
+  it("deletes and re-uploads an asset that already exists on the release (idempotent re-run)", async () => {
+    fs.writeFileSync(path.join(tempDir, "build.zip"), "content");
+
+    const existingRelease = {
+      id: 5,
+      upload_url: "https://uploads/assets{?name}",
+      html_url: "https://release",
+      assets: [{ id: 77, name: "build.zip" }],
+    };
+    vi.spyOn(githubApi, "getReleaseByTag").mockResolvedValue(existingRelease);
+    const deleteSpy = vi.spyOn(githubApi, "deleteAsset").mockResolvedValue(undefined);
+    vi.spyOn(githubApi, "uploadAsset").mockResolvedValue({ id: 78, name: "build.zip" });
+
+    const command = new GithubReleaseDeployCommand();
+    await command.execute({ buildPath: tempDir, repo: "o/r", tag: "v1.0.0" });
+
+    expect(deleteSpy).toHaveBeenCalledWith(expect.anything(), 77);
+  });
+
+  it("uses $GITHUB_REPOSITORY when --repo is not given", async () => {
+    process.env.GITHUB_REPOSITORY = "env-owner/env-repo";
+    fs.writeFileSync(path.join(tempDir, "build.zip"), "content");
+
+    vi.spyOn(githubApi, "getReleaseByTag").mockResolvedValue({
+      id: 1,
+      upload_url: "https://uploads/assets{?name}",
+      html_url: "https://release",
+      assets: [],
+    });
+    vi.spyOn(githubApi, "uploadAsset").mockResolvedValue({ id: 1, name: "build.zip" });
+
+    const command = new GithubReleaseDeployCommand();
+    await command.execute({ buildPath: tempDir, tag: "v1.0.0" });
+
+    expect(githubApi.getReleaseByTag).toHaveBeenCalledWith(
+      expect.objectContaining({ repo: "env-owner/env-repo" }),
+      "v1.0.0",
+    );
+    delete process.env.GITHUB_REPOSITORY;
+  });
+
+  it("renames a single-file buildPath via --assetName", async () => {
+    const filePath = path.join(tempDir, "original-name.zip");
+    fs.writeFileSync(filePath, "content");
+
+    vi.spyOn(githubApi, "getReleaseByTag").mockResolvedValue({
+      id: 1,
+      upload_url: "https://uploads/assets{?name}",
+      html_url: "https://release",
+      assets: [],
+    });
+    const uploadSpy = vi.spyOn(githubApi, "uploadAsset").mockResolvedValue({ id: 1, name: "renamed.zip" });
+
+    const command = new GithubReleaseDeployCommand();
+    await command.execute({ buildPath: filePath, repo: "o/r", tag: "v1.0.0", assetName: "renamed.zip" });
+
+    expect(uploadSpy.mock.calls[0][2]).toBe("renamed.zip");
+  });
+});

--- a/plugins/github-release-deploy/src/github-release-deploy-command.ts
+++ b/plugins/github-release-deploy/src/github-release-deploy-command.ts
@@ -1,0 +1,162 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { getReleaseByTag, createRelease, deleteAsset, uploadAsset, type GitHubApiOptions } from "./github-api";
+
+export interface GithubReleaseDeployOptions {
+  buildPath?: string;
+  repo?: string;
+  tag?: string;
+  releaseNotes?: string;
+  draft?: boolean;
+  prerelease?: boolean;
+  assetName?: string;
+  targetCommitish?: string;
+  [key: string]: unknown;
+}
+
+interface YargsLike {
+  option: (name: string, config: Record<string, unknown>) => YargsLike;
+}
+
+const CONTENT_TYPES: Record<string, string> = {
+  ".zip": "application/zip",
+  ".tar": "application/x-tar",
+  ".gz": "application/gzip",
+  ".tgz": "application/gzip",
+};
+
+function contentTypeFor(filePath: string): string {
+  return CONTENT_TYPES[path.extname(filePath).toLowerCase()] ?? "application/octet-stream";
+}
+
+export class GithubReleaseDeployCommand {
+  public readonly name = "Deploy github release";
+
+  public async configureOptions(yargs: YargsLike): Promise<void> {
+    yargs
+      .option("repo", {
+        describe: 'Repository to attach the release to, as "owner/repo". Defaults to $GITHUB_REPOSITORY when running in GitHub Actions.',
+        type: "string",
+      })
+      .option("tag", {
+        describe: "Release tag. An existing release for this tag is reused (its assets updated); otherwise a new release is created.",
+        type: "string",
+        demandOption: true,
+      })
+      .option("releaseNotes", {
+        describe: "Release body/description. Left blank if omitted (GitHub renders an empty body, not a placeholder).",
+        type: "string",
+      })
+      .option("draft", {
+        describe: "Create the release as a draft.",
+        type: "boolean",
+        default: false,
+      })
+      .option("prerelease", {
+        describe: "Mark the release as a prerelease.",
+        type: "boolean",
+        default: false,
+      })
+      .option("assetName", {
+        describe: "Override the uploaded asset's file name. Only valid when buildPath is a single file.",
+        type: "string",
+      })
+      .option("targetCommitish", {
+        describe: "Commit/branch to create the tag from, if it doesn't already exist. Defaults to the repository's default branch.",
+        type: "string",
+      });
+  }
+
+  public async execute(options: GithubReleaseDeployOptions): Promise<boolean> {
+    const buildPath = options.buildPath;
+    if (!buildPath) {
+      throw new Error("A build path is required: game-ci deploy github-release <buildPath>");
+    }
+    if (!fs.existsSync(buildPath)) {
+      throw new Error(`Build path does not exist: ${buildPath}`);
+    }
+
+    const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+    if (!token) {
+      throw new Error(
+        "GITHUB_TOKEN (or GH_TOKEN) must be set as an environment variable (never as a CLI argument - argv can leak through process listings).",
+      );
+    }
+
+    const repo = options.repo || process.env.GITHUB_REPOSITORY;
+    if (!repo) {
+      throw new Error("--repo is required (or set $GITHUB_REPOSITORY, as GitHub Actions does automatically).");
+    }
+
+    const tag = options.tag!;
+    const apiOptions: GitHubApiOptions = { repo, token };
+
+    const files = this.collectFiles(buildPath, options.assetName);
+    if (files.length === 0) {
+      throw new Error(`No files found to upload at "${buildPath}".`);
+    }
+
+    console.log(`Deploying ${files.length} asset(s) from ${buildPath} to ${repo}'s release "${tag}"`);
+
+    let release = await getReleaseByTag(apiOptions, tag);
+    if (release) {
+      console.log(`Reusing existing release "${tag}" (id ${release.id}).`);
+    } else {
+      release = await createRelease(apiOptions, {
+        tag,
+        body: options.releaseNotes,
+        draft: options.draft,
+        prerelease: options.prerelease,
+        targetCommitish: options.targetCommitish,
+      });
+      console.log(`Created release "${tag}" (id ${release.id}).`);
+    }
+
+    for (const file of files) {
+      const existing = release.assets.find((asset) => asset.name === file.assetName);
+      if (existing) {
+        // Re-uploading with the same name is rejected outright by GitHub's
+        // API (422 "already_exists") - delete first so re-running this
+        // command against the same tag (e.g. a retried CI job) is
+        // idempotent rather than a hard failure.
+        console.log(`Replacing existing asset "${file.assetName}".`);
+        await deleteAsset(apiOptions, existing.id);
+      }
+
+      const content = fs.readFileSync(file.absolutePath);
+      await uploadAsset(apiOptions, release.upload_url, file.assetName, content, contentTypeFor(file.absolutePath));
+      console.log(`Uploaded "${file.assetName}" (${content.byteLength} bytes).`);
+    }
+
+    console.log(`Release deployment succeeded: ${release.html_url}`);
+    return true;
+  }
+
+  /**
+   * buildPath may be a single file (uploaded as-is, optionally renamed via
+   * --assetName) or a directory (every top-level regular file inside it is
+   * uploaded as a separate asset, named after itself - not recursive, so
+   * naming stays predictable and matches how a build step typically lays
+   * out one file per platform/artifact rather than nested folders).
+   */
+  private collectFiles(buildPath: string, assetNameOverride?: string): Array<{ absolutePath: string; assetName: string }> {
+    const absoluteBuildPath = path.resolve(buildPath);
+    const stat = fs.statSync(absoluteBuildPath);
+
+    if (stat.isFile()) {
+      return [{ absolutePath: absoluteBuildPath, assetName: assetNameOverride || path.basename(absoluteBuildPath) }];
+    }
+
+    if (assetNameOverride) {
+      throw new Error("--assetName is only valid when buildPath is a single file, not a directory.");
+    }
+
+    return fs
+      .readdirSync(absoluteBuildPath, { withFileTypes: true })
+      .filter((entry) => entry.isFile())
+      .map((entry) => ({
+        absolutePath: path.join(absoluteBuildPath, entry.name),
+        assetName: entry.name,
+      }));
+  }
+}

--- a/plugins/github-release-deploy/src/index.ts
+++ b/plugins/github-release-deploy/src/index.ts
@@ -1,51 +1,36 @@
-/**
- * GitHub/GitLab Release deploy plugin - DRAFT.
- *
- * Plan: `game-ci deploy github-release <buildPath> --repo --tag` attaches
- * built artifacts to a GitHub or GitLab Release - a deploy target for
- * games distributed outside Steam/itch (open-source games, internal
- * builds, anything shipped straight from a repo). Handles multi-platform
- * artifact naming/organization the way a game build specifically
- * produces it, rather than being a bare file-upload wrapper.
- *
- * NOTE: mirrors steam-deploy's `deploy <target>` dispatch shape (already
- * registered in core - see game-ci/cli#123).
- */
+import { GithubReleaseDeployCommand } from "./github-release-deploy-command";
 
+/**
+ * GitHub Release deploy plugin - `game-ci deploy github-release <buildPath>`.
+ *
+ * Engine-agnostic: it uploads a pre-built output (file or directory), so
+ * it doesn't matter whether Unity, Godot, Unreal, or anything else
+ * produced it. Registered with engine: '*' (see PluginRegistry.createCommand's
+ * wildcard handling), mirroring steam-deploy's dispatch shape.
+ *
+ * GitLab Release support was scoped out of this first version (see
+ * README's "Remaining work" - GitHub first, given this repo's own
+ * hosting); the command/option shape doesn't preclude adding it later
+ * behind a --provider flag without a breaking change.
+ */
 export const githubReleaseDeployPlugin = {
   name: "github-release-deploy",
-  version: "0.0.1",
-
-  /**
-   * Loaded only via an explicit --plugin flag, never by default, so
-   * reaching this point is deliberate - warn rather than fail, but make
-   * it impossible to mistake for a working integration.
-   */
-  onLoad() {
-    console.warn(
-      "[game-ci] WARNING: @game-ci/github-release-deploy is an EXPERIMENTAL draft plugin. " +
-        "Its structure is real but its domain logic is not implemented - any command it " +
-        "claims will throw. Do not depend on it. See plugins/github-release-deploy/README.md.",
-    );
-  },
+  version: "0.1.0",
 
   commands: [
     {
       engine: "*",
       createCommand(command: string, subCommands: string[]) {
         if (command === "deploy" && subCommands[0] === "github-release") {
-          return {
-            name: "Deploy github release",
-            async configureOptions() {
-              // TODO: register --repo, --tag, --releaseNotes, --draft, --prerelease.
-            },
-            async execute(): Promise<boolean> {
-              throw new Error(
-                "GitHub Release deploy is not implemented yet (draft plugin). " +
-                  "See plugins/github-release-deploy/README.md for the planned approach.",
-              );
-            },
-          };
+          // Warned here rather than in onLoad: this plugin is only loaded
+          // via an explicit --plugin flag, but warning there would fire
+          // even for someone just inspecting `--help` output. This fires
+          // exactly when the experimental feature is used.
+          console.warn(
+            "[game-ci] WARNING: `deploy github-release` is EXPERIMENTAL. " +
+              "Verify against a test repo before pointing it at a real release.",
+          );
+          return new GithubReleaseDeployCommand();
         }
         return null;
       },
@@ -54,3 +39,11 @@ export const githubReleaseDeployPlugin = {
 };
 
 export default githubReleaseDeployPlugin;
+export { GithubReleaseDeployCommand } from "./github-release-deploy-command";
+export {
+  getReleaseByTag,
+  createRelease,
+  deleteAsset,
+  uploadAsset,
+  stripUploadUrlTemplate,
+} from "./github-api";

--- a/plugins/github-release-deploy/tsconfig.json
+++ b/plugins/github-release-deploy/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "lib": ["es2022"],
+    "lib": ["es2022", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",
     "declaration": true,


### PR DESCRIPTION
## Summary
\`@game-ci/github-release-deploy\` was a structural-only draft (\`execute()\` threw immediately). Implements \`deploy github-release <buildPath> --repo --tag\` for real:

- \`buildPath\` may be a single file or a directory (every top-level file inside it uploaded as a separate asset).
- \`--tag\` reuses an existing release for that tag if one exists, or creates a new one.
- Re-running against the same tag is idempotent - an asset that already exists on the release is deleted and re-uploaded rather than failing with GitHub's \`422 already_exists\`.
- Token read from \`$GITHUB_TOKEN\`/\`$GH_TOKEN\` only, never a CLI argument.
- \`github-api.ts\`: a minimal fetch-based GitHub Releases API client (no octokit dependency justified for four endpoints).

GitLab Release support is scoped out of this version (GitHub first, given this repo's own hosting) - the option shape leaves room for a \`--provider\` flag later without a breaking change.

## Test plan
- [x] \`bunx vitest run\` - 21/21 passing (full coverage of the GitHub API client and the command's create-vs-reuse-release and idempotent-asset-replace flows)
- [x] \`bunx tsc --noEmit\` - clean