### PR TITLE
feat(pseudo-localization): implement the plugin for real

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -136,7 +136,7 @@
     },
     "plugins/pseudo-localization": {
       "name": "@game-ci/pseudo-localization",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "devDependencies": {
         "@types/node": "^17.0.23",
         "typescript": "4.7.4",

--- a/plugins/pseudo-localization/README.md
+++ b/plugins/pseudo-localization/README.md
@@ -1,13 +1,21 @@
-> **EXPERIMENTAL — NOT IMPLEMENTED.** This is a structural draft only: the plugin
-> shape is real, but its domain logic is not written. Any command it claims will
-> throw. It is not published to npm and is never loaded unless you pass
-> `--plugin @game-ci/pseudo-localization` explicitly.
+> **EXPERIMENTAL.** Functional, but not published to npm and never loaded
+> unless you pass `--plugin @game-ci/pseudo-localization` explicitly.
 
-# @game-ci/pseudo-localization (draft)
+# @game-ci/pseudo-localization
 
-Injects pseudo-loc strings pre-translation to catch UI overflow/
-truncation bugs. **Not functional yet**, and `pseudo-localize` is not yet
-registered anywhere in core's CLI.
+`game-ci pseudo-localize <projectPath>` injects pseudo-loc strings
+pre-translation to catch UI overflow/truncation bugs before real
+translation work starts.
+
+## Usage
+
+```bash
+game-ci pseudo-localize ./Localization --sourceLocale en --expansionFactor 1.4
+```
+
+Reads `<projectPath>/<sourceLocale>.json` or `.csv` (a flat key -> string
+table) and writes the pseudo-localized result to
+`<projectPath>/<outputLocale>.<same format>`.
 
 ## Why this, distinct from translation sync
 
@@ -15,13 +23,39 @@ UI _testing_, not translation management - deliberately different from a
 Crowdin/Lokalise-style sync plugin (which was considered and cut from the
 roadmap for not being game-specific enough).
 
-## Remaining work before this is real
+## The transform
 
-1. Add `pseudo-localize <projectPath>` to core's `CliCommands`.
-2. Pseudo-loc transform (accented characters, length expansion/padding,
-   bracket markers around each string) applied to whatever localization
-   table format the target engine uses - this is genuinely
-   engine-specific (Unity's Localization package format differs
-   completely from a flat JSON/CSV table), so the first real
-   implementation will likely need to pick one engine's format to start.
-3. Tests once the above is real.
+Three real, well-established pseudo-loc techniques:
+
+1. **Accented lookalikes** replace plain ASCII letters, so any string
+   that skipped the pipeline (hardcoded, forgotten) stands out
+   immediately in a build.
+2. **Length expansion** pads the string (`--expansionFactor`, default
+   `1.3`) - most languages run 30-50% longer than English for the same
+   meaning, the #1 real cause of UI truncation bugs.
+3. **Bracket markers** around the whole string make its exact
+   boundaries visible, catching concatenation bugs.
+
+Format placeholders (`{0}`, `{playerName}`, `%s`, `%d`) and simple markup
+(`<b>...</b>`) are detected and left untouched, so string
+formatting/rich text keeps working on the pseudo-localized output.
+
+## Table format scope
+
+Supports the two most common *generic* flat-table interchange formats -
+a plain JSON object (`{"key": "value"}`) and a two-column CSV. Deliberately
+**not** engine-specific structured formats (e.g. Unity's binary
+StringTable assets) - those need real verification against an actual
+engine install before being guessed at, same reasoning as this repo's
+other engine-specific draft plugins (see `plugins/gamemaker`'s README).
+If your project uses an engine-native format, export/import through a
+flat table as an intermediate step, or convert this plugin's output.
+
+## Options
+
+| Option              | Description                                                          |
+| -------------------- | ------------------------------------------------------------------ |
+| `--sourceLocale`     | Source locale to read. Default `en`.                                |
+| `--outputLocale`     | Locale code the output table is written under. Default `qps-ploc`.  |
+| `--expansionFactor`  | Length multiplier applied to each string. Default `1.3`.            |
+| `--outputPath`       | Directory to write the output table into. Defaults to `projectPath`. |

--- a/plugins/pseudo-localization/package.json
+++ b/plugins/pseudo-localization/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@game-ci/pseudo-localization",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
-  "description": "EXPERIMENTAL (draft, not implemented): Pseudo-localization QA plugin (draft). Injects pseudo-loc strings pre-translation to catch UI overflow/truncation bugs.",
+  "description": "EXPERIMENTAL: Pseudo-localization QA plugin. Injects pseudo-loc strings pre-translation to catch UI overflow/truncation bugs.",
   "license": "MIT",
   "repository": "git@github.com:game-ci/cli.git",
   "files": [

--- a/plugins/pseudo-localization/src/index.ts
+++ b/plugins/pseudo-localization/src/index.ts
@@ -1,50 +1,27 @@
-/**
- * Pseudo-localization QA plugin - DRAFT.
- *
- * Plan: `game-ci pseudo-localize <projectPath>` injects pseudo-loc
- * strings (accented/expanded characters standing in for real
- * translations) into a project's localization tables pre-translation, so
- * UI overflow/truncation bugs surface before real translation work ever
- * starts. Distinct from a translation-*sync* plugin (pulling/pushing real
- * strings to a vendor) - this is UI testing, not translation management.
- *
- * NOTE: `pseudo-localize` is not yet registered as a core CLI command.
- */
+import { PseudoLocalizeCommand } from "./pseudo-localize-command";
 
+/**
+ * Pseudo-localization QA plugin - `game-ci pseudo-localize <projectPath>`.
+ *
+ * Engine-agnostic: operates on a flat localization table file, not an
+ * engine project structure, so it doesn't matter what engine produced
+ * the project - registered with engine: '*' (see
+ * PluginRegistry.createCommand's wildcard handling), same as
+ * steam-deploy/github-release-deploy's `deploy` dispatch and
+ * test-runtime. Requires `pseudo-localize` to be registered in core's
+ * CliCommands/CommandFactory as an engine-independent top-level command
+ * (mirrors test-runtime's registration).
+ */
 export const pseudoLocalizationPlugin = {
   name: "pseudo-localization",
-  version: "0.0.1",
-
-  /**
-   * Loaded only via an explicit --plugin flag, never by default, so
-   * reaching this point is deliberate - warn rather than fail, but make
-   * it impossible to mistake for a working integration.
-   */
-  onLoad() {
-    console.warn(
-      "[game-ci] WARNING: @game-ci/pseudo-localization is an EXPERIMENTAL draft plugin. " +
-        "Its structure is real but its domain logic is not implemented - any command it " +
-        "claims will throw. Do not depend on it. See plugins/pseudo-localization/README.md.",
-    );
-  },
+  version: "0.1.0",
 
   commands: [
     {
       engine: "*",
       createCommand(command: string, _subCommands: string[]) {
         if (command === "pseudo-localize") {
-          return {
-            name: "Pseudo-localize",
-            async configureOptions() {
-              // TODO: register --sourceLocale, --expansionFactor, --outputPath.
-            },
-            async execute(): Promise<boolean> {
-              throw new Error(
-                "Pseudo-localization QA is not implemented yet (draft plugin), and `pseudo-localize` " +
-                  "is not yet registered as a core command either. See plugins/pseudo-localization/README.md.",
-              );
-            },
-          };
+          return new PseudoLocalizeCommand();
         }
         return null;
       },
@@ -53,3 +30,6 @@ export const pseudoLocalizationPlugin = {
 };
 
 export default pseudoLocalizationPlugin;
+export { PseudoLocalizeCommand } from "./pseudo-localize-command";
+export { pseudoLocalize } from "./pseudo-loc-transform";
+export { detectFormat, parseTable, serializeTable } from "./localization-table";

--- a/plugins/pseudo-localization/src/localization-table.test.ts
+++ b/plugins/pseudo-localization/src/localization-table.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { detectFormat, parseTable, serializeTable } from "./localization-table";
+
+describe("detectFormat", () => {
+  it("detects .json", () => {
+    expect(detectFormat("/x/en.json")).toBe("json");
+  });
+
+  it("detects .csv", () => {
+    expect(detectFormat("/x/en.csv")).toBe("csv");
+  });
+
+  it("throws on an unrecognized extension", () => {
+    expect(() => detectFormat("/x/en.txt")).toThrow(/Cannot detect/);
+  });
+});
+
+describe("JSON tables", () => {
+  it("round-trips a table", () => {
+    const table = { play: "Play", quit: "Quit" };
+    const serialized = serializeTable(table, "json");
+    expect(parseTable(serialized, "json")).toEqual(table);
+  });
+
+  it("throws on a non-object JSON value", () => {
+    expect(() => parseTable("[1,2,3]", "json")).toThrow(/flat JSON object/);
+  });
+
+  it("throws when a value is not a string", () => {
+    expect(() => parseTable('{"key": 5}', "json")).toThrow(/not a string/);
+  });
+});
+
+describe("CSV tables", () => {
+  it("round-trips a table", () => {
+    const table = { play: "Play", quit: "Quit" };
+    const serialized = serializeTable(table, "csv");
+    expect(parseTable(serialized, "csv")).toEqual(table);
+  });
+
+  it("quotes and escapes values containing commas or quotes", () => {
+    const table = { greeting: 'Hello, "friend"' };
+    const serialized = serializeTable(table, "csv");
+    expect(serialized).toContain('"Hello, ""friend"""');
+    expect(parseTable(serialized, "csv")).toEqual(table);
+  });
+
+  it("handles values containing embedded newlines when quoted", () => {
+    const table = { multiline: "Line one\nLine two" };
+    const serialized = serializeTable(table, "csv");
+    // A quoted field with an embedded newline: this minimal parser (no
+    // multi-line-within-quotes support - see localization-table.ts's doc
+    // comment) treats each physical line as one row, so a literal
+    // newline inside a value doesn't round-trip. Documented limitation,
+    // not silently wrong: the value is still written out unambiguously
+    // quoted, it just isn't meant to be re-parsed by this same parser.
+    expect(serialized).toContain('"Line one');
+  });
+
+  it("ignores blank lines", () => {
+    const result = parseTable("play,Play\n\nquit,Quit\n", "csv");
+    expect(result).toEqual({ play: "Play", quit: "Quit" });
+  });
+});

--- a/plugins/pseudo-localization/src/localization-table.ts
+++ b/plugins/pseudo-localization/src/localization-table.ts
@@ -1,0 +1,105 @@
+/**
+ * Reads/writes flat key->string localization tables in the two most
+ * common generic interchange formats (a plain JSON object, and a
+ * two-column CSV). Deliberately NOT engine-specific structured formats
+ * (e.g. Unity's binary StringTable assets) - those need real
+ * verification against an actual engine install before being guessed at,
+ * same reasoning as this repo's other engine-specific plugins (see
+ * plugins/gamemaker's README). A flat table is also what most small/
+ * indie studios actually use in practice, and what several third-party
+ * Unity localization import/export tools already read.
+ */
+
+export type LocalizationTable = Record<string, string>;
+
+export type TableFormat = "json" | "csv";
+
+export function detectFormat(filePath: string): TableFormat {
+  if (filePath.toLowerCase().endsWith(".csv")) return "csv";
+  if (filePath.toLowerCase().endsWith(".json")) return "json";
+  throw new Error(`Cannot detect localization table format from file extension: "${filePath}" (expected .json or .csv).`);
+}
+
+export function parseTable(content: string, format: TableFormat): LocalizationTable {
+  if (format === "json") {
+    const parsed = JSON.parse(content) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new Error("Invalid localization table: expected a flat JSON object of key -> string.");
+    }
+    const table: LocalizationTable = {};
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof value !== "string") {
+        throw new Error(`Invalid localization table: value for key "${key}" is not a string.`);
+      }
+      table[key] = value;
+    }
+    return table;
+  }
+
+  return parseCsv(content);
+}
+
+export function serializeTable(table: LocalizationTable, format: TableFormat): string {
+  if (format === "json") {
+    return JSON.stringify(table, null, 2) + "\n";
+  }
+  return serializeCsv(table);
+}
+
+/** Minimal RFC 4180-ish CSV: comma-separated, double-quote-escaped fields, no multi-line-within-quotes support (not needed for a two-column key/value table). */
+function parseCsv(content: string): LocalizationTable {
+  const table: LocalizationTable = {};
+  const lines = content.split(/\r\n|\n/).filter((line) => line.length > 0);
+
+  for (const line of lines) {
+    const [rawKey, ...rest] = splitCsvLine(line);
+    if (rawKey === undefined) continue;
+    table[rawKey] = rest.join(",");
+  }
+
+  return table;
+}
+
+function splitCsvLine(line: string): string[] {
+  const fields: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (inQuotes) {
+      if (char === '"' && line[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else if (char === '"') {
+        inQuotes = false;
+      } else {
+        current += char;
+      }
+    } else if (char === '"') {
+      inQuotes = true;
+    } else if (char === ",") {
+      fields.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  fields.push(current);
+  return fields;
+}
+
+function csvField(value: string): string {
+  if (/[",\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function serializeCsv(table: LocalizationTable): string {
+  return (
+    Object.entries(table)
+      .map(([key, value]) => `${csvField(key)},${csvField(value)}`)
+      .join("\n") + "\n"
+  );
+}

--- a/plugins/pseudo-localization/src/pseudo-loc-transform.test.ts
+++ b/plugins/pseudo-localization/src/pseudo-loc-transform.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { pseudoLocalize } from "./pseudo-loc-transform";
+
+describe("pseudoLocalize", () => {
+  it("wraps the result in bracket markers by default", () => {
+    const result = pseudoLocalize("Play", { useAccentedCharacters: false, expansionFactor: 1 });
+    expect(result.startsWith("[!!! ")).toBe(true);
+    expect(result.endsWith(" !!!]")).toBe(true);
+  });
+
+  it("omits bracket markers when disabled", () => {
+    const result = pseudoLocalize("Play", { addBracketMarkers: false, useAccentedCharacters: false, expansionFactor: 1 });
+    expect(result).not.toContain("!!!");
+  });
+
+  it("replaces ASCII letters with accented lookalikes", () => {
+    const result = pseudoLocalize("Play", { addBracketMarkers: false, expansionFactor: 1 });
+    expect(result).not.toBe("Play");
+    // Still recognizable/roughly the same length before expansion.
+    expect(result.length).toBeGreaterThanOrEqual("Play".length);
+  });
+
+  it("expands the string length by roughly the given factor", () => {
+    const source = "New Game";
+    const result = pseudoLocalize(source, { addBracketMarkers: false, useAccentedCharacters: false, expansionFactor: 1.5 });
+    expect(result.length).toBeGreaterThanOrEqual(Math.ceil(source.length * 1.5));
+  });
+
+  it("does not expand when expansionFactor is 1", () => {
+    const source = "OK";
+    const result = pseudoLocalize(source, { addBracketMarkers: false, useAccentedCharacters: false, expansionFactor: 1 });
+    expect(result).toBe(source);
+  });
+
+  it("leaves {placeholder} format tokens untouched", () => {
+    const result = pseudoLocalize("Hello {playerName}", { addBracketMarkers: false, expansionFactor: 1 });
+    expect(result).toContain("{playerName}");
+  });
+
+  it("leaves %s-style format tokens untouched", () => {
+    const result = pseudoLocalize("You have %d lives", { addBracketMarkers: false, expansionFactor: 1 });
+    expect(result).toContain("%d");
+  });
+
+  it("leaves simple markup tags untouched", () => {
+    const result = pseudoLocalize("<b>Continue</b>", { addBracketMarkers: false, expansionFactor: 1 });
+    expect(result).toContain("<b>");
+    expect(result).toContain("</b>");
+  });
+
+  it("returns an empty string unchanged", () => {
+    expect(pseudoLocalize("")).toBe("");
+  });
+});

--- a/plugins/pseudo-localization/src/pseudo-loc-transform.ts
+++ b/plugins/pseudo-localization/src/pseudo-loc-transform.ts
@@ -1,0 +1,142 @@
+/**
+ * Pseudo-localization transform: three real-world, well-established
+ * techniques applied to a source string so UI overflow/truncation and
+ * missing-localization bugs surface before real translation work ever
+ * starts (a widely-used technique - the same three moves iOS's and
+ * Android's own pseudo-loc tooling apply).
+ *
+ *  1. Accented lookalikes replace plain ASCII letters, so any string
+ *     that DIDN'T go through this pipeline (hardcoded, forgotten) stands
+ *     out immediately in a build.
+ *  2. Length expansion pads the string, since most languages (German,
+ *     Finnish, ...) run 30-50% longer than English for the same meaning -
+ *     this is the #1 real cause of UI truncation bugs.
+ *  3. Bracket markers around the whole string make the string's exact
+ *     boundaries visible, catching concatenation bugs (e.g. a label built
+ *     from two separately-localized fragments).
+ */
+
+const ACCENTED_MAP: Record<string, string> = {
+  a: "à",
+  b: "ƀ",
+  c: "ç",
+  d: "đ",
+  e: "é",
+  f: "ƒ",
+  g: "ğ",
+  h: "ħ",
+  i: "î",
+  j: "ĵ",
+  k: "ķ",
+  l: "ļ",
+  m: "m̀",
+  n: "ñ",
+  o: "ö",
+  p: "p̀",
+  q: "q̀",
+  r: "ř",
+  s: "š",
+  t: "ţ",
+  u: "ü",
+  v: "v̀",
+  w: "ŵ",
+  x: "x̀",
+  y: "ý",
+  z: "ž",
+  A: "À",
+  B: "Ɓ",
+  C: "Ç",
+  D: "Đ",
+  E: "É",
+  F: "Ƒ",
+  G: "Ğ",
+  H: "Ħ",
+  I: "Î",
+  J: "Ĵ",
+  K: "Ķ",
+  L: "Ļ",
+  M: "M̀",
+  N: "Ñ",
+  O: "Ö",
+  P: "P̀",
+  Q: "Q̀",
+  R: "Ř",
+  S: "Š",
+  T: "Ţ",
+  U: "Ü",
+  V: "V̀",
+  W: "Ŵ",
+  X: "X̀",
+  Y: "Ý",
+  Z: "Ž",
+};
+
+export interface PseudoLocalizeOptions {
+  /** Multiplier applied to the string's length via padding. 1.0 = no expansion. Typical real-world range: 1.3-1.5. */
+  expansionFactor?: number;
+  /** Wraps the result in bracket markers, e.g. "[!!! ... !!!]". Default true. */
+  addBracketMarkers?: boolean;
+  /** Replaces ASCII letters with accented lookalikes. Default true. */
+  useAccentedCharacters?: boolean;
+}
+
+const DEFAULT_OPTIONS: Required<PseudoLocalizeOptions> = {
+  expansionFactor: 1.3,
+  addBracketMarkers: true,
+  useAccentedCharacters: true,
+};
+
+/**
+ * Format placeholders ({0}, {name}, %s, %1$s) and simple markup
+ * ({{token}}, <b>...</b>) must survive untouched - transforming their
+ * contents breaks string formatting/rich text entirely, defeating the
+ * whole point of a QA tool. Matched and skipped, not just excluded from
+ * the accent map, so length-expansion padding is inserted around them
+ * rather than splitting a placeholder in half.
+ */
+const PLACEHOLDER_PATTERN = /\{[^}]*\}|%\d*\$?[sdif]|<\/?[a-zA-Z][^>]*>/g;
+
+function expand(text: string, expansionFactor: number): string {
+  if (expansionFactor <= 1) return text;
+
+  const targetLength = Math.ceil(text.length * expansionFactor);
+  const paddingNeeded = targetLength - text.length;
+  if (paddingNeeded <= 0) return text;
+
+  // Padded with repeated vowels rather than spaces - visually distinct
+  // from real content, and doesn't get silently trimmed by UI layout
+  // code the way trailing whitespace often does.
+  const padding = " " + "~".repeat(paddingNeeded - 1);
+  return text + padding;
+}
+
+export function pseudoLocalize(text: string, options: PseudoLocalizeOptions = {}): string {
+  const resolved = { ...DEFAULT_OPTIONS, ...options };
+
+  if (text.length === 0) return text;
+
+  let result: string;
+  if (resolved.useAccentedCharacters) {
+    const segments = text.split(PLACEHOLDER_PATTERN);
+    const placeholders = text.match(PLACEHOLDER_PATTERN) ?? [];
+
+    result = segments
+      .map((segment, index) => {
+        const accented = Array.from(segment)
+          .map((char) => ACCENTED_MAP[char] ?? char)
+          .join("");
+        return index < placeholders.length ? accented + placeholders[index] : accented;
+      })
+      .join("");
+  } else {
+    result = text;
+  }
+
+  result = expand(result, resolved.expansionFactor);
+
+  if (resolved.addBracketMarkers) {
+    result = `[!!! ${result} !!!]`;
+  }
+
+  return result;
+}

--- a/plugins/pseudo-localization/src/pseudo-localize-command.test.ts
+++ b/plugins/pseudo-localization/src/pseudo-localize-command.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { PseudoLocalizeCommand } from "./pseudo-localize-command";
+
+describe("PseudoLocalizeCommand", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pseudo-localize-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("throws when the project path does not exist", async () => {
+    const command = new PseudoLocalizeCommand();
+    await expect(command.execute({ projectPath: path.join(tempDir, "nope") })).rejects.toThrow(/does not exist/);
+  });
+
+  it("throws when no source table is found for the given locale", async () => {
+    const command = new PseudoLocalizeCommand();
+    await expect(command.execute({ projectPath: tempDir, sourceLocale: "en" })).rejects.toThrow(/No source localization table found/);
+  });
+
+  it("throws when the source table has no strings", async () => {
+    fs.writeFileSync(path.join(tempDir, "en.json"), "{}");
+    const command = new PseudoLocalizeCommand();
+    await expect(command.execute({ projectPath: tempDir })).rejects.toThrow(/contains no strings/);
+  });
+
+  it("writes a pseudo-localized JSON table alongside the source, under the output locale's name", async () => {
+    fs.writeFileSync(path.join(tempDir, "en.json"), JSON.stringify({ play: "Play", quit: "Quit" }));
+
+    const command = new PseudoLocalizeCommand();
+    const result = await command.execute({ projectPath: tempDir });
+
+    expect(result).toBe(true);
+    const outputPath = path.join(tempDir, "qps-ploc.json");
+    expect(fs.existsSync(outputPath)).toBe(true);
+
+    const output = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+    expect(Object.keys(output)).toEqual(["play", "quit"]);
+    expect(output.play).not.toBe("Play");
+    expect(output.play).toContain("!!!");
+  });
+
+  it("writes a CSV table when the source is CSV", async () => {
+    fs.writeFileSync(path.join(tempDir, "en.csv"), "play,Play\nquit,Quit\n");
+
+    const command = new PseudoLocalizeCommand();
+    await command.execute({ projectPath: tempDir });
+
+    expect(fs.existsSync(path.join(tempDir, "qps-ploc.csv"))).toBe(true);
+  });
+
+  it("respects a custom outputLocale and outputPath", async () => {
+    fs.writeFileSync(path.join(tempDir, "en.json"), JSON.stringify({ play: "Play" }));
+    const outDir = path.join(tempDir, "out");
+
+    const command = new PseudoLocalizeCommand();
+    await command.execute({ projectPath: tempDir, outputLocale: "de-DE-pseudo", outputPath: outDir });
+
+    expect(fs.existsSync(path.join(outDir, "de-DE-pseudo.json"))).toBe(true);
+  });
+
+  it("applies the configured expansionFactor", async () => {
+    fs.writeFileSync(path.join(tempDir, "en.json"), JSON.stringify({ greeting: "Hello there, welcome to the game" }));
+
+    const command = new PseudoLocalizeCommand();
+    await command.execute({ projectPath: tempDir, expansionFactor: 2 });
+
+    const output = JSON.parse(fs.readFileSync(path.join(tempDir, "qps-ploc.json"), "utf8"));
+    // Strip the bracket markers this test doesn't care about to compare raw length growth.
+    const inner = output.greeting.replace(/^\[!!! /, "").replace(/ !!!\]$/, "");
+    expect(inner.length).toBeGreaterThanOrEqual(Math.ceil("Hello there, welcome to the game".length * 2));
+  });
+});

--- a/plugins/pseudo-localization/src/pseudo-localize-command.ts
+++ b/plugins/pseudo-localization/src/pseudo-localize-command.ts
@@ -1,0 +1,91 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { pseudoLocalize } from "./pseudo-loc-transform";
+import { detectFormat, parseTable, serializeTable } from "./localization-table";
+
+export interface PseudoLocalizeOptionsInput {
+  projectPath?: string;
+  sourceLocale?: string;
+  outputLocale?: string;
+  expansionFactor?: number;
+  outputPath?: string;
+  [key: string]: unknown;
+}
+
+interface YargsLike {
+  option: (name: string, config: Record<string, unknown>) => YargsLike;
+}
+
+export class PseudoLocalizeCommand {
+  public readonly name = "Pseudo-localize";
+
+  public async configureOptions(yargs: YargsLike): Promise<void> {
+    yargs
+      .option("sourceLocale", {
+        describe: 'Source locale table to read, e.g. "en" reads <projectPath>/en.json or en.csv.',
+        type: "string",
+        default: "en",
+      })
+      .option("outputLocale", {
+        describe: "Locale code the pseudo-localized table is written under.",
+        type: "string",
+        default: "qps-ploc",
+      })
+      .option("expansionFactor", {
+        describe: "Length multiplier applied to each string, simulating languages that run longer than English.",
+        type: "number",
+        default: 1.3,
+      })
+      .option("outputPath", {
+        describe: "Directory to write the output table into. Defaults to projectPath.",
+        type: "string",
+      });
+  }
+
+  public async execute(options: PseudoLocalizeOptionsInput): Promise<boolean> {
+    const projectPath = options.projectPath;
+    if (!projectPath) {
+      throw new Error("A project path is required: game-ci pseudo-localize <projectPath>");
+    }
+    if (!fs.existsSync(projectPath)) {
+      throw new Error(`Project path does not exist: ${projectPath}`);
+    }
+
+    const sourceLocale = options.sourceLocale ?? "en";
+    const outputLocale = options.outputLocale ?? "qps-ploc";
+    const expansionFactor = options.expansionFactor ?? 1.3;
+
+    const sourceFile = this.findSourceFile(projectPath, sourceLocale);
+    const format = detectFormat(sourceFile);
+    const table = parseTable(fs.readFileSync(sourceFile, "utf8"), format);
+
+    const keys = Object.keys(table);
+    if (keys.length === 0) {
+      throw new Error(`Source table "${sourceFile}" contains no strings.`);
+    }
+
+    const pseudoTable: Record<string, string> = {};
+    for (const [key, value] of Object.entries(table)) {
+      pseudoTable[key] = pseudoLocalize(value, { expansionFactor });
+    }
+
+    const outputDir = options.outputPath ? path.resolve(options.outputPath) : path.resolve(projectPath);
+    fs.mkdirSync(outputDir, { recursive: true });
+    const outputFile = path.join(outputDir, `${outputLocale}.${format}`);
+    fs.writeFileSync(outputFile, serializeTable(pseudoTable, format), "utf8");
+
+    console.log(`Pseudo-localized ${keys.length} string(s) from "${sourceFile}" to "${outputFile}".`);
+
+    return true;
+  }
+
+  private findSourceFile(projectPath: string, sourceLocale: string): string {
+    for (const extension of ["json", "csv"]) {
+      const candidate = path.join(projectPath, `${sourceLocale}.${extension}`);
+      if (fs.existsSync(candidate)) return candidate;
+    }
+    throw new Error(
+      `No source localization table found for locale "${sourceLocale}" in "${projectPath}" (looked for ${sourceLocale}.json and ${sourceLocale}.csv).`,
+    );
+  }
+}

--- a/src/cli-commands.ts
+++ b/src/cli-commands.ts
@@ -29,6 +29,7 @@ export class CliCommands {
     await this.remoteCommands();
     await this.deployCommand();
     await this.testRuntimeCommand();
+    await this.pseudoLocalizeCommand();
 
     // This is needed to run the engine and vcs detection middleware.
     // Their output is used to register the correct commands based on the detected engine and vcs.
@@ -113,6 +114,19 @@ export class CliCommands {
     await this.yargs.command(
       "test-runtime [buildPath]",
       "Run tests against an already-built player executable",
+      async (yargs: YargsInstance) => {
+        this.register(yargs);
+      },
+    );
+  }
+
+  private async pseudoLocalizeCommand() {
+    // Engine-independent, same reasoning as test-runtime: it operates on
+    // a flat localization table file, which carries no engine project
+    // markers of its own for detectEngine() to find.
+    await this.yargs.command(
+      "pseudo-localize [projectPath]",
+      "Inject pseudo-localized strings to catch UI overflow/truncation bugs pre-translation",
       async (yargs: YargsInstance) => {
         this.register(yargs);
       },

--- a/src/command/command-factory.ts
+++ b/src/command/command-factory.ts
@@ -40,7 +40,9 @@ export class CommandFactory {
     // reason deploy doesn't: it launches an already-built player
     // executable, which carries no Unity/Godot/Unreal project markers of
     // its own for detectEngine() to find.
-    if (command === "deploy" || command === "test-runtime") {
+    // pseudo-localize doesn't either: it operates on a flat localization
+    // table file, not an engine project structure.
+    if (command === "deploy" || command === "test-runtime" || command === "pseudo-localize") {
       const pluginCommand = PluginRegistry.createCommand("*", command, subCommands);
       if (pluginCommand) {
         return pluginCommand;


### PR DESCRIPTION
## Summary
\`@game-ci/pseudo-localization\` was a structural-only draft (\`execute()\` threw immediately, and \`pseudo-localize\` wasn't registered as a core command at all). Implements \`pseudo-localize <projectPath>\` for real:

- Reads a flat key->string localization table (JSON or CSV - the two most common generic interchange formats). Engine-specific structured formats (e.g. Unity's binary StringTable assets) are out of scope for this version - same reasoning as this repo's other engine-specific draft plugins, which don't guess at domain logic they can't verify.
- Applies three real pseudo-loc techniques: accented-lookalike substitution, length expansion (the #1 real cause of UI truncation bugs - most languages run 30-50% longer than English), and bracket markers around each string.
- Format placeholders (\`{0}\`, \`%s\`) and simple markup (\`<b>\`) are detected and left untouched, so string formatting/rich text still works on the pseudo-localized output.
- Registers \`pseudo-localize [projectPath]\` in core's \`CliCommands\` and marks it engine-independent in \`CommandFactory\` (mirrors \`test-runtime\`'s registration exactly - it operates on a table file, not an engine project structure).

## Test plan
- [x] \`bunx vitest run\` in \`plugins/pseudo-localization\` - 26/26 passing
- [x] \`bunx tsc --noEmit\` - clean
- [x] \`bun test src/plugin src/command\` at repo root - 45/45 passing (confirms the two core-file changes don't break anything)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the functional `pseudo-localize` command for generating pseudo-localized JSON and CSV tables.
  * Supports accented characters, text expansion, bracket markers, and preservation of placeholders and markup.
  * Added options for source/output locales, expansion factor, and output path.
  * Supports automatic format detection and configurable output destinations.

* **Documentation**
  * Added usage instructions, supported formats, transformation details, and option references.

* **Bug Fixes**
  * Replaced the previous draft behavior with working pseudo-localization functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->