### PR TITLE
feat(itch-deploy): implement the plugin for real

### DIFF
--- a/plugins/itch-deploy/README.md
+++ b/plugins/itch-deploy/README.md
@@ -1,39 +1,48 @@
-> **EXPERIMENTAL — NOT IMPLEMENTED.** This is a structural draft only: the plugin
-> shape is real, but its domain logic is not written. Any command it claims will
-> throw. It is not published to npm and is never loaded unless you pass
-> `--plugin @game-ci/itch-deploy` explicitly.
+> **EXPERIMENTAL.** Functional, but not published to npm and never loaded
+> unless you pass `--plugin @game-ci/itch-deploy` explicitly. Not wired
+> into core's default load list.
 
-# @game-ci/itch-deploy (draft)
+# @game-ci/itch-deploy
 
-itch.io deploy plugin. **Not functional yet** - structural skeleton only.
-Mirrors `@game-ci/steam-deploy`'s shape: engine-agnostic, dispatched via
-the `deploy` command's `'*'` engine wildcard. Not wired into core's
-default load list.
+`game-ci deploy itch <buildPath> --user --game --channel` wraps itch.io's
+official `butler push` CLI. Mirrors `@game-ci/steam-deploy`'s shape:
+engine-agnostic, dispatched via the `deploy` command's `'*'` engine
+wildcard.
 
-## Why itch.io
+## Usage
 
-Huge game-jam/indie audience, currently all ad hoc third-party GitHub
-Actions. itch.io's official `butler` CLI is straightforward, so this
-should be one of the faster ones to bring to real functionality once
-someone picks it up.
+```bash
+BUTLER_API_KEY=... game-ci deploy itch ./build --user myuser --game mygame --channel windows
+```
 
-## What's real vs. TODO
+- Requires `butler` already installed and on `PATH` (or pass
+  `--butlerPath` explicitly - recommended for CI determinism). This
+  plugin doesn't auto-install or auto-download butler.
+- The API key is read from `$BUTLER_API_KEY` only, never a CLI argument -
+  butler itself reads this env var and skips its normal interactive
+  `butler login` flow, matching `steam-deploy`'s credential handling.
+- Success/failure is trusted from butler's own exit code - unlike
+  SteamCMD (see `steam-deploy`'s `parse-steamcmd-output.ts`), butler is a
+  modern Go CLI with reliable exit-code semantics, so no output-text
+  heuristic is needed. A failure's message includes the tail of butler's
+  own output for diagnostics.
 
-- Plugin/command registration shape: real, mirrors `steam-deploy`'s
-  `deploy <target>` dispatch.
-- `execute()`: throws immediately, pointing here.
+## Options
 
-## Remaining work before this is real
+| Option          | Description                                                                 |
+| ----------------- | ---------------------------------------------------------------------------- |
+| `--user`         | itch.io username or organization. Required.                                 |
+| `--game`         | itch.io game slug. Required.                                                 |
+| `--channel`      | Channel to push to, e.g. `windows`, `linux`, `web`. Required.               |
+| `--butlerPath`   | Explicit path to the butler executable.                                     |
+| `--userVersion`  | Custom version string shown in itch.io's build history (butler's `--userversion`). |
+| `--ignore`       | Comma-separated glob patterns excluded from the push.                       |
 
-1. Wrap `butler push <buildPath> <user>/<game>:<channel>`, including
-   butler's own login/credential handling (an API key, likely via
-   `BUTLER_API_KEY` env var, matching steam-deploy's env-var-only
-   credential convention - never CLI args).
-2. Decide how `game-ci deploy itch` needs core's `deploy <target>
-[buildPath]` yargs registration extended, if at all (steam-deploy
-   already required a core change here - see game-ci/cli#123 - itch may
-   reuse it as-is once its own options are registered via
-   `configureOptions`).
-3. Tests mirroring `steam-deploy`'s `parse-steamcmd-output.test.ts` and
-   `vdf-generator.test.ts` pattern - butler's own output has a similar
-   "did this actually succeed" ambiguity worth checking.
+## A note on verification
+
+Butler's `push`/`--userversion`/`--ignore` flag shapes are taken from
+itch.io's own public documentation and are stable, long-standing butler
+CLI conventions - but this implementation hasn't been run against a live
+`butler push` in this session. Verify against a real itch.io project
+before depending on it in production; please report back (or send a fix)
+if anything doesn't match butler's actual behavior.

--- a/plugins/itch-deploy/package.json
+++ b/plugins/itch-deploy/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@game-ci/itch-deploy",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
-  "description": "EXPERIMENTAL (draft, not implemented): itch.io deploy plugin (draft). Wraps butler push for itch.io channel deploys.",
+  "description": "EXPERIMENTAL: itch.io deploy plugin. Wraps butler push for itch.io channel deploys.",
   "license": "MIT",
   "repository": "git@github.com:game-ci/cli.git",
   "files": [

--- a/plugins/itch-deploy/src/butler-runner.test.ts
+++ b/plugins/itch-deploy/src/butler-runner.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { ButlerRunner } from "./butler-runner";
+
+function fakeSpawn(exitCode: number, output = "") {
+  const calls: Array<{ command: string; args: string[] }> = [];
+  const spawnFn = vi.fn((command: string, args: string[]) => {
+    calls.push({ command, args });
+    const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    setImmediate(() => {
+      if (output) child.stdout.emit("data", Buffer.from(output));
+      child.emit("close", exitCode);
+    });
+    return child as unknown as ReturnType<typeof import("node:child_process").spawn>;
+  });
+  return { spawnFn, calls };
+}
+
+describe("ButlerRunner", () => {
+  it("builds the expected push argv", async () => {
+    const { spawnFn, calls } = fakeSpawn(0);
+    const runner = new ButlerRunner(spawnFn);
+
+    await runner.push({ buildDir: "./build", target: "user/game", channel: "windows" });
+
+    expect(calls[0].command).toBe("butler");
+    expect(calls[0].args).toEqual(["push", "./build", "user/game:windows"]);
+  });
+
+  it("uses butlerPath when given instead of the bare PATH-resolved binary", async () => {
+    const { spawnFn, calls } = fakeSpawn(0);
+    const runner = new ButlerRunner(spawnFn);
+
+    await runner.push({ buildDir: "./build", target: "user/game", channel: "windows", butlerPath: "/opt/butler/butler" });
+
+    expect(calls[0].command).toBe("/opt/butler/butler");
+  });
+
+  it("appends --userversion when given", async () => {
+    const { spawnFn, calls } = fakeSpawn(0);
+    const runner = new ButlerRunner(spawnFn);
+
+    await runner.push({ buildDir: "./build", target: "user/game", channel: "windows", userVersion: "1.2.3" });
+
+    expect(calls[0].args).toContain("--userversion");
+    expect(calls[0].args[calls[0].args.indexOf("--userversion") + 1]).toBe("1.2.3");
+  });
+
+  it("appends a repeated --ignore flag per pattern", async () => {
+    const { spawnFn, calls } = fakeSpawn(0);
+    const runner = new ButlerRunner(spawnFn);
+
+    await runner.push({ buildDir: "./build", target: "user/game", channel: "windows", ignore: ["*.pdb", "*.log"] });
+
+    const ignoreIndices = calls[0].args.reduce<number[]>((acc, arg, i) => (arg === "--ignore" ? [...acc, i] : acc), []);
+    expect(ignoreIndices).toHaveLength(2);
+    expect(calls[0].args[ignoreIndices[0] + 1]).toBe("*.pdb");
+    expect(calls[0].args[ignoreIndices[1] + 1]).toBe("*.log");
+  });
+
+  it("resolves success on exit code 0", async () => {
+    const { spawnFn } = fakeSpawn(0);
+    const runner = new ButlerRunner(spawnFn);
+
+    const result = await runner.push({ buildDir: "./build", target: "user/game", channel: "windows" });
+
+    expect(result).toEqual({ success: true });
+  });
+
+  it("surfaces the output tail on a non-zero exit code", async () => {
+    const { spawnFn } = fakeSpawn(1, "Logging in...\nError: invalid API key\n");
+    const runner = new ButlerRunner(spawnFn);
+
+    const result = await runner.push({ buildDir: "./build", target: "user/game", channel: "windows" });
+
+    expect(result.success).toBe(false);
+    expect(result.failureReason).toContain("exit code 1");
+    expect(result.failureReason).toContain("invalid API key");
+  });
+
+  it("falls back to a bare exit code when there is no output", async () => {
+    const { spawnFn } = fakeSpawn(1);
+    const runner = new ButlerRunner(spawnFn);
+
+    const result = await runner.push({ buildDir: "./build", target: "user/game", channel: "windows" });
+
+    expect(result.failureReason).toBe("exit code 1");
+  });
+});

--- a/plugins/itch-deploy/src/butler-runner.ts
+++ b/plugins/itch-deploy/src/butler-runner.ts
@@ -1,0 +1,84 @@
+import { spawn } from "node:child_process";
+
+export interface RunButlerPushOptions {
+  /** Directory or zip to push. */
+  buildDir: string;
+  /** "user/game". */
+  target: string;
+  channel: string;
+  /** Explicit path to the butler executable. Recommended for CI determinism; defaults to "butler" (resolved via PATH). */
+  butlerPath?: string;
+  /** Tags this push with a custom version string, shown in itch.io's build history (butler's own --userversion flag). */
+  userVersion?: string;
+  /** Glob patterns excluded from the push (butler's own repeatable --ignore flag). */
+  ignore?: string[];
+}
+
+export interface ButlerPushResult {
+  success: boolean;
+  /** Populated on failure with the tail of butler's own output, for diagnostics. */
+  failureReason?: string;
+}
+
+type SpawnFn = typeof spawn;
+
+function pushArgs(options: RunButlerPushOptions): string[] {
+  const args = ["push", options.buildDir, `${options.target}:${options.channel}`];
+
+  if (options.userVersion) {
+    args.push("--userversion", options.userVersion);
+  }
+  for (const pattern of options.ignore ?? []) {
+    args.push("--ignore", pattern);
+  }
+
+  return args;
+}
+
+/**
+ * Runs `butler push`. Butler is a modern Go CLI with sane exit-code
+ * semantics (unlike steamcmd's well-documented "exit 0 can still mean
+ * failure" quirk - see steam-deploy's parse-steamcmd-output.ts) - success
+ * is trusted from the exit code directly, and only failures need their
+ * output surfaced for diagnostics.
+ *
+ * Requires butler already installed and on PATH (or at --butlerPath).
+ * Unlike steam-deploy's docker fallback (a well-known, stable
+ * cm2network/steamcmd image), this repo doesn't have a verified official
+ * itch.io/butler Docker image to fall back to - adding one later is a
+ * follow-up, not guessed at here (same "don't ship unverified domain
+ * logic" reasoning as this repo's other draft plugins).
+ */
+export class ButlerRunner {
+  constructor(private readonly spawnFn: SpawnFn = spawn) {}
+
+  async push(options: RunButlerPushOptions): Promise<ButlerPushResult> {
+    const butlerPath = options.butlerPath ?? "butler";
+    const args = pushArgs(options);
+
+    return new Promise((resolve, reject) => {
+      const child = this.spawnFn(butlerPath, args, { stdio: ["ignore", "pipe", "pipe"] });
+      let output = "";
+      child.stdout?.on("data", (chunk) => (output += chunk.toString()));
+      child.stderr?.on("data", (chunk) => (output += chunk.toString()));
+      child.on("error", reject);
+      child.on("close", (exitCode) => {
+        if (exitCode === 0) {
+          resolve({ success: true });
+          return;
+        }
+
+        const tail = output
+          .split("\n")
+          .map((line) => line.trim())
+          .filter(Boolean)
+          .slice(-5)
+          .join(" | ");
+        resolve({
+          success: false,
+          failureReason: tail ? `exit code ${exitCode}: ${tail}` : `exit code ${exitCode}`,
+        });
+      });
+    });
+  }
+}

--- a/plugins/itch-deploy/src/index.ts
+++ b/plugins/itch-deploy/src/index.ts
@@ -1,49 +1,28 @@
-/**
- * itch.io deploy plugin - DRAFT.
- *
- * Plan: `game-ci deploy itch <buildPath> --user --game --channel`,
- * wrapping itch.io's official `butler push` CLI. Structurally identical
- * to @game-ci/steam-deploy (engine-agnostic, dispatched via the '*'
- * engine wildcard on the `deploy` command) - butler's actual invocation
- * shape and channel-naming conventions need verification before this is
- * functional.
- */
+import { ItchDeployCommand } from "./itch-deploy-command";
 
+/**
+ * itch.io deploy plugin - `game-ci deploy itch <buildPath>`.
+ *
+ * Engine-agnostic: it deploys a pre-built output folder, so it doesn't
+ * matter whether Unity, Godot, Unreal, or anything else produced it.
+ * Registered with engine: '*' (see PluginRegistry.createCommand's
+ * wildcard handling), mirroring steam-deploy's dispatch shape. Not wired
+ * into core's default load list.
+ */
 export const itchDeployPlugin = {
   name: "itch-deploy",
-  version: "0.0.1",
-
-  /**
-   * Loaded only via an explicit --plugin flag, never by default, so
-   * reaching this point is deliberate - warn rather than fail, but make
-   * it impossible to mistake for a working integration.
-   */
-  onLoad() {
-    console.warn(
-      "[game-ci] WARNING: @game-ci/itch-deploy is an EXPERIMENTAL draft plugin. " +
-        "Its structure is real but its domain logic is not implemented - any command it " +
-        "claims will throw. Do not depend on it. See plugins/itch-deploy/README.md.",
-    );
-  },
+  version: "0.1.0",
 
   commands: [
     {
       engine: "*",
       createCommand(command: string, subCommands: string[]) {
         if (command === "deploy" && subCommands[0] === "itch") {
-          return {
-            name: "Deploy itch",
-            async configureOptions() {
-              // TODO: register --user, --game, --channel options, matching
-              // butler's <user>/<game>:<channel> target format.
-            },
-            async execute(): Promise<boolean> {
-              throw new Error(
-                "itch.io deploy is not implemented yet (draft plugin). " +
-                  "See plugins/itch-deploy/README.md for the planned `butler push` invocation.",
-              );
-            },
-          };
+          console.warn(
+            "[game-ci] WARNING: `deploy itch` is EXPERIMENTAL. Verify against a test channel " +
+              "before pointing it at a live one.",
+          );
+          return new ItchDeployCommand();
         }
         return null;
       },
@@ -52,3 +31,5 @@ export const itchDeployPlugin = {
 };
 
 export default itchDeployPlugin;
+export { ItchDeployCommand } from "./itch-deploy-command";
+export { ButlerRunner } from "./butler-runner";

--- a/plugins/itch-deploy/src/itch-deploy-command.test.ts
+++ b/plugins/itch-deploy/src/itch-deploy-command.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ItchDeployCommand } from "./itch-deploy-command";
+import * as butlerRunnerModule from "./butler-runner";
+
+describe("ItchDeployCommand", () => {
+  let tempDir: string;
+  const originalKey = process.env.BUTLER_API_KEY;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "itch-deploy-test-"));
+    process.env.BUTLER_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    process.env.BUTLER_API_KEY = originalKey;
+    vi.restoreAllMocks();
+  });
+
+  it("throws when the build path is missing", async () => {
+    const command = new ItchDeployCommand();
+    await expect(command.execute({ user: "u", game: "g", channel: "windows" })).rejects.toThrow(/build path is required/);
+  });
+
+  it("throws when the build path does not exist", async () => {
+    const command = new ItchDeployCommand();
+    await expect(
+      command.execute({ buildPath: path.join(tempDir, "nope"), user: "u", game: "g", channel: "windows" }),
+    ).rejects.toThrow(/does not exist/);
+  });
+
+  it("throws when BUTLER_API_KEY is not set", async () => {
+    delete process.env.BUTLER_API_KEY;
+    const command = new ItchDeployCommand();
+    await expect(command.execute({ buildPath: tempDir, user: "u", game: "g", channel: "windows" })).rejects.toThrow(
+      /BUTLER_API_KEY/,
+    );
+  });
+
+  it("pushes with the expected target/channel and surfaces success", async () => {
+    const pushSpy = vi.spyOn(butlerRunnerModule.ButlerRunner.prototype, "push").mockResolvedValue({ success: true });
+
+    const command = new ItchDeployCommand();
+    const result = await command.execute({ buildPath: tempDir, user: "myuser", game: "mygame", channel: "windows" });
+
+    expect(result).toBe(true);
+    expect(pushSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ buildDir: tempDir, target: "myuser/mygame", channel: "windows" }),
+    );
+  });
+
+  it("splits --ignore on commas into an array", async () => {
+    const pushSpy = vi.spyOn(butlerRunnerModule.ButlerRunner.prototype, "push").mockResolvedValue({ success: true });
+
+    const command = new ItchDeployCommand();
+    await command.execute({ buildPath: tempDir, user: "u", game: "g", channel: "windows", ignore: "*.pdb, *.log" });
+
+    expect(pushSpy).toHaveBeenCalledWith(expect.objectContaining({ ignore: ["*.pdb", "*.log"] }));
+  });
+
+  it("throws with the runner's failure reason when the push fails", async () => {
+    vi.spyOn(butlerRunnerModule.ButlerRunner.prototype, "push").mockResolvedValue({
+      success: false,
+      failureReason: "exit code 1: invalid API key",
+    });
+
+    const command = new ItchDeployCommand();
+    await expect(command.execute({ buildPath: tempDir, user: "u", game: "g", channel: "windows" })).rejects.toThrow(
+      /invalid API key/,
+    );
+  });
+});

--- a/plugins/itch-deploy/src/itch-deploy-command.ts
+++ b/plugins/itch-deploy/src/itch-deploy-command.ts
@@ -1,0 +1,97 @@
+import * as fs from "node:fs";
+import { ButlerRunner } from "./butler-runner";
+
+export interface ItchDeployOptions {
+  buildPath?: string;
+  user?: string;
+  game?: string;
+  channel?: string;
+  butlerPath?: string;
+  userVersion?: string;
+  ignore?: string;
+  [key: string]: unknown;
+}
+
+interface YargsLike {
+  option: (name: string, config: Record<string, unknown>) => YargsLike;
+}
+
+export class ItchDeployCommand {
+  public readonly name = "Deploy itch";
+
+  public async configureOptions(yargs: YargsLike): Promise<void> {
+    yargs
+      .option("user", {
+        describe: "itch.io username or organization.",
+        type: "string",
+        demandOption: true,
+      })
+      .option("game", {
+        describe: "itch.io game slug.",
+        type: "string",
+        demandOption: true,
+      })
+      .option("channel", {
+        describe: 'Channel to push to, e.g. "windows", "linux", "web".',
+        type: "string",
+        demandOption: true,
+      })
+      .option("butlerPath", {
+        describe: "Explicit path to the butler executable. Recommended for CI determinism; defaults to resolving \"butler\" via PATH.",
+        type: "string",
+      })
+      .option("userVersion", {
+        describe: "Custom version string shown in itch.io's build history (butler's own --userversion).",
+        type: "string",
+      })
+      .option("ignore", {
+        describe: "Comma-separated glob patterns to exclude from the push.",
+        type: "string",
+      });
+  }
+
+  public async execute(options: ItchDeployOptions): Promise<boolean> {
+    const buildPath = options.buildPath;
+    if (!buildPath) {
+      throw new Error("A build path is required: game-ci deploy itch <buildPath>");
+    }
+    if (!fs.existsSync(buildPath)) {
+      throw new Error(`Build path does not exist: ${buildPath}`);
+    }
+
+    // Butler itself reads BUTLER_API_KEY from its own process environment
+    // when present, skipping its normal interactive `butler login` flow -
+    // documented itch.io CI convention, and consistent with this repo's
+    // own credentials-as-env-vars-only rule (never CLI arguments - argv
+    // can leak through process listings).
+    if (!process.env.BUTLER_API_KEY) {
+      throw new Error(
+        "BUTLER_API_KEY must be set as an environment variable (never as a CLI argument - argv can leak through process listings).",
+      );
+    }
+
+    const user = options.user!;
+    const game = options.game!;
+    const channel = options.channel!;
+    const ignore = options.ignore ? options.ignore.split(",").map((pattern) => pattern.trim()) : undefined;
+
+    console.log(`Deploying ${buildPath} to itch.io as ${user}/${game}:${channel}`);
+
+    const runner = new ButlerRunner();
+    const result = await runner.push({
+      buildDir: buildPath,
+      target: `${user}/${game}`,
+      channel,
+      butlerPath: options.butlerPath,
+      userVersion: options.userVersion,
+      ignore,
+    });
+
+    if (!result.success) {
+      throw new Error(`itch.io deployment failed: ${result.failureReason}`);
+    }
+
+    console.log(`itch.io deployment succeeded: ${user}/${game}:${channel}`);
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary
\`@game-ci/itch-deploy\` was a structural-only draft (\`execute()\` threw immediately). Implements \`deploy itch <buildPath> --user --game --channel\`, wrapping itch.io's official \`butler push <buildDir> <user>/<game>:<channel>\` CLI.

- \`BUTLER_API_KEY\` read from the environment only, never a CLI argument - butler itself reads this env var and skips its interactive \`butler login\` flow, matching \`steam-deploy\`'s credential handling.
- Success/failure trusted from butler's own exit code (a modern Go CLI with reliable exit-code semantics, unlike SteamCMD) - a failure surfaces the tail of butler's own output for diagnostics.
- Requires butler already on \`PATH\` (or \`--butlerPath\`); no auto-install/download and no Docker fallback, since there's no verified official butler Docker image to fall back to.

Butler's flag shapes are taken from itch.io's own public docs (stable, long-standing conventions) but this hasn't been run against a live butler install in this session - flagged clearly in the README as worth a real smoke test before production use.

## Test plan
- [x] \`bunx vitest run\` - 13/13 passing
- [x] \`bunx tsc --noEmit\` - clean