### PR TITLE
feat(steam-workshop): implement the plugin for real

### DIFF
--- a/plugins/steam-workshop/README.md
+++ b/plugins/steam-workshop/README.md
@@ -1,40 +1,57 @@
-> **EXPERIMENTAL — NOT IMPLEMENTED.** A structural draft only: the plugin shape
-> is real, but its domain logic is not written, so any command it claims will
-> throw. Not published to npm, and never loaded unless you pass
-> `--plugin @game-ci/steam-workshop` explicitly.
+> **EXPERIMENTAL.** Functional, but not published to npm and never loaded
+> unless you pass `--plugin @game-ci/steam-workshop` explicitly.
 
-# @game-ci/steam-workshop (draft)
+# @game-ci/steam-workshop
 
-Steam Workshop / mod-publishing plugin. **Not functional yet** - structural
-skeleton only. Mirrors `@game-ci/steam-deploy`'s `deploy <target>` dispatch
-shape, so it reuses core's existing `deploy` command registration rather
-than needing a new one.
+`game-ci deploy steam-workshop <itemPath> --appId` uploads a Steam
+Workshop item (a mod, map, or asset pack) via SteamCMD's
+`workshop_build_item.vdf` path and `+workshop_build_item` command - a
+genuinely different upload target and VDF schema from
+`@game-ci/steam-deploy`'s full-game `appbuild.vdf`.
 
-## Why this, distinct from steam-deploy
+## Usage
 
-`@game-ci/steam-deploy` uploads a full game build via `appbuild.vdf`. This
-uploads a Workshop _item_ (a mod, map, or asset pack) via SteamCMD's
-separate `workshop_build_item.vdf` format and `+workshop_build_item`
-command - a genuinely different upload target and VDF schema, not a
-variation of the same thing. Real demand: any Workshop-integrated game
-currently has zero game-ci coverage for this.
+```bash
+STEAM_USERNAME=... STEAM_PASSWORD=... game-ci \
+  --plugin @game-ci/steam-workshop \
+  deploy steam-workshop ./my-mod --appId 480 --title "My Mod"
+```
 
-## What's real vs. TODO
+`itemPath` is the item's own content directory - the generated VDF is
+written into it directly and `contentfolder` points at it.
 
-- Plugin/command registration shape: real, mirrors `steam-deploy`.
-- `execute()`: throws immediately, pointing here.
+- Omit `--publishedFileId` to publish a **new** item; SteamCMD assigns
+  the id during upload and it's captured from the tool's own output
+  (there's no other way to learn it) and printed on success.
+- Pass `--publishedFileId` to **update** an existing item instead.
+- Success is trusted from a `PublishedFileId` line in SteamCMD's own
+  output, not exit code alone - SteamCMD can exit 0 without actually
+  uploading anything, so an exit-0-but-no-id result is still reported as
+  a failure (see `parse-workshop-output.ts`).
 
-## Remaining work before this is real
+## Options
 
-1. Verify the exact `workshop_build_item.vdf` schema (`appid`,
-   `contentfolder`, `previewfile`, `vdfpath`/`publishedfileid` for
-   updates vs. new items, `visibility`) against real SteamCMD Workshop
-   docs/behavior.
-2. Handle the new-item vs. update-existing-item distinction - a new item
-   has no `publishedfileid` yet and one needs to be captured from
-   SteamCMD's output and surfaced as a command output (the same way
-   `steam-deploy` captures `steam_build_id`).
-3. Reuse `@game-ci/steam-deploy`'s SteamCMD local/Docker execution and
-   output-parsing infrastructure rather than duplicating it, if a shared
-   `@game-ci/steam-shared` package ends up making sense once both exist.
-4. Tests once the above is real.
+| Option              | Description                                                      |
+| -------------------- | -------------------------------------------------------------- |
+| `--appId`            | Steam App ID the item belongs to. Required.                    |
+| `--publishedFileId`  | Existing item id to update. Omit to publish a new item.        |
+| `--title`            | Item title.                                                     |
+| `--description`      | Item description.                                               |
+| `--changeNote`       | Shown in the item's update history on the Workshop page.       |
+| `--visibility`       | `0` public, `1` friends-only, `2` private, `3` unlisted. Default `0`. |
+| `--previewImage`     | Path (relative to `itemPath`) to a preview image.               |
+| `--mode`             | `auto` (default), `local`, or `docker`.                         |
+| `--steamCmdPath`     | Explicit path to the steamcmd executable.                       |
+
+Credentials are read from `$STEAM_USERNAME`/`$STEAM_PASSWORD` only, never
+CLI arguments - matches `steam-deploy`'s credential handling. TOTP and
+`configVdf`-based auth (which `steam-deploy` supports) aren't wired up
+here yet.
+
+## Relationship to steam-deploy
+
+This duplicates `steam-deploy`'s local/Docker SteamCMD execution shape
+rather than sharing it - `SteamCmdRunner` is hardcoded to the
+`appbuild.vdf`/`+run_app_build` flow. Extracting a shared base package
+once both packages' real usage patterns are settled is a reasonable
+follow-up, not attempted here.

--- a/plugins/steam-workshop/package.json
+++ b/plugins/steam-workshop/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@game-ci/steam-workshop",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
-  "description": "EXPERIMENTAL (draft, not implemented): Steam Workshop / mod-publishing plugin (draft). Wraps SteamCMD's workshop_build_item.vdf upload path for mods/maps/asset packs - a distinct target and VDF schema from a full game build (see @game-ci/steam-deploy).",
+  "description": "EXPERIMENTAL: Steam Workshop / mod-publishing plugin. Wraps SteamCMD's workshop_build_item.vdf upload path for mods/maps/asset packs - a distinct target and VDF schema from a full game build (see @game-ci/steam-deploy).",
   "license": "MIT",
   "repository": "git@github.com:game-ci/cli.git",
   "files": [

--- a/plugins/steam-workshop/src/index.ts
+++ b/plugins/steam-workshop/src/index.ts
@@ -1,52 +1,29 @@
-/**
- * Steam Workshop / mod-publishing plugin - DRAFT.
- *
- * Plan: `game-ci deploy steam-workshop <buildPath> --appId --itemId`
- * wraps SteamCMD's workshop_build_item.vdf upload path - a genuinely
- * different VDF schema and upload target from @game-ci/steam-deploy's
- * full-game appbuild.vdf. This is for mods, maps, and asset packs, not a
- * whole game build.
- *
- * NOTE: mirrors steam-deploy's `deploy <target>` dispatch shape (already
- * registered in core - see game-ci/cli#123), so this doesn't need a new
- * core command registration, unlike most of the other drafts.
- */
+import { SteamWorkshopCommand } from "./steam-workshop-command";
 
+/**
+ * Steam Workshop deploy plugin - `game-ci deploy steam-workshop <itemPath>`.
+ *
+ * Uploads a Workshop item (a mod, map, or asset pack) via SteamCMD's
+ * workshop_build_item.vdf - a genuinely different upload target and VDF
+ * schema from @game-ci/steam-deploy's full-game appbuild.vdf. Registered
+ * with engine: '*' (see PluginRegistry.createCommand's wildcard
+ * handling), mirroring steam-deploy's dispatch shape - reuses core's
+ * existing `deploy <target>` command registration.
+ */
 export const steamWorkshopPlugin = {
   name: "steam-workshop",
-  version: "0.0.1",
-
-  /**
-   * Loaded only via an explicit --plugin flag, never by default, so
-   * reaching this point is deliberate - warn rather than fail, but make
-   * it impossible to mistake for a working integration.
-   */
-  onLoad() {
-    console.warn(
-      "[game-ci] WARNING: @game-ci/steam-workshop is an EXPERIMENTAL draft plugin. " +
-        "Its structure is real but its domain logic is not implemented - any command it " +
-        "claims will throw. Do not depend on it. See plugins/steam-workshop/README.md.",
-    );
-  },
+  version: "0.1.0",
 
   commands: [
     {
       engine: "*",
       createCommand(command: string, subCommands: string[]) {
         if (command === "deploy" && subCommands[0] === "steam-workshop") {
-          return {
-            name: "Deploy steam workshop",
-            async configureOptions() {
-              // TODO: register --appId, --itemId (omit to publish a new item),
-              // --title, --description, --changeNote, --visibility, --previewImage.
-            },
-            async execute(): Promise<boolean> {
-              throw new Error(
-                "Steam Workshop publishing is not implemented yet (draft plugin). " +
-                  "See plugins/steam-workshop/README.md for the planned workshop_build_item.vdf shape.",
-              );
-            },
-          };
+          console.warn(
+            "[game-ci] WARNING: `deploy steam-workshop` is EXPERIMENTAL. Verify against a test item " +
+              "before pointing it at a live one.",
+          );
+          return new SteamWorkshopCommand();
         }
         return null;
       },
@@ -55,3 +32,7 @@ export const steamWorkshopPlugin = {
 };
 
 export default steamWorkshopPlugin;
+export { SteamWorkshopCommand } from "./steam-workshop-command";
+export { generateWorkshopItemVdf } from "./workshop-vdf-generator";
+export { parseWorkshopOutput } from "./parse-workshop-output";
+export { WorkshopCmdRunner } from "./workshop-cmd-runner";

--- a/plugins/steam-workshop/src/parse-workshop-output.test.ts
+++ b/plugins/steam-workshop/src/parse-workshop-output.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { parseWorkshopOutput } from "./parse-workshop-output";
+
+describe("parseWorkshopOutput", () => {
+  it("reports success and captures the id when PublishedFileId appears in the output", () => {
+    const result = parseWorkshopOutput("Uploading...\nPublishedFileId: 123456789\n", 0);
+    expect(result.success).toBe(true);
+    expect(result.publishedFileId).toBe("123456789");
+  });
+
+  it("matches PublishedFileId regardless of a colon/equals separator", () => {
+    expect(parseWorkshopOutput("PublishedFileId = 42", 0).publishedFileId).toBe("42");
+    expect(parseWorkshopOutput("PublishedFileId 42", 0).publishedFileId).toBe("42");
+  });
+
+  it("does not trust exit code 0 alone as success when no PublishedFileId appears", () => {
+    const result = parseWorkshopOutput("Logging in...\ndone.\n", 0);
+    expect(result.success).toBe(false);
+    expect(result.failureReason).toContain("no PublishedFileId");
+  });
+
+  it("falls back to the exit code plus output tail on a non-zero exit with no PublishedFileId", () => {
+    const result = parseWorkshopOutput("ERROR! Upload failed.\n", 1);
+    expect(result.success).toBe(false);
+    expect(result.failureReason).toBe("exit code 1: ERROR! Upload failed.");
+  });
+
+  it("falls back to a bare exit code when there is no output", () => {
+    const result = parseWorkshopOutput("", 1);
+    expect(result.failureReason).toBe("exit code 1");
+  });
+});

--- a/plugins/steam-workshop/src/parse-workshop-output.ts
+++ b/plugins/steam-workshop/src/parse-workshop-output.ts
@@ -1,0 +1,43 @@
+/**
+ * SteamCMD's exit code alone isn't a reliable success signal here either
+ * (same reasoning as steam-deploy's parse-steamcmd-output.ts) - the
+ * definitive signal for `+workshop_build_item` is the "PublishedFileId"
+ * line SteamCMD prints on success, which is also how a NEW item's id
+ * gets captured (there's no other way to learn it - it's assigned by
+ * Steam during the upload).
+ */
+
+export interface WorkshopParseResult {
+  success: boolean;
+  /** The Workshop item's id - present on success whether this was a new item or an update. */
+  publishedFileId?: string;
+  failureReason?: string;
+}
+
+export function parseWorkshopOutput(output: string, exitCode: number): WorkshopParseResult {
+  const publishedMatch = /PublishedFileId\s*[:=]?\s*(\d+)/i.exec(output);
+
+  if (publishedMatch) {
+    return { success: true, publishedFileId: publishedMatch[1] };
+  }
+
+  if (exitCode === 0) {
+    // SteamCMD exited cleanly but never printed a PublishedFileId - the
+    // upload itself likely didn't happen (e.g. a silently-skipped/no-op
+    // command), so this is NOT trusted as success purely from exit code 0,
+    // unlike steam-deploy's build upload (which has its own confirmation
+    // line, "Successfully finished", as the definitive signal instead).
+    return { success: false, failureReason: "SteamCMD exited successfully but printed no PublishedFileId - the item may not have actually uploaded." };
+  }
+
+  const tail = output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(-5)
+    .join(" | ");
+  return {
+    success: false,
+    failureReason: tail ? `exit code ${exitCode}: ${tail}` : `exit code ${exitCode}`,
+  };
+}

--- a/plugins/steam-workshop/src/steam-workshop-command.test.ts
+++ b/plugins/steam-workshop/src/steam-workshop-command.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { SteamWorkshopCommand } from "./steam-workshop-command";
+import * as runnerModule from "./workshop-cmd-runner";
+
+describe("SteamWorkshopCommand", () => {
+  let tempDir: string;
+  const originalUsername = process.env.STEAM_USERNAME;
+  const originalPassword = process.env.STEAM_PASSWORD;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "steam-workshop-test-"));
+    process.env.STEAM_USERNAME = "u";
+    process.env.STEAM_PASSWORD = "p";
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    process.env.STEAM_USERNAME = originalUsername;
+    process.env.STEAM_PASSWORD = originalPassword;
+    vi.restoreAllMocks();
+  });
+
+  it("throws when the item path is missing", async () => {
+    const command = new SteamWorkshopCommand();
+    await expect(command.execute({ appId: "480" })).rejects.toThrow(/item path is required/);
+  });
+
+  it("throws when the item path does not exist", async () => {
+    const command = new SteamWorkshopCommand();
+    await expect(command.execute({ itemPath: path.join(tempDir, "nope"), appId: "480" })).rejects.toThrow(/does not exist/);
+  });
+
+  it("throws when credentials are not set", async () => {
+    delete process.env.STEAM_USERNAME;
+    const command = new SteamWorkshopCommand();
+    await expect(command.execute({ itemPath: tempDir, appId: "480" })).rejects.toThrow(/STEAM_USERNAME/);
+  });
+
+  it("writes the vdf into itemPath and uploads it", async () => {
+    const uploadSpy = vi
+      .spyOn(runnerModule.WorkshopCmdRunner.prototype, "upload")
+      .mockResolvedValue({ success: true, publishedFileId: "555" });
+
+    const command = new SteamWorkshopCommand();
+    const result = await command.execute({ itemPath: tempDir, appId: "480", title: "My Mod" });
+
+    expect(result).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, "workshop_build_item.vdf"))).toBe(true);
+    const vdfContent = fs.readFileSync(path.join(tempDir, "workshop_build_item.vdf"), "utf8");
+    expect(vdfContent).toContain('"title" "My Mod"');
+    expect(uploadSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ workDir: path.resolve(tempDir), vdfFileName: "workshop_build_item.vdf" }),
+    );
+  });
+
+  it("passes publishedFileId through to the generated vdf when updating", async () => {
+    vi.spyOn(runnerModule.WorkshopCmdRunner.prototype, "upload").mockResolvedValue({ success: true, publishedFileId: "555" });
+
+    const command = new SteamWorkshopCommand();
+    await command.execute({ itemPath: tempDir, appId: "480", publishedFileId: "555" });
+
+    const vdfContent = fs.readFileSync(path.join(tempDir, "workshop_build_item.vdf"), "utf8");
+    expect(vdfContent).toContain('"publishedfileid" "555"');
+  });
+
+  it("throws with the runner's failure reason when the upload fails", async () => {
+    vi.spyOn(runnerModule.WorkshopCmdRunner.prototype, "upload").mockResolvedValue({
+      success: false,
+      failureReason: "exit code 1: bad appid",
+    });
+
+    const command = new SteamWorkshopCommand();
+    await expect(command.execute({ itemPath: tempDir, appId: "480" })).rejects.toThrow(/bad appid/);
+  });
+});

--- a/plugins/steam-workshop/src/steam-workshop-command.ts
+++ b/plugins/steam-workshop/src/steam-workshop-command.ts
@@ -1,0 +1,122 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { generateWorkshopItemVdf } from "./workshop-vdf-generator";
+import { WorkshopCmdRunner } from "./workshop-cmd-runner";
+
+export interface SteamWorkshopOptions {
+  itemPath?: string;
+  appId?: string;
+  publishedFileId?: string;
+  title?: string;
+  description?: string;
+  changeNote?: string;
+  visibility?: number;
+  previewImage?: string;
+  mode?: string;
+  steamCmdPath?: string;
+  [key: string]: unknown;
+}
+
+interface YargsLike {
+  option: (name: string, config: Record<string, unknown>) => YargsLike;
+}
+
+const VDF_FILE_NAME = "workshop_build_item.vdf";
+
+export class SteamWorkshopCommand {
+  public readonly name = "Deploy steam workshop";
+
+  public async configureOptions(yargs: YargsLike): Promise<void> {
+    yargs
+      .option("appId", {
+        describe: "Steam App ID the Workshop item belongs to.",
+        type: "string",
+        demandOption: true,
+      })
+      .option("publishedFileId", {
+        describe: "Existing Workshop item id to update. Omit to publish a new item.",
+        type: "string",
+      })
+      .option("title", { describe: "Item title.", type: "string" })
+      .option("description", { describe: "Item description.", type: "string" })
+      .option("changeNote", { describe: "Shown in the item's update history on the Workshop page.", type: "string" })
+      .option("visibility", {
+        describe: "0 = public, 1 = friends-only, 2 = private, 3 = unlisted.",
+        type: "number",
+        default: 0,
+      })
+      .option("previewImage", {
+        describe: "Path (relative to itemPath) to a preview image (jpg/png/gif).",
+        type: "string",
+      })
+      .option("mode", {
+        describe: "How to run steamcmd: auto (default), local, or docker",
+        type: "string",
+        default: "auto",
+      })
+      .option("steamCmdPath", {
+        describe: "Explicit path to the steamcmd executable. Recommended for CI determinism; skips auto-detection.",
+        type: "string",
+      });
+  }
+
+  public async execute(options: SteamWorkshopOptions): Promise<boolean> {
+    const itemPath = options.itemPath;
+    if (!itemPath) {
+      throw new Error("An item path is required: game-ci deploy steam-workshop <itemPath>");
+    }
+    if (!fs.existsSync(itemPath)) {
+      throw new Error(`Item path does not exist: ${itemPath}`);
+    }
+
+    const username = process.env.STEAM_USERNAME;
+    const password = process.env.STEAM_PASSWORD;
+    if (!username || !password) {
+      throw new Error(
+        "STEAM_USERNAME and STEAM_PASSWORD must be set as environment variables (never as CLI arguments - argv can leak through process listings).",
+      );
+    }
+
+    const appId = options.appId!;
+    const mode = (options.mode ?? "auto") as "auto" | "local" | "docker";
+    const absoluteItemPath = path.resolve(itemPath);
+    // Same marker-then-substitute approach as steam-deploy's
+    // contentroot/buildoutput: the VDF's contentfolder must be a path
+    // steamcmd can actually see - an absolute host path for local mode,
+    // or the container mount point for docker.
+    const contentFolder = mode === "docker" ? "/build" : absoluteItemPath.replace(/\\/g, "/");
+
+    const vdf = generateWorkshopItemVdf({
+      appId,
+      contentFolder,
+      previewFile: options.previewImage ? `${contentFolder}/${options.previewImage}` : undefined,
+      title: options.title,
+      description: options.description,
+      changeNote: options.changeNote,
+      visibility: (options.visibility ?? 0) as 0 | 1 | 2 | 3,
+      publishedFileId: options.publishedFileId,
+    });
+
+    fs.writeFileSync(path.join(absoluteItemPath, VDF_FILE_NAME), vdf, "utf8");
+
+    const action = options.publishedFileId ? `Updating Workshop item ${options.publishedFileId}` : "Publishing a new Workshop item";
+    console.log(`${action} for app ${appId} from ${absoluteItemPath}`);
+
+    const runner = new WorkshopCmdRunner();
+    const result = await runner.upload({
+      workDir: absoluteItemPath,
+      vdfFileName: VDF_FILE_NAME,
+      username,
+      password,
+      mode,
+      steamCmdPath: options.steamCmdPath,
+    });
+
+    if (!result.success) {
+      throw new Error(`Steam Workshop upload failed: ${result.failureReason}`);
+    }
+
+    console.log(`Steam Workshop upload succeeded. PublishedFileId: ${result.publishedFileId}`);
+    return true;
+  }
+}

--- a/plugins/steam-workshop/src/workshop-cmd-runner.test.ts
+++ b/plugins/steam-workshop/src/workshop-cmd-runner.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { EventEmitter } from "node:events";
+import { WorkshopCmdRunner } from "./workshop-cmd-runner";
+
+function fakeSpawn(stdout: string, exitCode = 0) {
+  const calls: Array<{ command: string; args: string[] }> = [];
+  const spawnFn = vi.fn((command: string, args: string[]) => {
+    calls.push({ command, args });
+    const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    setImmediate(() => {
+      child.stdout.emit("data", Buffer.from(stdout));
+      child.emit("close", exitCode);
+    });
+    return child as unknown as ReturnType<typeof import("node:child_process").spawn>;
+  });
+  return { spawnFn, calls };
+}
+
+describe("WorkshopCmdRunner", () => {
+  let tempDir: string;
+  let localSteamCmdPath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "workshop-cmd-runner-test-"));
+    localSteamCmdPath = path.join(tempDir, "steamcmd.sh");
+    fs.writeFileSync(localSteamCmdPath, "#!/bin/sh\n");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("builds the +workshop_build_item login argv in local mode", async () => {
+    const { spawnFn, calls } = fakeSpawn("PublishedFileId: 1", 0);
+    const runner = new WorkshopCmdRunner(spawnFn);
+
+    await runner.upload({
+      workDir: tempDir,
+      vdfFileName: "workshop_build_item.vdf",
+      username: "u",
+      password: "p",
+      mode: "local",
+      steamCmdPath: localSteamCmdPath,
+    });
+
+    expect(calls[0].command).toBe(localSteamCmdPath);
+    expect(calls[0].args).toEqual([
+      "+login",
+      "u",
+      "p",
+      "+workshop_build_item",
+      `${tempDir.replace(/\\/g, "/")}/workshop_build_item.vdf`,
+      "+quit",
+    ]);
+  });
+
+  it("mounts workDir and points the vdf path at the container mount in docker mode", async () => {
+    const { spawnFn, calls } = fakeSpawn("PublishedFileId: 1", 0);
+    const runner = new WorkshopCmdRunner(spawnFn);
+
+    await runner.upload({
+      workDir: "/host/item",
+      vdfFileName: "workshop_build_item.vdf",
+      username: "u",
+      password: "p",
+      mode: "docker",
+    });
+
+    expect(calls[0].command).toBe("docker");
+    expect(calls[0].args).toContain("/host/item:/build");
+    expect(calls[0].args).toContain("/build/workshop_build_item.vdf");
+  });
+
+  it("throws a clear error when local mode is requested but steamcmd can't be found", async () => {
+    const { spawnFn } = fakeSpawn("unused");
+    const runner = new WorkshopCmdRunner(spawnFn);
+
+    await expect(
+      runner.upload({
+        workDir: tempDir,
+        vdfFileName: "workshop_build_item.vdf",
+        username: "u",
+        password: "p",
+        mode: "local",
+        steamCmdPath: path.join(tempDir, "does-not-exist.sh"),
+      }),
+    ).rejects.toThrow(/steamcmd was not found locally/);
+  });
+
+  it("returns the parsed result from a successful upload", async () => {
+    const { spawnFn } = fakeSpawn("PublishedFileId: 999", 0);
+    const runner = new WorkshopCmdRunner(spawnFn);
+
+    const result = await runner.upload({
+      workDir: tempDir,
+      vdfFileName: "workshop_build_item.vdf",
+      username: "u",
+      password: "p",
+      mode: "local",
+      steamCmdPath: localSteamCmdPath,
+    });
+
+    expect(result).toEqual({ success: true, publishedFileId: "999" });
+  });
+});

--- a/plugins/steam-workshop/src/workshop-cmd-runner.ts
+++ b/plugins/steam-workshop/src/workshop-cmd-runner.ts
@@ -1,0 +1,97 @@
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import { parseWorkshopOutput, type WorkshopParseResult } from "./parse-workshop-output";
+
+export interface RunWorkshopUploadOptions {
+  /**
+   * Directory containing both the prepared workshop_build_item.vdf and
+   * the item's own content - mounted as a whole in Docker mode (matching
+   * steam-deploy's buildDir mount) so relative contentfolder/previewfile
+   * paths inside the VDF resolve the same way whether steamcmd runs on
+   * the host or in the container.
+   */
+  workDir: string;
+  /** VDF file name, relative to workDir. */
+  vdfFileName: string;
+  username: string;
+  password: string;
+  mode: "auto" | "local" | "docker";
+  steamCmdPath?: string;
+}
+
+type SpawnFn = typeof spawn;
+
+const LOCAL_STEAMCMD_CANDIDATES =
+  process.platform === "win32"
+    ? ["C:\\steamcmd\\steamcmd.exe", "C:\\Steam\\steamcmd.exe", "C:\\Program Files (x86)\\Steam\\steamcmd.exe"]
+    : ["/usr/games/steamcmd", "/usr/bin/steamcmd", `${process.env.HOME}/steamcmd/steamcmd.sh`];
+
+function findLocalSteamCmd(explicitPath?: string): string | null {
+  if (explicitPath) return fs.existsSync(explicitPath) ? explicitPath : null;
+  return LOCAL_STEAMCMD_CANDIDATES.find((candidate) => fs.existsSync(candidate)) ?? null;
+}
+
+function runProcess(spawnFn: SpawnFn, command: string, args: string[]): Promise<{ output: string; exitCode: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawnFn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let output = "";
+    child.stdout?.on("data", (chunk) => (output += chunk.toString()));
+    child.stderr?.on("data", (chunk) => (output += chunk.toString()));
+    child.on("error", reject);
+    child.on("close", (exitCode) => resolve({ output, exitCode: exitCode ?? 1 }));
+  });
+}
+
+/**
+ * Runs `steamcmd +login <user> <pass> +workshop_build_item <vdfPath> +quit`.
+ *
+ * This duplicates steam-deploy's own local/Docker execution shape rather
+ * than reusing SteamCmdRunner directly - that class is hardcoded to the
+ * appbuild.vdf/+run_app_build flow, and it isn't exported in a form this
+ * package can drive with a different SteamCMD subcommand. Extracting a
+ * shared base once both packages' real usage patterns are settled is
+ * flagged as a follow-up in the README, not attempted here.
+ */
+export class WorkshopCmdRunner {
+  constructor(private readonly spawnFn: SpawnFn = spawn) {}
+
+  async upload(options: RunWorkshopUploadOptions): Promise<WorkshopParseResult> {
+    const localPath = findLocalSteamCmd(options.steamCmdPath);
+    const useDocker = options.mode === "docker" || (options.mode === "auto" && !localPath);
+
+    if (useDocker) {
+      const containerWorkDir = "/build";
+      const loginArgs = [
+        "+login",
+        options.username,
+        options.password,
+        "+workshop_build_item",
+        `${containerWorkDir}/${options.vdfFileName}`,
+        "+quit",
+      ];
+      const dockerArgs = [
+        "run",
+        "--rm",
+        "-v",
+        `${options.workDir}:${containerWorkDir}`,
+        "cm2network/steamcmd:latest",
+        "/home/steam/steamcmd/steamcmd.sh",
+        ...loginArgs,
+      ];
+      const { output, exitCode } = await runProcess(this.spawnFn, "docker", dockerArgs);
+      return parseWorkshopOutput(output, exitCode);
+    }
+
+    if (!localPath) {
+      throw new Error(
+        "steamcmd was not found locally (checked --steamCmdPath and common install locations). " +
+          "Pass --steamCmdPath explicitly, or use --mode=docker.",
+      );
+    }
+
+    const vdfPath = `${options.workDir}/${options.vdfFileName}`.replace(/\\/g, "/");
+    const loginArgs = ["+login", options.username, options.password, "+workshop_build_item", vdfPath, "+quit"];
+    const { output, exitCode } = await runProcess(this.spawnFn, localPath, loginArgs);
+    return parseWorkshopOutput(output, exitCode);
+  }
+}

--- a/plugins/steam-workshop/src/workshop-vdf-generator.test.ts
+++ b/plugins/steam-workshop/src/workshop-vdf-generator.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { generateWorkshopItemVdf } from "./workshop-vdf-generator";
+
+describe("generateWorkshopItemVdf", () => {
+  it("includes the appid and contentfolder", () => {
+    const vdf = generateWorkshopItemVdf({ appId: "480", contentFolder: "/build" });
+    expect(vdf).toContain('"appid" "480"');
+    expect(vdf).toContain('"contentfolder" "/build"');
+  });
+
+  it("defaults visibility to public (0)", () => {
+    const vdf = generateWorkshopItemVdf({ appId: "480", contentFolder: "/build" });
+    expect(vdf).toContain('"visibility" "0"');
+  });
+
+  it("uses the given visibility", () => {
+    const vdf = generateWorkshopItemVdf({ appId: "480", contentFolder: "/build", visibility: 2 });
+    expect(vdf).toContain('"visibility" "2"');
+  });
+
+  it("omits publishedfileid for a new item", () => {
+    const vdf = generateWorkshopItemVdf({ appId: "480", contentFolder: "/build" });
+    expect(vdf).not.toContain("publishedfileid");
+  });
+
+  it("includes publishedfileid when updating an existing item", () => {
+    const vdf = generateWorkshopItemVdf({ appId: "480", contentFolder: "/build", publishedFileId: "123456" });
+    expect(vdf).toContain('"publishedfileid" "123456"');
+  });
+
+  it("includes optional fields only when given", () => {
+    const withOptional = generateWorkshopItemVdf({
+      appId: "480",
+      contentFolder: "/build",
+      title: "My Mod",
+      description: "A great mod",
+      changeNote: "Fixed a bug",
+      previewFile: "/build/preview.png",
+    });
+    expect(withOptional).toContain('"title" "My Mod"');
+    expect(withOptional).toContain('"description" "A great mod"');
+    expect(withOptional).toContain('"changenote" "Fixed a bug"');
+    expect(withOptional).toContain('"previewfile" "/build/preview.png"');
+
+    const withoutOptional = generateWorkshopItemVdf({ appId: "480", contentFolder: "/build" });
+    expect(withoutOptional).not.toContain("title");
+    expect(withoutOptional).not.toContain("description");
+    expect(withoutOptional).not.toContain("changenote");
+    expect(withoutOptional).not.toContain("previewfile");
+  });
+});

--- a/plugins/steam-workshop/src/workshop-vdf-generator.ts
+++ b/plugins/steam-workshop/src/workshop-vdf-generator.ts
@@ -1,0 +1,49 @@
+/**
+ * Generates SteamCMD's workshop_build_item.vdf - a genuinely different
+ * schema and upload target from steam-deploy's appbuild.vdf (that's a
+ * full game build; this is a single Workshop item - a mod, map, or asset
+ * pack). Schema per Valve's own Steamworks Web API/SDK documentation for
+ * `+workshop_build_item`.
+ */
+
+export interface WorkshopItemVdfOptions {
+  appId: string;
+  /** Directory containing the item's content. */
+  contentFolder: string;
+  /** Path to a preview image (jpg/png/gif), shown on the Workshop page. */
+  previewFile?: string;
+  title?: string;
+  description?: string;
+  /** Shown in the item's update history on the Workshop page. */
+  changeNote?: string;
+  /**
+   * 0 = public, 1 = friends-only, 2 = private, 3 = unlisted (Valve's own
+   * numeric visibility values). Defaults to 0 (public) when omitted, same
+   * as SteamCMD's own default when the field isn't present.
+   */
+  visibility?: 0 | 1 | 2 | 3;
+  /**
+   * Set to update an existing Workshop item. Omit to publish a brand new
+   * one - SteamCMD assigns a fresh id and it appears in the tool's output
+   * (see parse-workshop-output.ts).
+   */
+  publishedFileId?: string;
+}
+
+export function generateWorkshopItemVdf(options: WorkshopItemVdfOptions): string {
+  const lines = [
+    '"workshopitem"',
+    "{",
+    `    "appid" "${options.appId}"`,
+    ...(options.publishedFileId ? [`    "publishedfileid" "${options.publishedFileId}"`] : []),
+    `    "contentfolder" "${options.contentFolder}"`,
+    ...(options.previewFile ? [`    "previewfile" "${options.previewFile}"`] : []),
+    ...(options.title ? [`    "title" "${options.title}"`] : []),
+    ...(options.description ? [`    "description" "${options.description}"`] : []),
+    ...(options.changeNote ? [`    "changenote" "${options.changeNote}"`] : []),
+    `    "visibility" "${options.visibility ?? 0}"`,
+    "}",
+  ];
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary
\`@game-ci/steam-workshop\` was a structural-only draft (\`execute()\` threw immediately). Implements \`deploy steam-workshop <itemPath> --appId\`, wrapping SteamCMD's \`workshop_build_item.vdf\` upload path (\`+workshop_build_item\`) - a genuinely different upload target and VDF schema from \`steam-deploy\`'s full-game \`appbuild.vdf\`, per Valve's own Steamworks documentation.

- Omitting \`--publishedFileId\` publishes a new item; SteamCMD assigns the id during upload, captured from the tool's own output and returned on success.
- Success is trusted from a \`PublishedFileId\` line in SteamCMD's own output, not exit code alone - SteamCMD can exit 0 without actually uploading anything.
- Credentials read from \`$STEAM_USERNAME\`/\`$STEAM_PASSWORD\` only, matching \`steam-deploy\`'s env-var-only convention. TOTP/configVdf auth isn't wired up here yet.
- Duplicates \`steam-deploy\`'s local/Docker SteamCMD execution shape rather than sharing it - extracting a shared base is flagged as a follow-up.

## Test plan
- [x] \`bunx vitest run\` - 21/21 passing
- [x] \`bunx tsc --noEmit\` - clean