### PR TITLE
feat(code-signing): implement the plugin for real

### DIFF
--- a/plugins/code-signing/README.md
+++ b/plugins/code-signing/README.md
@@ -1,35 +1,73 @@
-> **EXPERIMENTAL — NOT IMPLEMENTED.** This is a structural draft only: the plugin
-> shape is real, but its domain logic is not written. Any command it claims will
-> throw. It is not published to npm and is never loaded unless you pass
-> `--plugin @game-ci/code-signing` explicitly.
+> **EXPERIMENTAL.** Functional, but not published to npm and never loaded
+> unless you pass `--plugin @game-ci/code-signing` explicitly.
 
-# @game-ci/code-signing (draft)
+# @game-ci/code-signing
 
-macOS notarization (`xcrun notarytool` + stapling) and Windows
-Authenticode signing for built players. **Not functional yet**, and
-`sign` is not yet registered anywhere in core's CLI.
+`game-ci sign <buildPath> --platform macos|windows` signs (and, on
+macOS, notarizes and staples) a built player. An unsigned macOS build is
+blocked by Gatekeeper; an unsigned Windows build is flagged by
+SmartScreen - both real, common pain points outside Steam/console
+storefronts (direct download, itch.io).
 
-## Why this
+## macOS
 
-Real, common pain point currently entirely hand-rolled per studio: an
-unsigned macOS build gets blocked by Gatekeeper, an unsigned Windows
-build gets flagged by SmartScreen. Distribution outside Steam/console
-storefronts (direct download, itch.io) hits this immediately.
+```bash
+APPLE_ID=... APPLE_TEAM_ID=... APPLE_APP_SPECIFIC_PASSWORD=... game-ci \
+  --plugin @game-ci/code-signing \
+  sign ./build/Game.app --platform macos --identity "Developer ID Application: Studio Name (TEAM123)"
+```
 
-## Remaining work before this is real
+Runs `codesign` with the hardened runtime enabled (required for
+notarization since macOS 10.15), then by default zips the app with
+`ditto` (preserves bundle structure, unlike a plain `zip`), submits it
+via `xcrun notarytool submit --wait`, and staples the ticket with `xcrun
+stapler staple` on success. Pass `--notarize=false` to sign without
+notarizing.
 
-1. Add `sign <buildPath>` to core's `CliCommands`.
-2. macOS path: codesign the `.app` bundle with a Developer ID
-   certificate, submit to `xcrun notarytool submit --wait`, staple the
-   ticket on success. Certificate/App-Store-Connect-API-key handling via
-   environment variables only, matching `steam-deploy`'s credential
-   convention.
-3. Windows path: Authenticode signing via `signtool.exe` (or an HSM/cloud
-   signing service like Azure Trusted Signing, increasingly required
-   since traditional EV cert issuance has gotten harder for indies) -
-   needs real research into which signing backends are actually
-   accessible to indie/small studios today before picking one to
-   implement first.
-4. Tests once the above is real - likely needs to mock the actual
-   signing tool invocations, since real certificates can't be part of a
-   test fixture.
+Credentials are read from `$APPLE_ID`/`$APPLE_TEAM_ID`/
+`$APPLE_APP_SPECIFIC_PASSWORD` only, never CLI arguments - the app-specific
+password is generated at https://appleid.apple.com, not your regular
+Apple ID password.
+
+## Windows
+
+```bash
+WINDOWS_CERTIFICATE_PASSWORD=... game-ci \
+  --plugin @game-ci/code-signing \
+  sign ./build/Game.exe --platform windows --certificatePath ./cert.pfx --timestampUrl http://timestamp.digicert.com
+```
+
+Runs `signtool sign` with SHA-256 file and timestamp digests (the modern
+mode - `signtool`'s legacy SHA-1-only mode is deprecated and
+increasingly rejected by SmartScreen). Pass either `--certificatePath`
+(a PFX file, password from `$WINDOWS_CERTIFICATE_PASSWORD`) or
+`--certificateThumbprint` (a certificate already in the Windows
+certificate store) - not both.
+
+`--timestampUrl` is strongly recommended: without an RFC 3161 timestamp,
+the signature becomes invalid the moment the certificate expires, even
+for builds already shipped.
+
+## Options
+
+| Option                    | Platform | Description                                                          |
+| -------------------------- | -------- | ---------------------------------------------------------------------- |
+| `--platform`                | both     | `macos` or `windows`. Required.                                      |
+| `--identity`                | macOS    | Code signing identity. Falls back to `$APPLE_SIGNING_IDENTITY`.      |
+| `--entitlementsPath`        | macOS    | Path to an entitlements `.plist`, if the app needs any.              |
+| `--notarize`                | macOS    | Submit for notarization and staple after signing. Default `true`.    |
+| `--certificatePath`         | Windows  | Path to a PFX certificate file.                                      |
+| `--certificateThumbprint`   | Windows  | Thumbprint of a certificate in the Windows certificate store.        |
+| `--timestampUrl`            | Windows  | RFC 3161 timestamp server URL.                                       |
+
+## What isn't covered yet
+
+Cloud/HSM-based Windows signing (e.g. Azure Trusted Signing, increasingly
+required as traditional EV certificate issuance has gotten harder for
+indies) isn't wired up - only local `signtool` with a PFX file or a
+certificate-store thumbprint. Real certificates can't be part of an
+automated test fixture, so the signing tool invocations themselves are
+unit-tested with a mocked process runner (argument construction,
+credential handling, and the macOS sign→zip→notarize→staple sequencing
+are covered); an actual signing/notarization run hasn't been exercised
+against real Apple/Microsoft infrastructure in this session.

--- a/plugins/code-signing/package.json
+++ b/plugins/code-signing/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@game-ci/code-signing",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
-  "description": "EXPERIMENTAL (draft, not implemented): Code-signing and notarization plugin (draft). macOS notarization (xcrun notarytool + stapling) and Windows Authenticode signing for built players.",
+  "description": "EXPERIMENTAL: Code-signing and notarization plugin. macOS notarization (xcrun notarytool + stapling) and Windows Authenticode signing for built players.",
   "license": "MIT",
   "repository": "git@github.com:game-ci/cli.git",
   "files": [

--- a/plugins/code-signing/src/index.ts
+++ b/plugins/code-signing/src/index.ts
@@ -1,51 +1,25 @@
-/**
- * Code-signing and notarization plugin - DRAFT.
- *
- * Plan: `game-ci sign <buildPath> --platform macos|windows` signs (and,
- * on macOS, notarizes and staples) a built player. Real, common pain
- * point: an unsigned macOS build is blocked by Gatekeeper, an unsigned
- * Windows build is flagged by SmartScreen. Genuinely complex enough
- * (credential/certificate management, async notarization ticket polling
- * on macOS) to deserve dedicated code rather than a shell snippet.
- *
- * NOTE: `sign` is not yet registered as a core CLI command.
- */
+import { SignCommand } from "./sign-command";
 
+/**
+ * Code-signing and notarization plugin - `game-ci sign <buildPath> --platform macos|windows`.
+ *
+ * Engine-agnostic: signs an already-built player executable/app bundle,
+ * so it doesn't matter which engine produced it. Registered with
+ * engine: '*' (see PluginRegistry.createCommand's wildcard handling),
+ * mirroring test-runtime/deploy's dispatch shape. Requires `sign` to be
+ * registered in core's CliCommands/CommandFactory as an engine-
+ * independent top-level command (mirrors test-runtime's registration).
+ */
 export const codeSigningPlugin = {
   name: "code-signing",
-  version: "0.0.1",
-
-  /**
-   * Loaded only via an explicit --plugin flag, never by default, so
-   * reaching this point is deliberate - warn rather than fail, but make
-   * it impossible to mistake for a working integration.
-   */
-  onLoad() {
-    console.warn(
-      "[game-ci] WARNING: @game-ci/code-signing is an EXPERIMENTAL draft plugin. " +
-        "Its structure is real but its domain logic is not implemented - any command it " +
-        "claims will throw. Do not depend on it. See plugins/code-signing/README.md.",
-    );
-  },
+  version: "0.1.0",
 
   commands: [
     {
       engine: "*",
       createCommand(command: string, _subCommands: string[]) {
         if (command === "sign") {
-          return {
-            name: "Sign build",
-            async configureOptions() {
-              // TODO: register --platform (macos|windows), --identity/--certificate,
-              // --notarize (macOS, default true when --platform=macos), --timeout.
-            },
-            async execute(): Promise<boolean> {
-              throw new Error(
-                "Code-signing / notarization is not implemented yet (draft plugin), and `sign` " +
-                  "is not yet registered as a core command either. See plugins/code-signing/README.md.",
-              );
-            },
-          };
+          return new SignCommand();
         }
         return null;
       },
@@ -54,3 +28,6 @@ export const codeSigningPlugin = {
 };
 
 export default codeSigningPlugin;
+export { SignCommand } from "./sign-command";
+export { MacosSigner, codesignArgs, dittoZipArgs, notarytoolSubmitArgs, staplerArgs } from "./macos-signer";
+export { WindowsSigner, signtoolArgs } from "./windows-signer";

--- a/plugins/code-signing/src/macos-signer.test.ts
+++ b/plugins/code-signing/src/macos-signer.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { MacosSigner, codesignArgs, dittoZipArgs, notarytoolSubmitArgs, staplerArgs } from "./macos-signer";
+
+function fakeSpawn(exitCode: number, output = "") {
+  const calls: Array<{ command: string; args: string[] }> = [];
+  const spawnFn = vi.fn((command: string, args: string[]) => {
+    calls.push({ command, args });
+    const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    setImmediate(() => {
+      if (output) child.stdout.emit("data", Buffer.from(output));
+      child.emit("close", exitCode);
+    });
+    return child as unknown as ReturnType<typeof import("node:child_process").spawn>;
+  });
+  return { spawnFn, calls };
+}
+
+describe("codesignArgs", () => {
+  it("includes --sign, the identity, and hardened-runtime options", () => {
+    const args = codesignArgs({ appPath: "/build/Game.app", identity: "Developer ID Application: Studio (TEAM123)" });
+    expect(args).toContain("--sign");
+    expect(args).toContain("Developer ID Application: Studio (TEAM123)");
+    expect(args).toContain("--options");
+    expect(args).toContain("runtime");
+    expect(args[args.length - 1]).toBe("/build/Game.app");
+  });
+
+  it("includes --entitlements only when given", () => {
+    const withEntitlements = codesignArgs({ appPath: "/a", identity: "id", entitlementsPath: "/e.plist" });
+    expect(withEntitlements).toContain("--entitlements");
+    expect(withEntitlements).toContain("/e.plist");
+
+    const without = codesignArgs({ appPath: "/a", identity: "id" });
+    expect(without).not.toContain("--entitlements");
+  });
+});
+
+describe("dittoZipArgs", () => {
+  it("preserves the bundle with -k --keepParent", () => {
+    const args = dittoZipArgs("/build/Game.app", "/tmp/Game.zip");
+    expect(args).toEqual(["-c", "-k", "--keepParent", "/build/Game.app", "/tmp/Game.zip"]);
+  });
+});
+
+describe("notarytoolSubmitArgs", () => {
+  it("builds the expected submit argv", () => {
+    const args = notarytoolSubmitArgs({
+      archivePath: "/tmp/Game.zip",
+      appleId: "dev@example.com",
+      teamId: "TEAM123",
+      appSpecificPassword: "app-specific-pw",
+    });
+    expect(args).toEqual([
+      "notarytool",
+      "submit",
+      "/tmp/Game.zip",
+      "--apple-id",
+      "dev@example.com",
+      "--team-id",
+      "TEAM123",
+      "--password",
+      "app-specific-pw",
+      "--wait",
+    ]);
+  });
+});
+
+describe("staplerArgs", () => {
+  it("builds the expected staple argv", () => {
+    expect(staplerArgs("/build/Game.app")).toEqual(["stapler", "staple", "/build/Game.app"]);
+  });
+});
+
+describe("MacosSigner", () => {
+  it("runs codesign and reports success on exit code 0", async () => {
+    const { spawnFn, calls } = fakeSpawn(0);
+    const signer = new MacosSigner(spawnFn);
+
+    const result = await signer.codesign({ appPath: "/a", identity: "id" });
+
+    expect(result.success).toBe(true);
+    expect(calls[0].command).toBe("codesign");
+  });
+
+  it("runs notarize via xcrun and reports failure output on non-zero exit", async () => {
+    const { spawnFn, calls } = fakeSpawn(1, "error: invalid credentials");
+    const signer = new MacosSigner(spawnFn);
+
+    const result = await signer.notarize({ archivePath: "/z", appleId: "a", teamId: "t", appSpecificPassword: "p" });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("invalid credentials");
+    expect(calls[0].command).toBe("xcrun");
+    expect(calls[0].args[0]).toBe("notarytool");
+  });
+
+  it("runs staple via xcrun", async () => {
+    const { spawnFn, calls } = fakeSpawn(0);
+    const signer = new MacosSigner(spawnFn);
+
+    await signer.staple("/build/Game.app");
+
+    expect(calls[0].command).toBe("xcrun");
+    expect(calls[0].args[0]).toBe("stapler");
+  });
+});

--- a/plugins/code-signing/src/macos-signer.ts
+++ b/plugins/code-signing/src/macos-signer.ts
@@ -1,0 +1,102 @@
+import { spawn } from "node:child_process";
+
+type SpawnFn = typeof spawn;
+
+export interface MacosSignOptions {
+  /** Path to the built .app bundle. */
+  appPath: string;
+  /** Code signing identity, e.g. "Developer ID Application: Studio Name (TEAMID)". */
+  identity: string;
+  /** Path to an entitlements .plist, if the app needs any (e.g. hardened runtime exceptions). */
+  entitlementsPath?: string;
+}
+
+export interface NotarizeOptions {
+  /** Path to the zip/dmg/pkg submitted for notarization - notarytool doesn't accept a raw .app bundle. */
+  archivePath: string;
+  appleId: string;
+  teamId: string;
+  /** An App Store Connect app-specific password (not the Apple ID's own account password). */
+  appSpecificPassword: string;
+}
+
+export interface RunResult {
+  success: boolean;
+  output: string;
+  exitCode: number;
+}
+
+function runProcess(spawnFn: SpawnFn, command: string, args: string[]): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawnFn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let output = "";
+    child.stdout?.on("data", (chunk) => (output += chunk.toString()));
+    child.stderr?.on("data", (chunk) => (output += chunk.toString()));
+    child.on("error", reject);
+    child.on("close", (exitCode) => resolve({ success: exitCode === 0, output, exitCode: exitCode ?? 1 }));
+  });
+}
+
+export function codesignArgs(options: MacosSignOptions): string[] {
+  const args = [
+    "--deep",
+    "--force",
+    "--verify",
+    "--verbose",
+    "--sign",
+    options.identity,
+    // Required for notarization since macOS 10.15 - notarytool rejects
+    // submissions without the hardened runtime enabled.
+    "--options",
+    "runtime",
+  ];
+  if (options.entitlementsPath) {
+    args.push("--entitlements", options.entitlementsPath);
+  }
+  args.push(options.appPath);
+  return args;
+}
+
+/** ditto -c -k --keepParent, per Apple's own documented notarization workflow: zips the .app while preserving its bundle structure (a plain `zip` can silently break bundle metadata that ditto preserves). */
+export function dittoZipArgs(appPath: string, zipPath: string): string[] {
+  return ["-c", "-k", "--keepParent", appPath, zipPath];
+}
+
+export function notarytoolSubmitArgs(options: NotarizeOptions): string[] {
+  return [
+    "notarytool",
+    "submit",
+    options.archivePath,
+    "--apple-id",
+    options.appleId,
+    "--team-id",
+    options.teamId,
+    "--password",
+    options.appSpecificPassword,
+    "--wait",
+  ];
+}
+
+export function staplerArgs(appPath: string): string[] {
+  return ["stapler", "staple", appPath];
+}
+
+export class MacosSigner {
+  constructor(private readonly spawnFn: SpawnFn = spawn) {}
+
+  codesign(options: MacosSignOptions): Promise<RunResult> {
+    return runProcess(this.spawnFn, "codesign", codesignArgs(options));
+  }
+
+  ditto(appPath: string, zipPath: string): Promise<RunResult> {
+    return runProcess(this.spawnFn, "ditto", dittoZipArgs(appPath, zipPath));
+  }
+
+  notarize(options: NotarizeOptions): Promise<RunResult> {
+    return runProcess(this.spawnFn, "xcrun", notarytoolSubmitArgs(options));
+  }
+
+  staple(appPath: string): Promise<RunResult> {
+    return runProcess(this.spawnFn, "xcrun", staplerArgs(appPath));
+  }
+}

--- a/plugins/code-signing/src/sign-command.test.ts
+++ b/plugins/code-signing/src/sign-command.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { SignCommand } from "./sign-command";
+import { MacosSigner } from "./macos-signer";
+import { WindowsSigner } from "./windows-signer";
+
+function ok(output = "") {
+  return { success: true, output, exitCode: 0 };
+}
+
+function fail(output: string) {
+  return { success: false, output, exitCode: 1 };
+}
+
+describe("SignCommand", () => {
+  let tempDir: string;
+  const envKeys = ["APPLE_SIGNING_IDENTITY", "APPLE_ID", "APPLE_TEAM_ID", "APPLE_APP_SPECIFIC_PASSWORD", "WINDOWS_CERTIFICATE_PASSWORD"];
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "sign-command-test-"));
+    for (const key of envKeys) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    for (const key of envKeys) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+  });
+
+  function macosSignerStub(overrides: Partial<Record<"codesign" | "ditto" | "notarize" | "staple", any>> = {}) {
+    return {
+      codesign: vi.fn().mockResolvedValue(ok()),
+      ditto: vi.fn().mockResolvedValue(ok()),
+      notarize: vi.fn().mockResolvedValue(ok()),
+      staple: vi.fn().mockResolvedValue(ok()),
+      ...overrides,
+    } as unknown as MacosSigner;
+  }
+
+  function windowsSignerStub(overrides: Partial<Record<"sign", any>> = {}) {
+    return { sign: vi.fn().mockResolvedValue(ok()), ...overrides } as unknown as WindowsSigner;
+  }
+
+  it("throws when the build path does not exist", async () => {
+    const command = new SignCommand(macosSignerStub(), windowsSignerStub());
+    await expect(command.execute({ buildPath: path.join(tempDir, "nope"), platform: "macos" })).rejects.toThrow(/does not exist/);
+  });
+
+  it("throws on an unknown platform", async () => {
+    const command = new SignCommand(macosSignerStub(), windowsSignerStub());
+    await expect(command.execute({ buildPath: tempDir, platform: "linux" })).rejects.toThrow(/Unknown --platform/);
+  });
+
+  describe("macOS", () => {
+    it("throws when no identity is given (option or env var)", async () => {
+      const command = new SignCommand(macosSignerStub(), windowsSignerStub());
+      await expect(command.execute({ buildPath: tempDir, platform: "macos" })).rejects.toThrow(/identity/);
+    });
+
+    it("signs and skips notarization when --notarize=false", async () => {
+      const macos = macosSignerStub();
+      const command = new SignCommand(macos, windowsSignerStub());
+
+      const result = await command.execute({ buildPath: tempDir, platform: "macos", identity: "id", notarize: false });
+
+      expect(result).toBe(true);
+      expect(macos.codesign).toHaveBeenCalled();
+      expect(macos.notarize).not.toHaveBeenCalled();
+    });
+
+    it("throws when notarization credentials are missing", async () => {
+      const command = new SignCommand(macosSignerStub(), windowsSignerStub());
+      await expect(command.execute({ buildPath: tempDir, platform: "macos", identity: "id" })).rejects.toThrow(
+        /APPLE_ID/,
+      );
+    });
+
+    it("signs, zips, notarizes, and staples when notarization credentials are set", async () => {
+      process.env.APPLE_ID = "dev@example.com";
+      process.env.APPLE_TEAM_ID = "TEAM123";
+      process.env.APPLE_APP_SPECIFIC_PASSWORD = "app-specific-pw";
+      const macos = macosSignerStub();
+      const command = new SignCommand(macos, windowsSignerStub());
+
+      const result = await command.execute({ buildPath: tempDir, platform: "macos", identity: "id" });
+
+      expect(result).toBe(true);
+      expect(macos.codesign).toHaveBeenCalled();
+      expect(macos.ditto).toHaveBeenCalled();
+      expect(macos.notarize).toHaveBeenCalledWith(
+        expect.objectContaining({ appleId: "dev@example.com", teamId: "TEAM123", appSpecificPassword: "app-specific-pw" }),
+      );
+      expect(macos.staple).toHaveBeenCalled();
+    });
+
+    it("throws with codesign's output when signing fails", async () => {
+      const macos = macosSignerStub({ codesign: vi.fn().mockResolvedValue(fail("no identity found")) });
+      const command = new SignCommand(macos, windowsSignerStub());
+
+      await expect(command.execute({ buildPath: tempDir, platform: "macos", identity: "id", notarize: false })).rejects.toThrow(
+        /no identity found/,
+      );
+    });
+
+    it("throws with notarytool's output when notarization fails", async () => {
+      process.env.APPLE_ID = "a";
+      process.env.APPLE_TEAM_ID = "t";
+      process.env.APPLE_APP_SPECIFIC_PASSWORD = "p";
+      const macos = macosSignerStub({ notarize: vi.fn().mockResolvedValue(fail("invalid credentials")) });
+      const command = new SignCommand(macos, windowsSignerStub());
+
+      await expect(command.execute({ buildPath: tempDir, platform: "macos", identity: "id" })).rejects.toThrow(
+        /invalid credentials/,
+      );
+    });
+  });
+
+  describe("Windows", () => {
+    it("throws when neither certificatePath nor certificateThumbprint is given", async () => {
+      const command = new SignCommand(macosSignerStub(), windowsSignerStub());
+      await expect(command.execute({ buildPath: tempDir, platform: "windows" })).rejects.toThrow(
+        /--certificatePath or --certificateThumbprint/,
+      );
+    });
+
+    it("signs successfully with a certificate thumbprint", async () => {
+      const windows = windowsSignerStub();
+      const command = new SignCommand(macosSignerStub(), windows);
+
+      const result = await command.execute({ buildPath: tempDir, platform: "windows", certificateThumbprint: "ABC" });
+
+      expect(result).toBe(true);
+      expect(windows.sign).toHaveBeenCalledWith(expect.objectContaining({ certificateThumbprint: "ABC" }));
+    });
+
+    it("reads the certificate password from the environment, not options", async () => {
+      process.env.WINDOWS_CERTIFICATE_PASSWORD = "env-secret";
+      const windows = windowsSignerStub();
+      const command = new SignCommand(macosSignerStub(), windows);
+
+      await command.execute({ buildPath: tempDir, platform: "windows", certificatePath: "C:\\cert.pfx" });
+
+      expect(windows.sign).toHaveBeenCalledWith(expect.objectContaining({ certificatePassword: "env-secret" }));
+    });
+
+    it("throws with signtool's output when signing fails", async () => {
+      const windows = windowsSignerStub({ sign: vi.fn().mockResolvedValue(fail("no certificates found")) });
+      const command = new SignCommand(macosSignerStub(), windows);
+
+      await expect(
+        command.execute({ buildPath: tempDir, platform: "windows", certificateThumbprint: "ABC" }),
+      ).rejects.toThrow(/no certificates found/);
+    });
+  });
+});

--- a/plugins/code-signing/src/sign-command.ts
+++ b/plugins/code-signing/src/sign-command.ts
@@ -1,0 +1,162 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { MacosSigner } from "./macos-signer";
+import { WindowsSigner } from "./windows-signer";
+
+export interface SignOptions {
+  buildPath?: string;
+  platform?: string;
+  identity?: string;
+  entitlementsPath?: string;
+  notarize?: boolean;
+  certificatePath?: string;
+  certificateThumbprint?: string;
+  timestampUrl?: string;
+  [key: string]: unknown;
+}
+
+interface YargsLike {
+  option: (name: string, config: Record<string, unknown>) => YargsLike;
+}
+
+export class SignCommand {
+  public readonly name = "Sign build";
+
+  constructor(
+    private readonly macosSigner: MacosSigner = new MacosSigner(),
+    private readonly windowsSigner: WindowsSigner = new WindowsSigner(),
+  ) {}
+
+  public async configureOptions(yargs: YargsLike): Promise<void> {
+    yargs
+      .option("platform", {
+        describe: '"macos" or "windows".',
+        type: "string",
+        demandOption: true,
+      })
+      .option("identity", {
+        describe: 'macOS: code signing identity, e.g. "Developer ID Application: Studio Name (TEAMID)".',
+        type: "string",
+      })
+      .option("entitlementsPath", {
+        describe: "macOS: path to an entitlements .plist, if the app needs any.",
+        type: "string",
+      })
+      .option("notarize", {
+        describe: "macOS: submit for notarization and staple the ticket after signing. Default true.",
+        type: "boolean",
+        default: true,
+      })
+      .option("certificatePath", {
+        describe: "Windows: path to a PFX certificate file. Mutually exclusive with certificateThumbprint.",
+        type: "string",
+      })
+      .option("certificateThumbprint", {
+        describe: "Windows: thumbprint of a certificate already in the Windows certificate store.",
+        type: "string",
+      })
+      .option("timestampUrl", {
+        describe: "Windows: RFC 3161 timestamp server URL. Strongly recommended - without it the signature expires with the certificate.",
+        type: "string",
+      });
+  }
+
+  public async execute(options: SignOptions): Promise<boolean> {
+    const buildPath = options.buildPath;
+    if (!buildPath) {
+      throw new Error("A build path is required: game-ci sign <buildPath>");
+    }
+    if (!fs.existsSync(buildPath)) {
+      throw new Error(`Build path does not exist: ${buildPath}`);
+    }
+
+    if (options.platform === "macos") {
+      return this.signMacos(buildPath, options);
+    }
+    if (options.platform === "windows") {
+      return this.signWindows(buildPath, options);
+    }
+    throw new Error(`Unknown --platform "${options.platform}" (expected "macos" or "windows").`);
+  }
+
+  private async signMacos(appPath: string, options: SignOptions): Promise<boolean> {
+    // Credentials are read directly from the environment here, not
+    // threaded through options - never CLI arguments, matching
+    // steam-deploy's convention (argv can leak through process listings).
+    const identity = options.identity || process.env.APPLE_SIGNING_IDENTITY;
+    if (!identity) {
+      throw new Error("--identity or $APPLE_SIGNING_IDENTITY is required for macOS signing.");
+    }
+
+    console.log(`Signing ${appPath} with identity "${identity}"`);
+    const codesignResult = await this.macosSigner.codesign({
+      appPath,
+      identity,
+      entitlementsPath: options.entitlementsPath,
+    });
+    if (!codesignResult.success) {
+      throw new Error(`codesign failed: ${codesignResult.output}`);
+    }
+
+    if (options.notarize === false) {
+      console.log("Signing succeeded (notarization skipped via --notarize=false).");
+      return true;
+    }
+
+    const appleId = process.env.APPLE_ID;
+    const teamId = process.env.APPLE_TEAM_ID;
+    const appSpecificPassword = process.env.APPLE_APP_SPECIFIC_PASSWORD;
+    if (!appleId || !teamId || !appSpecificPassword) {
+      throw new Error(
+        "$APPLE_ID, $APPLE_TEAM_ID, and $APPLE_APP_SPECIFIC_PASSWORD must all be set as environment variables to notarize " +
+          "(never as CLI arguments), or pass --notarize=false to sign without notarizing.",
+      );
+    }
+
+    const zipPath = path.join(os.tmpdir(), `${path.basename(appPath)}-${Date.now()}.zip`);
+    const dittoResult = await this.macosSigner.ditto(appPath, zipPath);
+    if (!dittoResult.success) {
+      throw new Error(`Failed to zip "${appPath}" for notarization: ${dittoResult.output}`);
+    }
+
+    console.log("Submitting for notarization (this can take several minutes)...");
+    const notarizeResult = await this.macosSigner.notarize({ archivePath: zipPath, appleId, teamId, appSpecificPassword });
+    fs.rmSync(zipPath, { force: true });
+    if (!notarizeResult.success) {
+      throw new Error(`Notarization failed: ${notarizeResult.output}`);
+    }
+
+    const stapleResult = await this.macosSigner.staple(appPath);
+    if (!stapleResult.success) {
+      throw new Error(`Stapling the notarization ticket failed: ${stapleResult.output}`);
+    }
+
+    console.log(`Signed and notarized "${appPath}" successfully.`);
+    return true;
+  }
+
+  private async signWindows(filePath: string, options: SignOptions): Promise<boolean> {
+    const certificatePassword = process.env.WINDOWS_CERTIFICATE_PASSWORD;
+
+    if (!options.certificatePath && !options.certificateThumbprint) {
+      throw new Error("--certificatePath or --certificateThumbprint is required for Windows signing.");
+    }
+
+    console.log(`Signing ${filePath}`);
+    const result = await this.windowsSigner.sign({
+      filePath,
+      certificatePath: options.certificatePath,
+      certificatePassword,
+      certificateThumbprint: options.certificateThumbprint,
+      timestampUrl: options.timestampUrl,
+    });
+
+    if (!result.success) {
+      throw new Error(`signtool failed: ${result.output}`);
+    }
+
+    console.log(`Signed "${filePath}" successfully.`);
+    return true;
+  }
+}

--- a/plugins/code-signing/src/windows-signer.test.ts
+++ b/plugins/code-signing/src/windows-signer.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { WindowsSigner, signtoolArgs } from "./windows-signer";
+
+function fakeSpawn(exitCode: number, output = "") {
+  const calls: Array<{ command: string; args: string[] }> = [];
+  const spawnFn = vi.fn((command: string, args: string[]) => {
+    calls.push({ command, args });
+    const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    setImmediate(() => {
+      if (output) child.stdout.emit("data", Buffer.from(output));
+      child.emit("close", exitCode);
+    });
+    return child as unknown as ReturnType<typeof import("node:child_process").spawn>;
+  });
+  return { spawnFn, calls };
+}
+
+describe("signtoolArgs", () => {
+  it("uses /sha1 with a certificate thumbprint", () => {
+    const args = signtoolArgs({ filePath: "C:\\build\\Game.exe", certificateThumbprint: "ABCDEF1234" });
+    expect(args).toContain("/sha1");
+    expect(args).toContain("ABCDEF1234");
+    expect(args).not.toContain("/f");
+  });
+
+  it("uses /f and /p with a PFX file and password", () => {
+    const args = signtoolArgs({ filePath: "C:\\build\\Game.exe", certificatePath: "C:\\cert.pfx", certificatePassword: "secret" });
+    expect(args).toContain("/f");
+    expect(args).toContain("C:\\cert.pfx");
+    expect(args).toContain("/p");
+    expect(args).toContain("secret");
+  });
+
+  it("omits /p when no password is given for a PFX file", () => {
+    const args = signtoolArgs({ filePath: "C:\\build\\Game.exe", certificatePath: "C:\\cert.pfx" });
+    expect(args).not.toContain("/p");
+  });
+
+  it("includes a timestamp URL when given", () => {
+    const args = signtoolArgs({
+      filePath: "C:\\build\\Game.exe",
+      certificateThumbprint: "ABC",
+      timestampUrl: "http://timestamp.example.com",
+    });
+    expect(args).toContain("/tr");
+    expect(args).toContain("http://timestamp.example.com");
+    expect(args).toContain("/td");
+  });
+
+  it("omits timestamp flags when no timestamp URL is given", () => {
+    const args = signtoolArgs({ filePath: "C:\\build\\Game.exe", certificateThumbprint: "ABC" });
+    expect(args).not.toContain("/tr");
+  });
+
+  it("throws when neither certificatePath nor certificateThumbprint is given", () => {
+    expect(() => signtoolArgs({ filePath: "C:\\build\\Game.exe" })).toThrow(/certificatePath or certificateThumbprint/);
+  });
+
+  it("ends with the file path being signed", () => {
+    const args = signtoolArgs({ filePath: "C:\\build\\Game.exe", certificateThumbprint: "ABC" });
+    expect(args[args.length - 1]).toBe("C:\\build\\Game.exe");
+  });
+});
+
+describe("WindowsSigner", () => {
+  it("runs signtool and reports success on exit code 0", async () => {
+    const { spawnFn, calls } = fakeSpawn(0);
+    const signer = new WindowsSigner(spawnFn);
+
+    const result = await signer.sign({ filePath: "C:\\build\\Game.exe", certificateThumbprint: "ABC" });
+
+    expect(result.success).toBe(true);
+    expect(calls[0].command).toBe("signtool");
+  });
+
+  it("reports failure output on a non-zero exit", async () => {
+    const { spawnFn } = fakeSpawn(1, "SignTool Error: No certificates were found");
+    const signer = new WindowsSigner(spawnFn);
+
+    const result = await signer.sign({ filePath: "C:\\build\\Game.exe", certificateThumbprint: "ABC" });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("No certificates were found");
+  });
+});

--- a/plugins/code-signing/src/windows-signer.ts
+++ b/plugins/code-signing/src/windows-signer.ts
@@ -1,0 +1,63 @@
+import { spawn } from "node:child_process";
+import type { RunResult } from "./macos-signer";
+
+type SpawnFn = typeof spawn;
+
+function runProcess(spawnFn: SpawnFn, command: string, args: string[]): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawnFn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let output = "";
+    child.stdout?.on("data", (chunk) => (output += chunk.toString()));
+    child.stderr?.on("data", (chunk) => (output += chunk.toString()));
+    child.on("error", reject);
+    child.on("close", (exitCode) => resolve({ success: exitCode === 0, output, exitCode: exitCode ?? 1 }));
+  });
+}
+
+export interface WindowsSignOptions {
+  filePath: string;
+  /** Path to a PFX certificate file. Mutually exclusive with certificateThumbprint (a cert already in the Windows certificate store). */
+  certificatePath?: string;
+  /** Password for the PFX file. Read from an env var by the caller - never passed as a bare CLI argument here either, though signtool itself has no other way to take it. */
+  certificatePassword?: string;
+  /** Thumbprint of a certificate already installed in the Windows certificate store, as an alternative to a PFX file. */
+  certificateThumbprint?: string;
+  /** RFC 3161 timestamp server URL - without this, the signature becomes invalid the moment the certificate expires, even for already-shipped builds. */
+  timestampUrl?: string;
+}
+
+/**
+ * signtool.exe's own documented flag set (Windows SDK). /fd sha256 /td
+ * sha256 is the modern (SHA-256 file + timestamp digest) signing mode -
+ * signtool's legacy SHA-1-only mode is deprecated by Microsoft and
+ * increasingly rejected by SmartScreen.
+ */
+export function signtoolArgs(options: WindowsSignOptions): string[] {
+  const args = ["sign", "/fd", "sha256"];
+
+  if (options.certificateThumbprint) {
+    args.push("/sha1", options.certificateThumbprint);
+  } else if (options.certificatePath) {
+    args.push("/f", options.certificatePath);
+    if (options.certificatePassword) {
+      args.push("/p", options.certificatePassword);
+    }
+  } else {
+    throw new Error("Either certificatePath or certificateThumbprint is required for Windows signing.");
+  }
+
+  if (options.timestampUrl) {
+    args.push("/tr", options.timestampUrl, "/td", "sha256");
+  }
+
+  args.push(options.filePath);
+  return args;
+}
+
+export class WindowsSigner {
+  constructor(private readonly spawnFn: SpawnFn = spawn) {}
+
+  sign(options: WindowsSignOptions): Promise<RunResult> {
+    return runProcess(this.spawnFn, "signtool", signtoolArgs(options));
+  }
+}

--- a/src/cli-commands.ts
+++ b/src/cli-commands.ts
@@ -30,6 +30,7 @@ export class CliCommands {
     await this.deployCommand();
     await this.testRuntimeCommand();
     await this.pseudoLocalizeCommand();
+    await this.signCommand();
 
     // This is needed to run the engine and vcs detection middleware.
     // Their output is used to register the correct commands based on the detected engine and vcs.
@@ -127,6 +128,20 @@ export class CliCommands {
     await this.yargs.command(
       "pseudo-localize [projectPath]",
       "Inject pseudo-localized strings to catch UI overflow/truncation bugs pre-translation",
+      async (yargs: YargsInstance) => {
+        this.register(yargs);
+      },
+    );
+  }
+
+  private async signCommand() {
+    // Engine-independent, same reasoning as deploy/test-runtime: it signs
+    // an already-built player executable/app bundle, which carries no
+    // Unity/Godot/Unreal project markers of its own for detectEngine() to
+    // find.
+    await this.yargs.command(
+      "sign [buildPath]",
+      "Sign (and, on macOS, notarize) a built player",
       async (yargs: YargsInstance) => {
         this.register(yargs);
       },

--- a/src/command/command-factory.ts
+++ b/src/command/command-factory.ts
@@ -42,7 +42,9 @@ export class CommandFactory {
     // its own for detectEngine() to find.
     // pseudo-localize doesn't either: it operates on a flat localization
     // table file, not an engine project structure.
-    if (command === "deploy" || command === "test-runtime" || command === "pseudo-localize") {
+    // sign doesn't either: it signs an already-built player executable/
+    // app bundle, same reasoning as test-runtime.
+    if (command === "deploy" || command === "test-runtime" || command === "pseudo-localize" || command === "sign") {
       const pluginCommand = PluginRegistry.createCommand("*", command, subCommands);
       if (pluginCommand) {
         return pluginCommand;


### PR DESCRIPTION
## Summary
\`@game-ci/code-signing\` was a structural-only draft (\`execute()\` threw immediately, and \`sign\` wasn't registered as a core command at all). Implements \`sign <buildPath> --platform macos|windows\`.

**macOS**: \`codesign\` with hardened runtime enabled (required for notarization), then \`ditto\`-zip (preserves bundle structure) → \`xcrun notarytool submit --wait\` → \`xcrun stapler staple\`. \`--notarize=false\` skips notarization. Credentials read from \`$APPLE_ID\`/\`$APPLE_TEAM_ID\`/\`$APPLE_APP_SPECIFIC_PASSWORD\` only.

**Windows**: \`signtool sign\` with modern SHA-256 file+timestamp digests. Either \`--certificatePath\` (PFX, password from \`$WINDOWS_CERTIFICATE_PASSWORD\`) or \`--certificateThumbprint\`. Cloud/HSM signing (e.g. Azure Trusted Signing) isn't wired up yet.

Registers \`sign [buildPath]\` in core's \`CliCommands\` and marks it engine-independent in \`CommandFactory\`, mirroring \`test-runtime\`/\`deploy\`/\`pseudo-localize\`'s registration.

Real certificates can't be part of an automated test fixture, so tests cover argument construction, credential handling, and the macOS sign→zip→notarize→staple sequencing via a mocked process runner - not an actual run against real Apple/Microsoft infrastructure.

## Test plan
- [x] \`bunx vitest run\` - 29/29 passing
- [x] \`bunx tsc --noEmit\` - clean
- [x] \`bun test src/plugin src/command\` at repo root - 45/45 passing