### PR TITLE
fix(steam-deploy): compute contentroot with the actual docker-vs-local decision

### DIFF
--- a/plugins/steam-deploy/src/index.ts
+++ b/plugins/steam-deploy/src/index.ts
@@ -38,4 +38,4 @@ export default steamDeployPlugin;
 export { SteamDeployCommand } from "./steam-deploy-command";
 export { generateAppVdf, generateDepotVdf } from "./vdf-generator";
 export { parseSteamCmdOutput } from "./parse-steamcmd-output";
-export { SteamCmdRunner } from "./steamcmd-runner";
+export { SteamCmdRunner, resolveUseDocker } from "./steamcmd-runner";

--- a/plugins/steam-deploy/src/steam-deploy-command.ts
+++ b/plugins/steam-deploy/src/steam-deploy-command.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { generateAppVdf, generateDepotVdf } from "./vdf-generator";
-import { SteamCmdRunner } from "./steamcmd-runner";
+import { SteamCmdRunner, resolveUseDocker } from "./steamcmd-runner";
 
 const MAX_EXTRA_DEPOTS = 9;
 
@@ -145,7 +145,7 @@ export class SteamDeployCommand {
     const includeDebugSymbols = options.debugBranch ?? false;
 
     const absoluteBuildPath = path.resolve(buildPath);
-    const contentRoot = mode === "docker" ? "/build" : absoluteBuildPath.replace(/\\/g, "/");
+    const contentRoot = resolveUseDocker(mode, options.steamCmdPath) ? "/build" : absoluteBuildPath.replace(/\\/g, "/");
 
     const extraDepots = this.collectExtraDepots(options, depotId);
     const primaryLocalPath = options.depotPath ? `./${options.depotPath.replace(/^\.?\/*/, "")}/*` : undefined;

--- a/plugins/steam-deploy/src/steamcmd-runner.test.ts
+++ b/plugins/steam-deploy/src/steamcmd-runner.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { EventEmitter } from "node:events";
-import { SteamCmdRunner } from "./steamcmd-runner";
+import { SteamCmdRunner, resolveUseDocker } from "./steamcmd-runner";
 
 /** A fake child_process that immediately succeeds with the given stdout, matching the shape SteamCmdRunner reads from. */
 function fakeSpawn(stdout: string, exitCode = 0) {
@@ -216,5 +216,27 @@ describe("SteamCmdRunner", () => {
         steamCmdPath: path.join(tempDir, "does-not-exist.sh"),
       }),
     ).rejects.toThrow(/steamcmd was not found locally/);
+  });
+});
+
+describe("resolveUseDocker", () => {
+  it("is true for mode=docker regardless of a local steamcmd's presence", () => {
+    expect(resolveUseDocker("docker", "/does/not/exist")).toBe(true);
+  });
+
+  it("is false for mode=local regardless of a local steamcmd's presence", () => {
+    expect(resolveUseDocker("local", "/does/not/exist")).toBe(false);
+  });
+
+  it("falls back to docker for mode=auto when no local steamcmd is found", () => {
+    // Regression test for a real bug (game-ci/steam-deploy#92's live CI):
+    // steam-deploy-command.ts used to decide the manifest's contentroot
+    // via a literal `mode === "docker"` check, which stayed false for
+    // mode=auto even when run() itself fell back to Docker here - writing
+    // a host absolute path into the manifest for a build that then
+    // actually executed inside a container, where only /build was
+    // mounted. This function is now the single source of truth both
+    // callers share.
+    expect(resolveUseDocker("auto", "/does/not/exist")).toBe(true);
   });
 });

--- a/plugins/steam-deploy/src/steamcmd-runner.ts
+++ b/plugins/steam-deploy/src/steamcmd-runner.ts
@@ -52,6 +52,21 @@ function findLocalSteamCmd(explicitPath?: string): string | null {
   return LOCAL_STEAMCMD_CANDIDATES.find((candidate) => fs.existsSync(candidate)) ?? null;
 }
 
+/**
+ * Exported so callers that need to know the actual execution mode ahead
+ * of time (steam-deploy-command.ts picks the manifest's contentroot/
+ * buildoutput based on this) compute it identically to run()'s own
+ * internal decision - previously duplicated ad hoc as `mode === "docker"`
+ * in the command, which silently diverged from this function's "auto"
+ * case, writing a host absolute path into the manifest for a build that
+ * then actually ran in Docker (steamcmd inside the container correctly
+ * reported "Content root folder does not exist", since only /build was
+ * mounted there, confirmed live via game-ci/steam-deploy#92's CI).
+ */
+export function resolveUseDocker(mode: "auto" | "local" | "docker", steamCmdPath?: string): boolean {
+  return mode === "docker" || (mode === "auto" && !findLocalSteamCmd(steamCmdPath));
+}
+
 function resolveSteamHome(explicit?: string): string {
   return explicit ?? process.env.STEAM_HOME ?? path.join(process.env.HOME ?? process.env.USERPROFILE ?? ".", "Steam");
 }


### PR DESCRIPTION
## Summary
\`steam-deploy-command.ts\` decided the manifest's \`contentroot\`/\`buildoutput\` via a literal \`mode === "docker"\` check, but \`SteamCmdRunner.run()\` falls back to Docker whenever \`mode="auto"\` and no local steamcmd is found - these silently diverged for the default \`mode=auto\` case whenever steamcmd wasn't installed locally (e.g. a bare GitHub Actions runner).

Confirmed live via game-ci/steam-deploy#92's CI (now that cli#216's diagnostics surface real output): the manifest was written with the host's absolute build path, but steamcmd then actually ran inside the \`cm2network/steamcmd\` Docker container (where only \`/build\` is mounted), failing with \`ERROR! Content root folder does not exist: /home/runner/work/steam-deploy/steam-deploy/build.\`

Extracts the shared decision into \`resolveUseDocker()\`, used by both \`run()\` and the command's \`contentRoot\` computation, so they can't diverge again.

## Test plan
- [x] \`bunx vitest run\` - 30/30 passing (new regression test covers the mode=auto-falls-back-to-docker case directly)
- [x] \`bunx tsc --noEmit\` - clean