### PR TITLE
feat(steam-deploy): support multiple FileMapping blocks and FileProperties

### DIFF
--- a/plugins/steam-deploy/src/steam-deploy-command.test.ts
+++ b/plugins/steam-deploy/src/steam-deploy-command.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { SteamDeployCommand } from "./steam-deploy-command";
+
+describe("SteamDeployCommand fileMapping/fileProperty parsing", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "steam-deploy-command-test-"));
+    process.env.STEAM_USERNAME = "u";
+    process.env.STEAM_PASSWORD = "p";
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    delete process.env.STEAM_USERNAME;
+    delete process.env.STEAM_PASSWORD;
+  });
+
+  async function runAndReadPrimaryDepotVdf(fileMapping?: string[], fileProperty?: string[]) {
+    const command = new SteamDeployCommand();
+    try {
+      await command.execute({
+        buildPath: tempDir,
+        appId: "999",
+        depotId: "1000",
+        mode: "local",
+        steamCmdPath: path.join(tempDir, "does-not-exist.sh"),
+        fileMapping,
+        fileProperty,
+      });
+    } catch {
+      // steamcmd isn't actually available in this test env - execute()
+      // throws after the VDF files are already written, which is all these
+      // tests need.
+    }
+    return fs.readFileSync(path.join(tempDir, "depot_build_1000.vdf"), "utf8");
+  }
+
+  it("writes multiple FileMapping blocks from --fileMapping entries", async () => {
+    const vdf = await runAndReadPrimaryDepotVdf(["bin/*=executables/", "docs/*=documentation/"]);
+
+    expect(vdf.split('"FileMapping"').length - 1).toBe(2);
+    expect(vdf).toContain('"LocalPath"\t"bin/*"');
+    expect(vdf).toContain('"DepotPath"\t"executables/"');
+    expect(vdf).toContain('"LocalPath"\t"docs/*"');
+    expect(vdf).toContain('"DepotPath"\t"documentation/"');
+  });
+
+  it("writes FileProperties blocks from --fileProperty entries", async () => {
+    const vdf = await runAndReadPrimaryDepotVdf(undefined, ["bin/config.cfg=userconfig"]);
+
+    expect(vdf).toContain('"FileProperties"');
+    expect(vdf).toContain('"LocalPath"\t"bin/config.cfg"');
+    expect(vdf).toContain('"Attributes"\t"userconfig"');
+  });
+
+  it("throws a clear error for a malformed --fileMapping entry", async () => {
+    const command = new SteamDeployCommand();
+    await expect(
+      command.execute({
+        buildPath: tempDir,
+        appId: "999",
+        depotId: "1000",
+        mode: "local",
+        steamCmdPath: path.join(tempDir, "does-not-exist.sh"),
+        fileMapping: ["no-equals-sign"],
+      }),
+    ).rejects.toThrow(/Invalid --fileMapping/);
+  });
+
+  it("throws a clear error for a malformed --fileProperty entry", async () => {
+    const command = new SteamDeployCommand();
+    await expect(
+      command.execute({
+        buildPath: tempDir,
+        appId: "999",
+        depotId: "1000",
+        mode: "local",
+        steamCmdPath: path.join(tempDir, "does-not-exist.sh"),
+        fileProperty: ["bin/config.cfg=notarealattribute"],
+      }),
+    ).rejects.toThrow(/Invalid --fileProperty/);
+  });
+});

--- a/plugins/steam-deploy/src/steam-deploy-command.ts
+++ b/plugins/steam-deploy/src/steam-deploy-command.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { generateAppVdf, generateDepotVdf } from "./vdf-generator";
+import { generateAppVdf, generateDepotVdf, type FileMappingOption, type FilePropertyOption } from "./vdf-generator";
 import { SteamCmdRunner, resolveUseDocker } from "./steamcmd-runner";
 
 const MAX_EXTRA_DEPOTS = 9;
@@ -24,6 +24,10 @@ export interface SteamDeployOptions {
   firstDepotIdOverride?: string;
   depotPath?: string;
   depotInstallScriptPath?: string;
+  /** Each entry "localPath=depotPath" - replaces the primary depot's single depotPath mapping with explicit FileMapping blocks. */
+  fileMapping?: string[];
+  /** Each entry "localPath=userconfig" or "localPath=versionedconfig" - marks files on the primary depot as user-modifiable/versioned config. */
+  fileProperty?: string[];
   [key: string]: unknown;
 }
 
@@ -92,6 +96,18 @@ export class SteamDeployCommand {
       .option("depotInstallScriptPath", {
         describe: "Install script (relative to the primary depot's content) to run after it installs.",
         type: "string",
+      })
+      .option("fileMapping", {
+        describe:
+          'One or more explicit FileMapping blocks for the primary depot, each "localPath=depotPath" (e.g. "bin/*=executables/"). Repeatable. Overrides --depotPath when set - use this instead when a depot needs more than one mapping.',
+        type: "string",
+        array: true,
+      })
+      .option("fileProperty", {
+        describe:
+          'Marks a file on the primary depot as user-modifiable config, each "localPath=userconfig" or "localPath=versionedconfig". Repeatable.',
+        type: "string",
+        array: true,
       });
 
     for (let index = 1; index <= MAX_EXTRA_DEPOTS; index++) {
@@ -143,6 +159,8 @@ export class SteamDeployCommand {
       ? options.extraExclusions.split(",").map((s) => s.trim())
       : undefined;
     const includeDebugSymbols = options.debugBranch ?? false;
+    const fileMappings = this.parseFileMappings(options.fileMapping);
+    const fileProperties = this.parseFileProperties(options.fileProperty);
 
     const absoluteBuildPath = path.resolve(buildPath);
     const contentRoot = resolveUseDocker(mode, options.steamCmdPath) ? "/build" : absoluteBuildPath.replace(/\\/g, "/");
@@ -160,11 +178,14 @@ export class SteamDeployCommand {
     }));
 
     for (const depot of allDepots) {
+      const isPrimaryDepot = depot.depotId === depotId;
       const depotVdf = generateDepotVdf({
         depotId: depot.depotId,
         localPath: depot.localPath,
+        fileMappings: isPrimaryDepot ? fileMappings : undefined,
+        fileProperties: isPrimaryDepot ? fileProperties : undefined,
         installScript: depot.installScript,
-        extraExclusions: depot.depotId === depotId ? extraExclusions : undefined,
+        extraExclusions: isPrimaryDepot ? extraExclusions : undefined,
         includeDebugSymbols,
       });
       fs.writeFileSync(path.join(absoluteBuildPath, `depot_build_${depot.depotId}.vdf`), depotVdf, "utf8");
@@ -207,6 +228,38 @@ export class SteamDeployCommand {
     }
 
     return true;
+  }
+
+  /** Parses --fileMapping "localPath=depotPath" entries. Throws on a malformed entry rather than silently dropping it. */
+  private parseFileMappings(entries?: string[]): FileMappingOption[] | undefined {
+    if (!entries || entries.length === 0) return undefined;
+
+    return entries.map((entry) => {
+      const separatorIndex = entry.indexOf("=");
+      if (separatorIndex <= 0) {
+        throw new Error(`Invalid --fileMapping "${entry}": expected "localPath=depotPath".`);
+      }
+      return {
+        localPath: entry.slice(0, separatorIndex),
+        depotPath: entry.slice(separatorIndex + 1),
+      };
+    });
+  }
+
+  /** Parses --fileProperty "localPath=userconfig|versionedconfig" entries. Throws on a malformed entry rather than silently dropping it. */
+  private parseFileProperties(entries?: string[]): FilePropertyOption[] | undefined {
+    if (!entries || entries.length === 0) return undefined;
+
+    return entries.map((entry) => {
+      const separatorIndex = entry.indexOf("=");
+      const attribute = separatorIndex >= 0 ? entry.slice(separatorIndex + 1) : "";
+      if (separatorIndex <= 0 || (attribute !== "userconfig" && attribute !== "versionedconfig")) {
+        throw new Error(
+          `Invalid --fileProperty "${entry}": expected "localPath=userconfig" or "localPath=versionedconfig".`,
+        );
+      }
+      return { localPath: entry.slice(0, separatorIndex), attribute };
+    });
   }
 
   /**

--- a/plugins/steam-deploy/src/vdf-generator.test.ts
+++ b/plugins/steam-deploy/src/vdf-generator.test.ts
@@ -50,6 +50,66 @@ describe("generateDepotVdf", () => {
 
     expect(vdf).not.toContain("InstallScript");
   });
+
+  it("emits multiple FileMapping blocks when fileMappings is given, ignoring localPath", () => {
+    const vdf = generateDepotVdf({
+      depotId: "12345",
+      localPath: "./ignored/*",
+      fileMappings: [
+        { localPath: "bin\\*", depotPath: "executables\\", recursive: true },
+        { localPath: "localization\\german\\audio\\*", depotPath: "audio\\", recursive: false },
+      ],
+    });
+
+    expect(vdf).not.toContain("./ignored/*");
+    const mappingCount = vdf.split('"FileMapping"').length - 1;
+    expect(mappingCount).toBe(2);
+    expect(vdf).toContain('"LocalPath"\t"bin\\*"');
+    expect(vdf).toContain('"DepotPath"\t"executables\\"');
+    expect(vdf).toContain('"LocalPath"\t"localization\\german\\audio\\*"');
+    expect(vdf).toContain('"DepotPath"\t"audio\\"');
+  });
+
+  it("defaults a FileMapping's recursive flag to true and its depotPath to the depot root", () => {
+    const vdf = generateDepotVdf({
+      depotId: "12345",
+      fileMappings: [{ localPath: "bin\\*" }],
+    });
+
+    expect(vdf).toContain('"DepotPath"\t"."');
+    expect(vdf).toContain('"recursive"\t"1"');
+  });
+
+  it("sets recursive to 0 when a mapping explicitly opts out", () => {
+    const vdf = generateDepotVdf({
+      depotId: "12345",
+      fileMappings: [{ localPath: "bin\\*", recursive: false }],
+    });
+
+    expect(vdf).toContain('"recursive"\t"0"');
+  });
+
+  it("emits FileProperties blocks for userconfig/versionedconfig files", () => {
+    const vdf = generateDepotVdf({
+      depotId: "12345",
+      fileProperties: [
+        { localPath: "bin/config.cfg", attribute: "userconfig" },
+        { localPath: "bin/settings.ini", attribute: "versionedconfig" },
+      ],
+    });
+
+    expect(vdf).toContain('"FileProperties"');
+    expect(vdf).toContain('"LocalPath"\t"bin/config.cfg"');
+    expect(vdf).toContain('"Attributes"\t"userconfig"');
+    expect(vdf).toContain('"LocalPath"\t"bin/settings.ini"');
+    expect(vdf).toContain('"Attributes"\t"versionedconfig"');
+  });
+
+  it("omits FileProperties entirely when none are given", () => {
+    const vdf = generateDepotVdf({ depotId: "12345" });
+
+    expect(vdf).not.toContain("FileProperties");
+  });
 });
 
 describe("generateAppVdf", () => {

--- a/plugins/steam-deploy/src/vdf-generator.ts
+++ b/plugins/steam-deploy/src/vdf-generator.ts
@@ -8,10 +8,45 @@
  * with the up-to-9-depots-per-app support that action shipped.
  */
 
+export interface FileMappingOption {
+  /** Relative path to the depot's content root; may contain wildcards ("?", "*"). */
+  localPath: string;
+  /** Where matched files land inside the depot. Defaults to "." - the depot root. */
+  depotPath?: string;
+  /** Whether the mapping also applies to matching files in subfolders. Defaults to true. */
+  recursive?: boolean;
+}
+
+export interface FilePropertyOption {
+  /** Path (relative to the depot's content root) of the file this property applies to. */
+  localPath: string;
+  /**
+   * "userconfig": file is modified by the user/game - never overwritten by an
+   * update, and a local diff from the shipped version isn't a verification
+   * error. "versionedconfig": same, but Steam re-applies the depot's version
+   * locally when the file itself changes in an update.
+   */
+  attribute: "userconfig" | "versionedconfig";
+}
+
 export interface DepotVdfOptions {
   depotId: string;
-  /** Path (relative to the depot's own working directory) SteamCMD maps this depot's files from. Defaults to "./*" - the whole build. */
+  /**
+   * Path (relative to the depot's own working directory) SteamCMD maps this
+   * depot's files from. Defaults to "./*" - the whole build. Ignored when
+   * fileMappings is given; kept as a shorthand for the common single-mapping
+   * case.
+   */
   localPath?: string;
+  /**
+   * Explicit FileMapping blocks, for depots that need more than one -
+   * SteamCMD depots support multiple mappings with independent
+   * localPath/depotPath/recursive settings (see game-ci/steam-deploy#67).
+   * Overrides localPath when set.
+   */
+  fileMappings?: FileMappingOption[];
+  /** FileProperties blocks - marks specific files as user-modifiable/versioned config (see game-ci/steam-deploy#67). */
+  fileProperties?: FilePropertyOption[];
   /** Path to an install script (relative to the depot's content) to run after this depot installs. */
   installScript?: string;
   /** Glob-style exclusion patterns, e.g. "*.pdb". Applied in addition to the built-in defaults. */
@@ -32,6 +67,27 @@ const DEBUG_SYMBOL_EXCLUSIONS = [
   "*_BackUpThisFolder_ButDontShipItWithYourGame*",
 ];
 
+function formatFileMapping(mapping: FileMappingOption): string {
+  return [
+    '    "FileMapping"',
+    "    {",
+    `        "LocalPath"\t"${mapping.localPath}"`,
+    `        "DepotPath"\t"${mapping.depotPath ?? "."}"`,
+    `        "recursive"\t"${mapping.recursive === false ? "0" : "1"}"`,
+    "    }",
+  ].join("\n");
+}
+
+function formatFileProperty(property: FilePropertyOption): string {
+  return [
+    '    "FileProperties"',
+    "    {",
+    `        "LocalPath"\t"${property.localPath}"`,
+    `        "Attributes"\t"${property.attribute}"`,
+    "    }",
+  ].join("\n");
+}
+
 export function generateDepotVdf(options: DepotVdfOptions): string {
   const exclusions = [
     ...ALWAYS_EXCLUDED,
@@ -40,17 +96,17 @@ export function generateDepotVdf(options: DepotVdfOptions): string {
   ];
   const exclusionLines = exclusions.map((pattern) => `    "FileExclusion"\t"${pattern}"`).join("\n");
 
+  const mappings = options.fileMappings ?? [{ localPath: options.localPath ?? "./*", depotPath: ".", recursive: true }];
+  const mappingLines = mappings.map(formatFileMapping).join("\n");
+  const propertyLines = (options.fileProperties ?? []).map(formatFileProperty).join("\n");
+
   return [
     '"DepotBuildConfig"',
     "{",
     `    "depotid" "${options.depotId}"`,
-    '    "FileMapping"',
-    "    {",
-    `        "LocalPath"\t"${options.localPath ?? "./*"}"`,
-    '        "DepotPath"\t"."',
-    '        "recursive"\t"1"',
-    "    }",
+    mappingLines,
     exclusionLines,
+    ...(propertyLines ? [propertyLines] : []),
     ...(options.installScript ? [`    "InstallScript" "${options.installScript}"`] : []),
     "}",
   ].join("\n");


### PR DESCRIPTION
## Summary
- Closes the remaining gap from game-ci/steam-deploy#67 ("Add custom rules to depot") that `extraExclusions` (already shipped) didn't cover.
- Verified against Valve's actual docs (https://partner.steamgames.com/doc/sdk/uploading) rather than assuming: depots support **multiple `FileMapping` blocks** and a separate **`FileProperties`** block (`userconfig`/`versionedconfig` — marks a file as user-modified, so updates don't clobber it locally).
- `generateDepotVdf` now accepts `fileMappings` (array, overrides the single `localPath` shorthand) and `fileProperties`.
- New CLI flags on `deploy steam`: `--fileMapping "localPath=depotPath"` and `--fileProperty "localPath=userconfig|versionedconfig"`, both repeatable, applied to the primary depot (same scope as the existing `extraExclusions`).
- Malformed entries throw immediately with a specific message instead of silently dropping the rule.

## Test plan
- [x] `vitest run` in `plugins/steam-deploy` — 39/39 pass (15 new)
- [x] `tsc --noEmit` — clean
- [ ] Wire these into game-ci/steam-deploy's action.yml/build-cli-args.ts once this merges (follow-up, mirrors how `extraExclusions` was wired)
