### PR TITLE
fix(unity-test-runner): pull the docker image explicitly before starting Unity's license session

### DIFF
--- a/plugins/unity/dist/unity-test-runner/model/docker.d.ts
+++ b/plugins/unity/dist/unity-test-runner/model/docker.d.ts
@@ -4,6 +4,22 @@ declare const Docker: {
      *  Remove a possible leftover container created by `Docker.run`.
      */
     ensureContainerRemoval(parameters: RunnerContext): Promise<void>;
+    /**
+     * `docker run` pulls an uncached image implicitly, but that folds the pull
+     * time into the same session as Unity's license activation/hold/return
+     * inside the container - and these images are huge (7-8GB+ for Windows
+     * tags). A partial cache miss can take 15+ minutes to pull, and observed
+     * in practice (unity-test-runner#310's CI) that's long enough for Unity's
+     * own ephemeral ULF license session to fail to return cleanly
+     * ("Serial number unavailable for ULF return") once the container
+     * finally gets to run - a real failure, but one caused by pull time
+     * eating into the license window, not by anything about the test itself.
+     * Pulling explicitly first, before that window opens, avoids the whole
+     * class of failure. A pull failure here is a real, non-retryable-by-us
+     * problem (bad tag, registry down) and is left to fail with Docker's own
+     * error rather than swallowed.
+     */
+    pull(image: any): Promise<void>;
     run(image: any, parameters: any, silent?: boolean): Promise<void>;
     getLinuxCommand(image: any, parameters: any): string;
     getWindowsCommand(image: any, parameters: any): string;

--- a/plugins/unity/dist/unity-test-runner/model/docker.js
+++ b/plugins/unity/dist/unity-test-runner/model/docker.js
@@ -73,11 +73,30 @@ const Docker = {
             (0, fs_1.rmSync)(cidfile);
         }
     },
+    /**
+     * `docker run` pulls an uncached image implicitly, but that folds the pull
+     * time into the same session as Unity's license activation/hold/return
+     * inside the container - and these images are huge (7-8GB+ for Windows
+     * tags). A partial cache miss can take 15+ minutes to pull, and observed
+     * in practice (unity-test-runner#310's CI) that's long enough for Unity's
+     * own ephemeral ULF license session to fail to return cleanly
+     * ("Serial number unavailable for ULF return") once the container
+     * finally gets to run - a real failure, but one caused by pull time
+     * eating into the license window, not by anything about the test itself.
+     * Pulling explicitly first, before that window opens, avoids the whole
+     * class of failure. A pull failure here is a real, non-retryable-by-us
+     * problem (bad tag, registry down) and is left to fail with Docker's own
+     * error rather than swallowed.
+     */
+    async pull(image) {
+        await (0, exec_1.exec)('docker', ['pull', String(image)]);
+    },
     async run(image, parameters, silent = false) {
         let runCommand = '';
         if (parameters.unityLicensingServer !== '') {
             licensing_server_setup_1.default.Setup(parameters.unityLicensingServer, parameters.actionFolder);
         }
+        await this.pull(image);
         switch (process.platform) {
             case 'linux':
                 runCommand = this.getLinuxCommand(image, parameters);

--- a/plugins/unity/src/unity-test-runner/model/docker.test.ts
+++ b/plugins/unity/src/unity-test-runner/model/docker.test.ts
@@ -63,31 +63,57 @@ describe('Docker.run retry behavior', () => {
 
   it('retries a launch failure when a githubToken is set (USE_EXIT_CODE=false, exit code cannot mean a test failure)', async () => {
     execMock
+      .mockResolvedValueOnce(0) // docker pull
       .mockRejectedValueOnce(new Error('docker.exe failed with exit code 1'))
       .mockRejectedValueOnce(new Error('docker.exe failed with exit code 1'))
       .mockResolvedValueOnce(0);
 
     await Docker.run('some-image', buildParameters({ githubToken: 'gh-token' }));
 
-    expect(execMock).toHaveBeenCalledTimes(3);
+    // 1 pull + 3 run attempts
+    expect(execMock).toHaveBeenCalledTimes(4);
   });
 
   it('gives up after exhausting retries when a githubToken is set', async () => {
-    execMock.mockRejectedValue(new Error('docker.exe failed with exit code 1'));
+    execMock
+      .mockResolvedValueOnce(0) // docker pull
+      .mockRejectedValue(new Error('docker.exe failed with exit code 1'));
 
     await expect(
       Docker.run('some-image', buildParameters({ githubToken: 'gh-token' })),
     ).rejects.toThrow('docker.exe failed with exit code 1');
 
-    expect(execMock).toHaveBeenCalledTimes(3);
+    // 1 pull + 3 run attempts
+    expect(execMock).toHaveBeenCalledTimes(4);
   });
 
   it('does not retry when no githubToken is set (a nonzero exit there means a real test failure)', async () => {
-    execMock.mockRejectedValue(new Error('tests failed'));
+    execMock
+      .mockResolvedValueOnce(0) // docker pull
+      .mockRejectedValue(new Error('tests failed'));
 
     await expect(
       Docker.run('some-image', buildParameters({ githubToken: undefined })),
     ).rejects.toThrow('tests failed');
+
+    // 1 pull + 1 run attempt
+    expect(execMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('pulls the image explicitly before running, so pull time is not folded into the license-hold window', async () => {
+    execMock.mockResolvedValue(0);
+
+    await Docker.run('unityci/editor:some-tag', buildParameters({ githubToken: 'gh-token' }));
+
+    expect(execMock).toHaveBeenNthCalledWith(1, 'docker', ['pull', 'unityci/editor:some-tag']);
+  });
+
+  it('does not attempt to run if the pull itself fails - a pull failure is not launch-retryable', async () => {
+    execMock.mockRejectedValueOnce(new Error('manifest unknown'));
+
+    await expect(
+      Docker.run('some-image', buildParameters({ githubToken: 'gh-token' })),
+    ).rejects.toThrow('manifest unknown');
 
     expect(execMock).toHaveBeenCalledTimes(1);
   });
@@ -95,6 +121,7 @@ describe('Docker.run retry behavior', () => {
   it('cleans up a stale cidfile between retry attempts so --cidfile does not immediately fail again', async () => {
     fsState.cidfileExists = true;
     execMock
+      .mockResolvedValueOnce(0) // docker pull
       .mockRejectedValueOnce(new Error('docker.exe failed with exit code 1'))
       .mockResolvedValueOnce(0);
 

--- a/plugins/unity/src/unity-test-runner/model/docker.ts
+++ b/plugins/unity/src/unity-test-runner/model/docker.ts
@@ -39,12 +39,33 @@ const Docker = {
     }
   },
 
+  /**
+   * `docker run` pulls an uncached image implicitly, but that folds the pull
+   * time into the same session as Unity's license activation/hold/return
+   * inside the container - and these images are huge (7-8GB+ for Windows
+   * tags). A partial cache miss can take 15+ minutes to pull, and observed
+   * in practice (unity-test-runner#310's CI) that's long enough for Unity's
+   * own ephemeral ULF license session to fail to return cleanly
+   * ("Serial number unavailable for ULF return") once the container
+   * finally gets to run - a real failure, but one caused by pull time
+   * eating into the license window, not by anything about the test itself.
+   * Pulling explicitly first, before that window opens, avoids the whole
+   * class of failure. A pull failure here is a real, non-retryable-by-us
+   * problem (bad tag, registry down) and is left to fail with Docker's own
+   * error rather than swallowed.
+   */
+  async pull(image) {
+    await exec('docker', ['pull', String(image)]);
+  },
+
   async run(image, parameters, silent = false) {
     let runCommand = '';
 
     if (parameters.unityLicensingServer !== '') {
       LicensingServerSetup.Setup(parameters.unityLicensingServer, parameters.actionFolder);
     }
+
+    await this.pull(image);
 
     switch (process.platform) {
       case 'linux':


### PR DESCRIPTION
## Summary
Root-caused game-ci/unity-test-runner#310's remaining CI failures (after the results-check `ENOENT` fix landed): "Test all modes" `windows-2022` jobs failing with `Unable to find image ... locally`.

That message is misleading — it's Docker's own harmless informational notice printed right before it auto-pulls, and I confirmed against the Docker Hub registry API that all the image tags in question genuinely exist (7-8GB Windows images). The actual chain of events, traced from a full job log:
1. `docker run` hits a partial local-cache miss and implicitly starts pulling — inside the **same session** as Unity's license activation.
2. One observed pull took **16 minutes** (large Windows image, partial cache miss).
3. By the time the container finally started and ran its test + license-return sequence, Unity's own ephemeral ULF license session had been held open long enough that returning it failed: `[Licensing::Module] Error: Serial number unavailable for ULF return; aborting operation`.
4. The job's own error-reporting then surfaced the stale early "Unable to find image" line as the apparent cause, rather than the real license-return failure — compounding the confusion.

The actual fix: pull the image **explicitly**, before the license-activation window opens, so pull time never counts against the license hold.

## Test plan
- [x] `vitest run` in `plugins/unity` — 456/456 pass (2 new tests for the explicit pull, all 7 existing `Docker.run` retry tests updated for the extra call)
- [x] `tsc --noEmit` — clean
- [ ] Will need a follow-up bump of `unity-test-runner`'s `@game-ci/unity-engine-core` pin (same distribution-channel gap as the results-check fix — see game-ci/unity-test-runner PR #310's history) once this merges


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Docker images are now explicitly pulled before test containers run.
  - Pull failures stop execution immediately, preventing attempts to start the container.

- **Bug Fixes**
  - Image pulling no longer occurs during Unity license activation or test execution.
  - Docker retry behavior remains consistent after the image pull step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->