### PR TITLE
feat: register bevy, github-release-deploy, itch-deploy, pseudo-localization, code-signing, and steam-workshop as built-in plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lint": "echo 'Not implemented yet.'"
   },
   "dependencies": {
+    "@game-ci/bevy": "workspace:*",
     "@game-ci/orchestrator": "workspace:*",
     "@game-ci/runtime-test-framework": "workspace:*",
     "@game-ci/steam-deploy": "workspace:*",

--- a/plugins/bevy/README.md
+++ b/plugins/bevy/README.md
@@ -1,5 +1,7 @@
-> **EXPERIMENTAL.** Functional, but not published to npm and never loaded
-> unless you pass `--plugin @game-ci/bevy` explicitly.
+> **EXPERIMENTAL.** Functional, and registered by default in every `game-ci`
+> binary (no `--plugin` flag needed) - not published to npm, so it's loaded
+> the same way orchestrator/steam-deploy/runtime-test-framework are: a
+> literal `import()` compiled directly into the binary.
 
 # @game-ci/bevy
 
@@ -12,9 +14,11 @@ Rust crate as a game) plus locating cargo's own build output.
 
 ## Usage
 
+Registered by default - just point `game-ci` at a Bevy project:
+
 ```bash
-game-ci --plugin @game-ci/bevy build ./my-game --target x86_64-pc-windows-gnu
-game-ci --plugin @game-ci/bevy test ./my-game
+game-ci build ./my-game --target x86_64-pc-windows-gnu
+game-ci test ./my-game
 ```
 
 - Detected via a `bevy` dependency in `Cargo.toml` (a plain version

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -84,6 +84,15 @@ export class Cli {
       await import("@game-ci/runtime-test-framework"),
       "@game-ci/runtime-test-framework",
     );
+    // EXPERIMENTAL (see plugins/bevy/README.md), but always registered like
+    // the other workspace plugins above rather than gated behind --plugin:
+    // detection only fires for a project with a real `bevy` dependency in
+    // Cargo.toml, so registering it unconditionally costs nothing for
+    // non-Bevy projects. Not published to npm - PluginLoader.load's
+    // string-parameter/--plugin path (loadFromNpm) can't resolve it, so it
+    // must go through this literal `import()` instead, same reasoning as
+    // orchestrator/steam-deploy/runtime-test-framework above.
+    await PluginLoader.loadModule(await import("@game-ci/bevy"), "@game-ci/bevy");
 
     const options = await this.getPreCommandOptions();
     const pluginSources = this.getPluginSources(options);


### PR DESCRIPTION
## Summary
Registers six functional-but-unpublished plugins as built-ins, so they're actually usable from the released binary with no `--plugin` flag and no npm publish:

- `@game-ci/bevy` — `game-ci build <path>` auto-detects a Bevy project
- `@game-ci/github-release-deploy` — `game-ci deploy github-release <buildPath>`
- `@game-ci/itch-deploy` — `game-ci deploy itch <buildPath>`
- `@game-ci/pseudo-localization` — `game-ci pseudo-localize`
- `@game-ci/code-signing` — `game-ci sign <path>`
- `@game-ci/steam-workshop` — `game-ci deploy steam-workshop <itemPath>`

All six were previously only reachable via `--plugin @game-ci/<name>`, which routes through `PluginLoader.load`'s string-parameter path (`loadFromNpm`) and fails at runtime since none of them are published to npm — the only working path today is running from source inside this monorepo. This registers each the same way `orchestrator`/`steam-deploy`/`runtime-test-framework` already are: a literal `import()` at the `loadPlugins()` call site, which Bun's `--compile` bundler traces and embeds directly into the standalone binary.

- Bevy does project-structure detection (a real `bevy` dependency in `Cargo.toml`), so registering it unconditionally costs nothing for non-Bevy projects using the same binary.
- The other five each register their own subcommand (not engine detection), matching how `steam-deploy` — already built-in — works: they only do anything when their own subcommand is actually invoked.

Updated each plugin's README banner and usage examples to drop the now-stale `--plugin` flag, and a stale code comment in `github-release-deploy`'s `onLoad` warning that referenced the old load-gating.

## Test plan
- [x] `bun test ./src` — 220/220 pass
- [x] Each affected plugin's own `vitest run` — all pass (bevy, github-release-deploy, itch-deploy, pseudo-localization, code-signing, steam-workshop)
- [x] Built the actual standalone binary and verified against it directly, no `--plugin` flag:
  - `game-ci build <fake-bevy-project> --debug` → correctly detects and reaches `Building fake-bevy-game (cargo build)`
  - `game-ci deploy github-release` → reaches real command logic (`Missing required argument: tag`, not "unknown command")
  - `game-ci deploy steam-workshop` → same (`Missing required argument: appId`)
